### PR TITLE
Adding support for testClassResult

### DIFF
--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestClassWrapper.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestClassWrapper.java
@@ -218,6 +218,12 @@ public class TestClassWrapper {
 
         this.testStructure.setResult(this.result.getName());
 
+        try {
+            managers.testClassResult(this.result, null);
+        } catch (FrameworkException e) {
+            throw new TestRunException("Problem with test class result", e);
+        }
+
         String report = this.testStructure.report(LOG_START_LINE);
         logger.trace("Finishing Test Class structure:-" + report);
 

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunManagers.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunManagers.java
@@ -574,6 +574,16 @@ public class TestRunManagers {
         return newResult;
     }
 
+    public void testClassResult(@NotNull Result finalResult, Throwable finalException) throws FrameworkException {
+        for (IManager manager : activeManagers) {
+            try {
+                manager.testClassResult(finalResult.getName(), finalException);
+            } catch (ManagerException e) {
+                throw new FrameworkException("Problem in test class result for manager " + manager.getClass().getName(), e);
+            }
+        }
+    }
+
     public void endOfTestRun() {
         for (IManager manager : activeManagers) {
             manager.endOfTestRun();


### PR DESCRIPTION
Test Class Wrapper now calls testClassResult on all managers after test result is finalised