### PR TITLE
Galasa Language abstraction + abstracting Mangers

### DIFF
--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GenericMethodWrapper.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GenericMethodWrapper.java
@@ -18,6 +18,7 @@ import org.apache.commons.logging.LogFactory;
 
 import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.Result;
+import dev.galasa.framework.spi.language.GalasaMethod;
 import dev.galasa.framework.spi.teststructure.TestMethod;
 
 public class GenericMethodWrapper {
@@ -62,13 +63,13 @@ public class GenericMethodWrapper {
     public void invoke(@NotNull TestRunManagers managers, Object testClassObject, GenericMethodWrapper testMethod) throws TestRunException {
         try {
             String methodType = ",type=" + type.toString();
-            Result ignored = managers.anyReasonTestMethodShouldBeIgnored(this.excecutionMethod);
+            Result ignored = managers.anyReasonTestMethodShouldBeIgnored(new GalasaMethod(this.excecutionMethod, null));
             if (ignored != null) {
                 this.result = ignored;
                 return;
             }
             managers.fillAnnotatedFields(testClassObject);
-            managers.startOfTestMethod(this.excecutionMethod, (testMethod != null ? testMethod.excecutionMethod: null));
+            managers.startOfTestMethod(new GalasaMethod(this.excecutionMethod, (testMethod != null ? testMethod.excecutionMethod: null)));
 
             logger.info(TestClassWrapper.LOG_STARTING + TestClassWrapper.LOG_START_LINE + TestClassWrapper.LOG_ASTERS
                     + TestClassWrapper.LOG_START_LINE + "*** Start of test method " + testClass.getName() + "#"
@@ -86,7 +87,7 @@ public class GenericMethodWrapper {
                 this.result = Result.failed(e);
             }
 
-            Result overrideResult = managers.endOfTestMethod(this.excecutionMethod, this.result, this.result.getThrowable());
+            Result overrideResult = managers.endOfTestMethod(new GalasaMethod(this.excecutionMethod, null), this.result, this.result.getThrowable());
             if (overrideResult != null) {
                 this.result = overrideResult;
             }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GherkinTestRunner.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GherkinTestRunner.java
@@ -231,7 +231,7 @@ public class GherkinTestRunner {
         // *** Initialise the Managers ready for the test run
         TestRunManagers managers = null;
         try {
-            managers = new TestRunManagers(frameworkInitialisation.getFramework(), null);
+            managers = new TestRunManagers(frameworkInitialisation.getFramework(), gherkinTest);
         } catch (FrameworkException e) {
             this.ras.shutdown();
             throw new TestRunException("Problem initialising the Managers for a test run", e);

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GherkinTestRunner.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GherkinTestRunner.java
@@ -43,6 +43,7 @@ import dev.galasa.framework.spi.IResultArchiveStore;
 import dev.galasa.framework.spi.IRun;
 import dev.galasa.framework.spi.Result;
 import dev.galasa.framework.spi.ResultArchiveStoreException;
+import dev.galasa.framework.spi.language.GalasaTest;
 import dev.galasa.framework.spi.language.gherkin.GherkinTest;
 import dev.galasa.framework.spi.teststructure.TestStructure;
 import dev.galasa.framework.spi.utils.DssUtils;
@@ -231,7 +232,7 @@ public class GherkinTestRunner {
         // *** Initialise the Managers ready for the test run
         TestRunManagers managers = null;
         try {
-            managers = new TestRunManagers(frameworkInitialisation.getFramework(), gherkinTest);
+            managers = new TestRunManagers(frameworkInitialisation.getFramework(), new GalasaTest(gherkinTest));
         } catch (FrameworkException e) {
             this.ras.shutdown();
             throw new TestRunException("Problem initialising the Managers for a test run", e);

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunManagers.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunManagers.java
@@ -5,7 +5,6 @@
  */
 package dev.galasa.framework;
 
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -32,6 +31,9 @@ import dev.galasa.framework.spi.IFramework;
 import dev.galasa.framework.spi.IManager;
 import dev.galasa.framework.spi.ResourceUnavailableException;
 import dev.galasa.framework.spi.Result;
+import dev.galasa.framework.spi.language.gherkin.GherkinTest;
+import dev.galasa.framework.spi.language.GalasaMethod;
+import dev.galasa.framework.spi.language.GalasaTest;
 
 public class TestRunManagers {
 
@@ -53,7 +55,28 @@ public class TestRunManagers {
 
         List<IManager> allManagers = locateManagers();
         requestExtraBundlesFromManager(allManagers, allManagers);
-        buildActiveManagers(allManagers, testClass);
+        buildActiveManagers(allManagers, new GalasaTest(testClass));
+
+        logger.debug("The following Managers are active:-");
+        reportManagers();
+
+        calculateProvisioningDependencies();
+
+        logger.debug("The following Managers are sorted in provisioning order:-");
+        reportManagers();
+
+    }
+
+    public TestRunManagers(IFramework framework, GherkinTest gherkinTest) throws FrameworkException {
+        this.framework = framework;
+        this.bundleContext = FrameworkUtil.getBundle(getClass()).getBundleContext();
+
+        ServiceReference<?> serviceReference = bundleContext.getServiceReference(RepositoryAdmin.class.getName());
+        repositoryAdmin = (RepositoryAdmin) bundleContext.getService(serviceReference);
+
+        List<IManager> allManagers = locateManagers();
+        requestExtraBundlesFromManager(allManagers, allManagers);
+        buildActiveManagers(allManagers, new GalasaTest(gherkinTest));
 
         logger.debug("The following Managers are active:-");
         reportManagers();
@@ -148,17 +171,16 @@ public class TestRunManagers {
 
     }
 
-    private void buildActiveManagers(List<IManager> allManagers, Class<?> testClass) throws FrameworkException {
+    private void buildActiveManagers(List<IManager> allManagers, GalasaTest galasaTest) throws FrameworkException {
         // *** Ask each one to initialise itself if required and chain request other
         // managers
         for (IManager manager : allManagers) {
             try {
-                manager.initialise(framework, allManagers, activeManagers, testClass);
+                manager.initialise(framework, allManagers, activeManagers, galasaTest);
             } catch (ManagerException e) {
                 throw new FrameworkException("Unable to initialise Manager " + manager.getClass().getName(), e);
             }
         }
-
     }
 
     private void requestExtraBundlesFromManager(List<IManager> managersToCheck, List<IManager> allManagers)
@@ -501,10 +523,10 @@ public class TestRunManagers {
         }
     }
 
-    public Result anyReasonTestMethodShouldBeIgnored(@NotNull Method method) throws FrameworkException {
+    public Result anyReasonTestMethodShouldBeIgnored(@NotNull GalasaMethod galasaMethod) throws FrameworkException {
         for (IManager manager : activeManagers) {
             try {
-                String reason = manager.anyReasonTestMethodShouldBeIgnored(method);
+                String reason = manager.anyReasonTestMethodShouldBeIgnored(galasaMethod);
                 if (reason != null) {
                     logger.info("Ignoring method due to " + reason);
                     return Result.ignore(reason + " from " + manager.getClass().getName());
@@ -527,10 +549,10 @@ public class TestRunManagers {
         }
     }
 
-    public void startOfTestMethod(@NotNull Method excecutionMethod, Method testMethod) throws FrameworkException {
+    public void startOfTestMethod(@NotNull GalasaMethod galasaMethod) throws FrameworkException {
         for (IManager manager : activeManagers) {
             try {
-                manager.startOfTestMethod(excecutionMethod, testMethod);
+                manager.startOfTestMethod(galasaMethod);
             } catch (ManagerException e) {
                 throw new FrameworkException(
                         "Problem in start of test test method for manager " + manager.getClass().getName(), e);
@@ -538,13 +560,13 @@ public class TestRunManagers {
         }
     }
 
-    public Result endOfTestMethod(@NotNull Method testMethod, @NotNull Result currentResult, Throwable currentException)
+    public Result endOfTestMethod(@NotNull GalasaMethod galasaMethod, @NotNull Result currentResult, Throwable currentException)
             throws FrameworkException {
         Result newResult = null;
 
         for (IManager manager : activeManagers) {
             try {
-                String managerResult = manager.endOfTestMethod(testMethod, currentResult.getName(), currentException); // TODO
+                String managerResult = manager.endOfTestMethod(galasaMethod, currentResult.getName(), currentException); // TODO
                                                                                                                        // change
                                                                                                                        // managers
                                                                                                                        // to

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunManagers.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunManagers.java
@@ -46,7 +46,7 @@ public class TestRunManagers {
 
     private final RepositoryAdmin repositoryAdmin;
 
-    public TestRunManagers(IFramework framework, Class<?> testClass) throws FrameworkException {
+    public TestRunManagers(IFramework framework, GalasaTest galasaTest) throws FrameworkException {
         this.framework = framework;
         this.bundleContext = FrameworkUtil.getBundle(getClass()).getBundleContext();
 
@@ -55,28 +55,7 @@ public class TestRunManagers {
 
         List<IManager> allManagers = locateManagers();
         requestExtraBundlesFromManager(allManagers, allManagers);
-        buildActiveManagers(allManagers, new GalasaTest(testClass));
-
-        logger.debug("The following Managers are active:-");
-        reportManagers();
-
-        calculateProvisioningDependencies();
-
-        logger.debug("The following Managers are sorted in provisioning order:-");
-        reportManagers();
-
-    }
-
-    public TestRunManagers(IFramework framework, GherkinTest gherkinTest) throws FrameworkException {
-        this.framework = framework;
-        this.bundleContext = FrameworkUtil.getBundle(getClass()).getBundleContext();
-
-        ServiceReference<?> serviceReference = bundleContext.getServiceReference(RepositoryAdmin.class.getName());
-        repositoryAdmin = (RepositoryAdmin) bundleContext.getService(serviceReference);
-
-        List<IManager> allManagers = locateManagers();
-        requestExtraBundlesFromManager(allManagers, allManagers);
-        buildActiveManagers(allManagers, new GalasaTest(gherkinTest));
+        buildActiveManagers(allManagers, galasaTest);
 
         logger.debug("The following Managers are active:-");
         reportManagers();

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
@@ -48,6 +48,7 @@ import dev.galasa.framework.spi.IRun;
 import dev.galasa.framework.spi.Result;
 import dev.galasa.framework.spi.ResultArchiveStoreException;
 import dev.galasa.framework.spi.SharedEnvironmentRunType;
+import dev.galasa.framework.spi.language.GalasaTest;
 import dev.galasa.framework.spi.teststructure.TestStructure;
 import dev.galasa.framework.spi.utils.DssUtils;
 
@@ -291,7 +292,7 @@ public class TestRunner {
         // *** Initialise the Managers ready for the test run
         TestRunManagers managers = null;
         try {
-            managers = new TestRunManagers(frameworkInitialisation.getFramework(), testClass);
+            managers = new TestRunManagers(frameworkInitialisation.getFramework(), new GalasaTest(testClass));
         } catch (FrameworkException e) {
             this.ras.shutdown();
             throw new TestRunException("Problem initialising the Managers for a test run", e);

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/AbstractGherkinManager.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/AbstractGherkinManager.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import javax.validation.constraints.NotNull;
 
 import dev.galasa.ManagerException;
-import dev.galasa.framework.IGherkinExecutable;
 
 public abstract class AbstractGherkinManager extends AbstractManager implements IGherkinManager {
 

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/AbstractManager.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/AbstractManager.java
@@ -21,6 +21,9 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import dev.galasa.ManagerException;
+import dev.galasa.framework.spi.language.GalasaLanguage;
+import dev.galasa.framework.spi.language.GalasaMethod;
+import dev.galasa.framework.spi.language.GalasaTest;
 
 /**
  * An abstract manager which attempts to provide all the boilerplate code
@@ -250,9 +253,11 @@ public abstract class AbstractManager implements IManager {
      */
     @Override
     public void initialise(@NotNull IFramework framework, @NotNull List<IManager> allManagers,
-            @NotNull List<IManager> activeManagers, @NotNull Class<?> testClass) throws ManagerException {
+            @NotNull List<IManager> activeManagers, @NotNull GalasaTest galasaTest) throws ManagerException {
         this.framework = framework;
-        this.testClass = testClass;
+        if(galasaTest.isJava()) {
+            this.testClass = galasaTest.getJavaTestClass();
+        }
     }
 
     /**
@@ -365,7 +370,7 @@ public abstract class AbstractManager implements IManager {
      * lang. reflect.Method)
      */
     @Override
-    public String anyReasonTestMethodShouldBeIgnored(@NotNull Method method) throws ManagerException {
+    public String anyReasonTestMethodShouldBeIgnored(@NotNull GalasaMethod galasaMethod) throws ManagerException {
         return null;
     }
 
@@ -375,7 +380,7 @@ public abstract class AbstractManager implements IManager {
      * @see dev.galasa.framework.spi.IManager#startOfTestMethod()
      */
     @Override
-    public void startOfTestMethod(@NotNull Method excecutionMethod, Method testMethod) throws ManagerException {
+    public void startOfTestMethod(@NotNull GalasaMethod galasaMethod) throws ManagerException {
     }
 
     /*
@@ -385,7 +390,7 @@ public abstract class AbstractManager implements IManager {
      * java.lang.Throwable)
      */
     @Override
-    public String endOfTestMethod(@NotNull Method testMethod, @NotNull String currentResult, Throwable currentException)
+    public String endOfTestMethod(@NotNull GalasaMethod galasaMethod, @NotNull String currentResult, Throwable currentException)
             throws ManagerException {
         return null;
     }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IGherkinExecutable.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IGherkinExecutable.java
@@ -3,9 +3,10 @@
  * 
  * (c) Copyright IBM Corp. 2019.
  */
-package dev.galasa.framework;
+package dev.galasa.framework.spi;
 
-import dev.galasa.framework.spi.IGherkinManager;
+import dev.galasa.framework.TestRunException;
+import dev.galasa.framework.spi.language.gherkin.GherkinKeyword;
 
 public interface IGherkinExecutable {
 
@@ -13,6 +14,8 @@ public interface IGherkinExecutable {
 
     void registerManager(IGherkinManager manager) throws TestRunException;
 
-    String getText();
+    String getValue();
+
+    GherkinKeyword getKeyword();
     
 }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IGherkinManager.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IGherkinManager.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import javax.validation.constraints.NotNull;
 
 import dev.galasa.ManagerException;
-import dev.galasa.framework.IGherkinExecutable;
 
 public interface IGherkinManager {
 

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IManager.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IManager.java
@@ -5,12 +5,13 @@
  */
 package dev.galasa.framework.spi;
 
-import java.lang.reflect.Method;
 import java.util.List;
 
 import javax.validation.constraints.NotNull;
 
 import dev.galasa.ManagerException;
+import dev.galasa.framework.spi.language.GalasaMethod;
+import dev.galasa.framework.spi.language.GalasaTest;
 
 /**
  * <p>
@@ -84,8 +85,7 @@ public interface IManager {
      * @throws ManagerException If there is a problem initialising the Manager
      */
     void initialise(@NotNull IFramework framework, @NotNull List<IManager> allManagers,
-            @NotNull List<IManager> activeManagers, @NotNull Class<?> testClass) throws ManagerException;
-    
+            @NotNull List<IManager> activeManagers, @NotNull GalasaTest galasaTest) throws ManagerException;
     
     /**
      * The framework will check each manager during Shared Environment Build to see if they support shared environments.
@@ -222,7 +222,7 @@ public interface IManager {
      *         should be ignored
      * @throws ManagerException - Just in case something goes wrong, eg CPS
      */
-    String anyReasonTestMethodShouldBeIgnored(@NotNull Method method) throws ManagerException;
+    String anyReasonTestMethodShouldBeIgnored(@NotNull GalasaMethod galasaMethod) throws ManagerException;
 
     /**
      * Called when we are about to start the Test Method.
@@ -232,7 +232,7 @@ public interface IManager {
      *
      * @throws ManagerException On the off chance something when wrong
      */
-    void startOfTestMethod(@NotNull Method excecutionMethod, Method testMethod) throws ManagerException;
+    void startOfTestMethod(@NotNull GalasaMethod galasaMethod) throws ManagerException;
 
     /**
      * <p>
@@ -251,7 +251,7 @@ public interface IManager {
      * @return Override the test result, or null if ok
      * @throws ManagerException If something went wrong
      */
-    String endOfTestMethod(@NotNull Method testMethod, @NotNull String currentResult, Throwable currentException)
+    String endOfTestMethod(@NotNull GalasaMethod galasaMethod, @NotNull String currentResult, Throwable currentException)
             throws ManagerException;
 
     /**

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/language/GalasaLanguage.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/language/GalasaLanguage.java
@@ -1,0 +1,11 @@
+/*
+ * Licensed Materials - Property of IBM
+ * 
+ * (c) Copyright IBM Corp. 2019.
+ */
+package dev.galasa.framework.spi.language;
+
+public enum GalasaLanguage {
+    java,
+    gherkin
+}

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/language/GalasaMethod.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/language/GalasaMethod.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed Materials - Property of IBM
+ * 
+ * (c) Copyright IBM Corp. 2019.
+ */
+package dev.galasa.framework.spi.language;
+
+import java.lang.reflect.Method;
+
+import dev.galasa.framework.spi.language.gherkin.GherkinMethod;
+
+public class GalasaMethod {
+
+    private GalasaLanguage language;
+
+    private Method javaTestMethod;
+    private Method javaExecutionMethod;
+    private GherkinMethod gherkinMethod;
+
+    public GalasaMethod(Method executionMethod, Method testMethod) {
+        this.javaTestMethod = testMethod;
+        this.javaExecutionMethod = executionMethod;
+        this.language = GalasaLanguage.java;
+    }
+
+    public GalasaMethod(GherkinMethod method) {
+        this.gherkinMethod = method;
+        this.language = GalasaLanguage.gherkin;
+    }
+
+    public GalasaLanguage getLanguage() {
+        return this.language;
+    }
+
+    public Boolean isJava() {
+        return this.language == GalasaLanguage.java;
+    }
+
+    public Boolean isGherkin() {
+        return this.language == GalasaLanguage.gherkin;
+    }
+
+    public Method getJavaTestMethod() {
+        return this.javaTestMethod;
+    }
+
+    public Method getJavaExecutionMethod() {
+        return this.javaExecutionMethod;
+    }
+
+    public GherkinMethod getGherkinMethod() {
+        return this.gherkinMethod;
+    }
+    
+}

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/language/GalasaTest.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/language/GalasaTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed Materials - Property of IBM
+ * 
+ * (c) Copyright IBM Corp. 2019.
+ */
+package dev.galasa.framework.spi.language;
+
+import dev.galasa.framework.spi.language.gherkin.GherkinTest;
+
+public class GalasaTest {
+
+    private GalasaLanguage language;
+    
+    private Class<?> javaTestClass;
+    private GherkinTest gherkinTest;
+
+    public GalasaTest(Class<?> klass) {
+        this.javaTestClass = klass;
+        this.language = GalasaLanguage.java;
+    }
+
+    public GalasaTest(GherkinTest test) {
+        this.gherkinTest = test;
+        this.language = GalasaLanguage.gherkin;
+    }
+
+    public GalasaLanguage getLanguage() {
+        return this.language;
+    }
+
+    public Boolean isJava() {
+        return this.language == GalasaLanguage.java;
+    }
+
+    public Boolean isGherkin() {
+        return this.language == GalasaLanguage.gherkin;
+    }
+
+    public Class<?> getJavaTestClass() {
+        return this.javaTestClass;
+    }
+
+    public GherkinTest getGherkinTest() {
+        return this.gherkinTest;
+    }
+    
+}

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/language/gherkin/GherkinKeyword.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/language/gherkin/GherkinKeyword.java
@@ -1,0 +1,22 @@
+package dev.galasa.framework.spi.language.gherkin;
+
+import dev.galasa.framework.TestRunException;
+
+public enum GherkinKeyword {
+    GIVEN,
+    WHEN,
+    THEN,
+    AND,
+    DATATABLE;
+
+    public static GherkinKeyword get(String statement) throws TestRunException {
+        String[] words = statement.split(" ");
+        for(GherkinKeyword keyword : values()) {
+            if(words[0].toUpperCase().equals(keyword.name())) {
+                return keyword;
+            }
+        }
+        throw new TestRunException("Invalid statement: " + statement);
+    }
+}
+

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/language/gherkin/GherkinStatement.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/language/gherkin/GherkinStatement.java
@@ -5,20 +5,22 @@
  */
 package dev.galasa.framework.spi.language.gherkin;
 
-import dev.galasa.framework.IGherkinExecutable;
+import dev.galasa.framework.spi.IGherkinExecutable;
 import dev.galasa.framework.TestRunException;
 import dev.galasa.framework.spi.IGherkinManager;
 
 public class GherkinStatement implements IGherkinExecutable {
 
     private String statement;
+    private GherkinKeyword keyword;
     private IGherkinManager registeredManager;
     
-    private GherkinStatement(String statement) {
-        this.statement = statement;
+    private GherkinStatement(String statement) throws TestRunException {
+        this.keyword = GherkinKeyword.get(statement);
+        this.statement = statement.substring(statement.indexOf(" ") + 1).trim();
     }
 
-    public static IGherkinExecutable get(String statement) {
+    public static IGherkinExecutable get(String statement) throws TestRunException {
         IGherkinExecutable executable = new GherkinStatement(statement);
         return executable;
     }
@@ -34,7 +36,11 @@ public class GherkinStatement implements IGherkinExecutable {
         return this.registeredManager;
     }
 
-    public String getText() {
+    public String getValue() {
         return this.statement;
+    }
+
+    public GherkinKeyword getKeyword() {
+        return this.keyword;
     }
 }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/language/gherkin/GherkinTest.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/language/gherkin/GherkinTest.java
@@ -23,10 +23,10 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import dev.galasa.framework.IGherkinExecutable;
 import dev.galasa.framework.TestRunException;
 import dev.galasa.framework.TestRunManagers;
 import dev.galasa.framework.spi.FrameworkException;
+import dev.galasa.framework.spi.IGherkinExecutable;
 import dev.galasa.framework.spi.IRun;
 import dev.galasa.framework.spi.Result;
 import dev.galasa.framework.spi.teststructure.TestStructure;

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/spi/AbstractManagerTest.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/spi/AbstractManagerTest.java
@@ -14,6 +14,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import dev.galasa.ManagerException;
+import dev.galasa.framework.spi.language.GalasaTest;
 
 public class AbstractManagerTest {
 
@@ -21,7 +22,7 @@ public class AbstractManagerTest {
     public void testAnnotatedFields() throws NoSuchFieldException, SecurityException, ManagerException {
         final TestManager testManager = new TestManager();
         final TestClass testClass = new TestClass();
-        testManager.initialise(null, null, null, testClass.getClass());
+        testManager.initialise(null, null, null, new GalasaTest(testClass.getClass()));
 
         final List<AnnotatedField> annotatedFields = testManager.findAnnotatedFields(TestManagerAnnotation.class);
         Assert.assertNotNull("A list should always be returned", annotatedFields);
@@ -103,7 +104,7 @@ public class AbstractManagerTest {
             throws NoSuchFieldException, SecurityException, ManagerException, ResourceUnavailableException {
         final TestManager testManager = new TestManager();
         final TestClass testClass = new TestClass();
-        testManager.initialise(null, null, null, testClass.getClass());
+        testManager.initialise(null, null, null, new GalasaTest(testClass.getClass()));
 
         testManager.provisionGenerate();
         testManager.fillAnnotatedFields(testClass);
@@ -135,7 +136,7 @@ public class AbstractManagerTest {
         testManager.provisionStart();
         testManager.startOfTestClass();
         testManager.anyReasonTestMethodShouldBeIgnored(null);
-        testManager.startOfTestMethod(null, null);
+        testManager.startOfTestMethod(null);
         testManager.endOfTestMethod(null, null, null);
         testManager.testMethodResult(null, null);
         testManager.endOfTestClass(null, null);


### PR DESCRIPTION
Changes to IManager to abstract the test class to support many languages
Changes to the GherkinTestRunner to support these managers lifecycles
Updating IGherkinExecutable to include a GherkinKeyword enum

GalasaTest and GalasaMethod create language agnostic testclasses and testmethods

Will break current managers