### PR TITLE
Fix markdown tables in templates

### DIFF
--- a/galasa-parent/galasautils-maven-plugin/src/main/resources/annotation.template
+++ b/galasa-parent/galasautils-maven-plugin/src/main/resources/annotation.template
@@ -1,5 +1,6 @@
 <details>
 <summary>$title</summary>
+
 | Annotation: | $title |
 | --------------------------------------- | :------------------------------------- |
 | Name: | $name |
@@ -13,4 +14,5 @@
 #if ( $extra ) 
 | Notes: | $extra |
 #end
+
 </details>

--- a/galasa-parent/galasautils-maven-plugin/src/main/resources/managerTopic.template
+++ b/galasa-parent/galasautils-maven-plugin/src/main/resources/managerTopic.template
@@ -15,15 +15,13 @@ $annotation
 
 
 #if( $codeSnippets )
-<details>
-<summary>Code snippets</summary>
+$H$H Code snippets
 
 Use the following code snippets to help you get started with the $name Manager.
 #foreach( $codeSnippet in $codeSnippets )
  
 $codeSnippet
 #end
-</details>
 #end
 
 #if( $cpsProperties )

--- a/galasa-parent/galasautils-maven-plugin/src/main/resources/property.template
+++ b/galasa-parent/galasautils-maven-plugin/src/main/resources/property.template
@@ -1,5 +1,6 @@
 <details>
 <summary>$title</summary>
+
 | Property: | $title |
 | --------------------------------------- | :------------------------------------- |
 | Name: | $name |
@@ -12,4 +13,5 @@
 
 $extra
 #end
+
 </details>


### PR DESCRIPTION
No space between <elements> and subsequent markdown table, causing rendering errors.