### PR TITLE
CPS Restore

### DIFF
--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/RestoreCPS.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/RestoreCPS.java
@@ -1,0 +1,274 @@
+/*
+ * Licensed Materials - Property of IBM
+ * 
+ * (c) Copyright IBM Corp. 2020.
+ */
+
+package dev.galasa.framework;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.osgi.service.component.annotations.Component;
+
+import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
+import dev.galasa.framework.spi.FrameworkException;
+import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
+import dev.galasa.framework.spi.IFramework;
+
+@Component(service = { RestoreCPS.class })
+public class RestoreCPS {
+    
+    private Log             logger  =  LogFactory.getLog(this.getClass());
+    
+    private IFramework      framework;
+    
+    private Map<String, IConfigurationPropertyStoreService>     namespaceCPS 
+                            = new HashMap<String ,IConfigurationPropertyStoreService>();
+    
+    List<String> forbiddenNamespaces = new ArrayList<String>();
+    
+    public RestoreCPS(){
+    	forbiddenNamespaces.add("dss");
+        forbiddenNamespaces.add("certificate");
+        forbiddenNamespaces.add("secure");
+    }
+    
+    /**
+     * <p>Restores configuration properties from the specified file to the Configuration Property Store (CPS)</p>
+     * 
+     * @param bootstrapProperties
+     * @param overrideProperties
+     * @param filePath
+     * @return
+     * @throws FrameworkException
+     * @throws IOException 
+     */
+    public void restore(Properties bootstrapProperties, Properties overrideProperties, String filePath) throws FrameworkException, IOException {
+        logger.info("Initialising CPS Restore Service");
+        
+        FrameworkInitialisation frameworkInitialisation = null;
+        try {
+            frameworkInitialisation = new FrameworkInitialisation(bootstrapProperties, overrideProperties);
+        } catch (Exception e) {
+            throw new FrameworkException("Unable to initialise the Framework Service", e);
+        }
+        
+        framework = frameworkInitialisation.getFramework();
+        
+        Properties properties = getProperties(filePath);
+        if (!properties.isEmpty()) {
+            restoreProperties(properties);
+        } else {
+            throw new FrameworkException("Cannot restore properties. The specified file is either empty or was not found.");
+        }
+    }
+    
+    /**
+     * <p>Fetches configuration properties from a specified file</p>
+     * 
+     * @param filePath
+     * @return properties
+     * @throws IOException 
+     */
+    private Properties getProperties(String filePath) throws IOException {
+        
+        Properties properties = new Properties();
+
+        try (InputStream inputStream = Files.newInputStream(Paths.get(filePath))) {
+            properties.load(inputStream);
+        } catch (Exception e) {
+        	throw new IOException("Couldn't load properties from specified file: ".concat(filePath), e);
+        }
+        
+        return properties;
+
+    }
+    
+    /**
+     * <p>Iterates through the properties in the supplied object, restoring them one-by-one to the Configuration Property Store<p>
+     * 
+     * @param properties (instance of object: Properties)
+     * @return 
+     */
+    private void restoreProperties(Properties properties) throws ConfigurationPropertyStoreException {
+        
+        for (Entry<Object, Object> prop : properties.entrySet()) {
+            if (isValidProperty(prop.getKey().toString())) {
+                restoreProperty(prop.getKey().toString(), prop.getValue().toString());
+            } else {
+                logPropertyRestore("invalid", "n/a", "n/a", "n/a", "n/a");
+            }
+        }
+                
+    }
+    
+    /**
+     * <p>Restores individual property to CPS</p>
+     * 
+     * @param key (String)
+     * @param value (String)
+     * @return
+     * @throws ConfigurationPropertyStoreException
+     */
+    private void restoreProperty(String key, String newValue) throws ConfigurationPropertyStoreException {
+        
+        String namespace = getPropertyPrefix(key);
+        String property = getPropertySuffix(key);
+        
+        if (!forbiddenNamespaces.contains(namespace)){
+            
+            ensureCPSExists(namespace);
+            
+            String currentValue = getExistingValue(namespace, property);
+            
+            namespaceCPS.get(namespace).setProperty(property, newValue);
+
+            logPropertyRestore(getStatusCRU(newValue, currentValue), namespace, property, newValue, currentValue);
+
+        } else {
+            logPropertyRestore("denied", namespace, property, "n/a", "n/a");
+        }
+        
+    }
+
+    /**
+     * <p>Initialise an instance of IConfigurationPropertyStoreService for the specified namespace if one doesn't already exist.</p>
+     * @param namespace
+     * @throws ConfigurationPropertyStoreException
+     */
+    private void ensureCPSExists(String namespace) throws ConfigurationPropertyStoreException {
+        if (!namespaceCPS.containsKey(namespace)){
+            namespaceCPS.put(namespace, framework.getConfigurationPropertyService(namespace));
+        }
+    }
+
+    /**
+     * <p>Returns the status message to be displayed based on the new and current value of the property that was set<p>
+     * @param newValue
+     * @param currentValue
+     * @return
+     */
+    private String getStatusCRU(String newValue, String currentValue) {
+        if (currentValue != null) {
+            return getValueChangeStatus(newValue, currentValue);
+        } else {
+            return "created";
+        }
+    }
+
+    /**
+     * <p>Returns status message to identify whether a property's value was updated or remained the same<p>
+     * @param newValue
+     * @param currentValue
+     * @return
+     */
+    private String getValueChangeStatus(String newValue, String currentValue) {
+        if (currentValue.equals(newValue)) {
+            return "no_change";
+        } else {
+            return "updated";
+        }
+    }
+    
+    /**
+     * <p>Retrieves Property Prefix (after first dot ".")</p>
+     * 
+     * @param propertyName
+     * @return
+     */
+    private String getPropertyPrefix(String propertyName) throws ConfigurationPropertyStoreException {
+        return propSplit(propertyName, 0);
+    }
+    
+    /**
+     * <p>Retrieves Property Suffix (after first dot ".")</p>
+     * 
+     * @param propertyName
+     * @return
+     */
+    private String getPropertySuffix(String propertyName) throws ConfigurationPropertyStoreException {
+        return propSplit(propertyName, 1);
+    }
+    
+    /**
+     * <p>Splits a string into two parts: a prefix and a suffix.</p>
+     * <p>Prefix: Anything before the first dot "."</p>
+     * <p>Suffix: Anything after the first dot "."</p>
+     * 
+     * <p>Position specified as 0 or 1</p>
+     * 
+     * @param str
+     * @param position
+     * @return dashes
+     */
+    private String propSplit(String str, int position) throws ConfigurationPropertyStoreException {
+        
+        String[] kvp = str.split("\\.", 2);
+        if (kvp.length <= 1) {
+            throw new ConfigurationPropertyStoreException("Invalid Property Format: " + str);
+        }
+        return kvp[position];
+    }
+    
+    /**
+     * <p>Checks for property validity (whether there is a prefix and a suffix, separated by a dot ".").</p>
+     * 
+     * @param key
+     * @return boolean
+     */
+    private boolean isValidProperty(String key) {
+        /**
+         *  Regex matches (at least) three words (of one letter or more) separated by dots (".")
+         *  e.g. framework.foo.bar or framework.foo.bar.fizz.buzz
+         */
+        
+        Pattern pattern = Pattern.compile("^([a-zA-Z0-9]+\\.){2,}[a-zA-Z0-9]+$");
+        Matcher matcher = pattern.matcher(key);
+        boolean matchFound = matcher.find();
+        return matchFound;
+    }
+       
+    /**
+     * <p>Retrieves the current/existing value for a specified property.</p>
+     * <p>This wrapper is required due to properties only being retrievable using both a prefix and a suffix.</p>
+     * 
+     * @param namespace
+     * @param property
+     * @return existingValue
+     * @throws ConfigurationPropertyStoreException 
+     */
+    private String getExistingValue(String namespace, String property) throws ConfigurationPropertyStoreException {
+     
+        String existingValue = 
+                namespaceCPS.get(namespace).getProperty(getPropertyPrefix(property), getPropertySuffix(property));
+                
+        return existingValue;
+        
+    }
+
+    /**
+     * <p>Log property restore status</p>
+     * @param status
+     * @param namespace
+     * @param property
+     * @param currentValue
+     * @param newValue
+     */
+    private void logPropertyRestore(String status, String namespace, String property, String currentValue, String newValue){
+        logger.info(String.format("STATUS: %-10s\tNAMESPACE: %s\tPROPERTY: %s\tOLDVALUE: %s\tNEWVALUE: %s", status, namespace, property, currentValue, newValue));
+    }
+
+}

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/RestoreCPS.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/RestoreCPS.java
@@ -16,11 +16,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.felix.bundlerepository.Property;
 import org.osgi.service.component.annotations.Component;
 
 import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
@@ -104,15 +106,18 @@ public class RestoreCPS {
      * @return 
      */
     private void restoreProperties(Properties properties) throws ConfigurationPropertyStoreException {
-        
-        for (Entry<Object, Object> prop : properties.entrySet()) {
-            if (isValidProperty(prop.getKey().toString())) {
-                restoreProperty(prop.getKey().toString(), prop.getValue().toString());
+
+        List<String> keys = new ArrayList<>(properties.stringPropertyNames());
+
+        java.util.Collections.sort(keys, java.text.Collator.getInstance());
+
+        for(String key : keys){
+            if (isValidProperty(key)) {
+                restoreProperty(key, properties.getProperty(key).toString());
             } else {
                 logPropertyRestore("invalid", "n/a", "n/a", "n/a", "n/a");
             }
-        }
-                
+        }                
     }
     
     /**

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/cps/FrameworkConfigurationPropertyService.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/cps/FrameworkConfigurationPropertyService.java
@@ -118,7 +118,7 @@ public class FrameworkConfigurationPropertyService implements IConfigurationProp
      */
     public void setProperty(@NotNull String name, @NotNull String value)
             throws ConfigurationPropertyStoreException {
-        cpsStore.setProperty(name, value);
+    	cpsStore.setProperty(namespace + "." + name, value);
     }
 
     /**

--- a/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/Launcher.java
+++ b/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/Launcher.java
@@ -66,6 +66,7 @@ public class Launcher {
     private static final String     REMOTEMAVEN_OPTION        = "remotemaven";
     private static final String     TRACE_OPTION              = "trace";
     private static final String     BACKUPCPS_OPTION          = "backupcps";
+    private static final String     RESTORECPS_OPTION         = "restorecps";
     private static final String     FILE_OPTION               = "f";
     private static final String     FILE_OPTION_LONG          = "file";
     
@@ -95,6 +96,7 @@ public class Launcher {
     private boolean                 metricsServer;
     private boolean                 api;
     private boolean                 backupCPS;
+    private boolean                 restoreCPS;
 
     private Integer                 metrics;
     private Integer                 health;
@@ -172,10 +174,13 @@ public class Launcher {
             } else if (api) {
                 logger.debug("Web API Server");
                 felixFramework.runWebApiServer(boostrapProperties, overridesProperties, bundles, metrics, health);
-            }  else if (backupCPS) {
+            } else if (backupCPS) {
                 logger.debug("Back Up CPS Properties");
                 felixFramework.runBackupCPS(boostrapProperties, overridesProperties, filePath);
+            } else if (restoreCPS) {
+                felixFramework.runRestoreCPS(boostrapProperties, overridesProperties, filePath);
             }
+
         } catch (LauncherException e) {
             logger.error("Unable to run test class", e);
             throw e;
@@ -234,7 +239,8 @@ public class Launcher {
         options.addOption(null, LOCALMAVEN_OPTION, true, "The local maven repository, defaults to ~/.m2/repository");
         options.addOption(null, REMOTEMAVEN_OPTION, true, "The remote maven repositories, defaults to central");
         options.addOption(null, TRACE_OPTION, false, "Enable TRACE logging");
-        options.addOption(null, BACKUPCPS_OPTION, false, "Back up CPS properties");
+        options.addOption(null, BACKUPCPS_OPTION, false, "Back up CPS properties to file");
+        options.addOption(null, RESTORECPS_OPTION, false, "Restore CPS properties from file");
         options.addOption(FILE_OPTION, FILE_OPTION_LONG, true, "File for data input/output");
 
         CommandLineParser parser = new DefaultParser();
@@ -276,6 +282,7 @@ public class Launcher {
         metricsServer = commandLine.hasOption(METRICSERVER_OPTION);
         api = commandLine.hasOption(API_OPTION);
         backupCPS = commandLine.hasOption(BACKUPCPS_OPTION);
+        restoreCPS = commandLine.hasOption(RESTORECPS_OPTION);
 
         if (testRun) {
             runName = commandLine.getOptionValue(RUN_OPTION);
@@ -323,16 +330,30 @@ public class Launcher {
             return;
         }
 
-        if (backupCPS) {
-            filePath = commandLine.getOptionValue(FILE_OPTION);
-            if (filePath == null) {
-                commandLineError("The option " + BACKUPCPS_OPTION + " requires an output file (specify with --" + FILE_OPTION_LONG + " <path> or -" + FILE_OPTION + " <path>)");
+        if (backupCPS || restoreCPS) {
+            if (backupCPS && restoreCPS) {
+                commandLineError("Cannot use options \"" + BACKUPCPS_OPTION + "\" and \"" + RESTORECPS_OPTION + "\" together.");
+            } else {
+                filePath = commandLine.getOptionValue(FILE_OPTION);
+                if (filePath == null) {
+                    if (backupCPS) { 
+                        filePathError(BACKUPCPS_OPTION);
+                    } else {
+                        filePathError(RESTORECPS_OPTION);
+                    }
+                }
             }
             return;
         }
 
         commandLineError(
                 "Error: Must select either --test, --run, --gherkin, --k8scontroller, --metricserver, --resourcemanagement or --webbundle");
+    }
+    
+    private void filePathError(String option) {
+
+        commandLineError("The option \"" + option + "\" requires an output file (specify with --" + FILE_OPTION_LONG + " <path> or -" + FILE_OPTION + " <path>)");
+
     }
 
     private void checkForRemoteMaven(CommandLine commandLine) {

--- a/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/felix/FelixFramework.java
+++ b/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/felix/FelixFramework.java
@@ -487,7 +487,59 @@ public class FelixFramework {
 
     }
     
-    
+    /**
+     * Restore the CPS Properties
+     * 
+     * @param boostrapProperties  the bootstrap properties
+     * @param overridesProperties the override properties
+     * @param filePath 
+     * @throws LauncherException
+     */
+    public void runRestoreCPS(Properties boostrapProperties, Properties overridesProperties, String filePath) throws LauncherException {
+
+        // Get the framework bundle
+        Bundle frameWorkBundle = getBundle("dev.galasa.framework");
+
+        String className = "RestoreCPS";
+        String methodName = "restore";
+
+        // Get the dev.galasa.framework.RestoreCPS class service
+        String classString = "dev.galasa.framework." + className;
+        String filterString = "(" + Constants.OBJECTCLASS + "=" + classString + ")";
+
+        ServiceReference<?>[] serviceReferences;
+        try {
+            serviceReferences = frameWorkBundle.getBundleContext().getServiceReferences(classString, filterString);
+        } catch (InvalidSyntaxException e) {
+            throw new LauncherException("Unable to get framework service reference", e);
+        }
+        if (serviceReferences == null || serviceReferences.length != 1) {
+            throw new LauncherException("Unable to get single reference to " + className + " service: "
+                    + ((serviceReferences == null) ? 0 : serviceReferences.length) + " service(s) returned");
+        }
+
+        Object service = frameWorkBundle.getBundleContext().getService(serviceReferences[0]);
+        if (service == null) {
+            throw new LauncherException("Unable to get " + className + " service");
+        }
+
+        // Get the dev.galasa.framework.RestoreCPS#restore() method
+        Method runRestoreCPSMethod;
+        try {
+            runRestoreCPSMethod = service.getClass().getMethod(methodName, Properties.class, Properties.class, String.class);
+        } catch (NoSuchMethodException | SecurityException e) {
+            throw new LauncherException("Unable to get Framework " + className + " " + methodName + " method", e);
+        }
+
+        // Invoke the runBackupCPSMethod method
+        logger.debug("Invoking " + className + " " + methodName + "()");
+        try {
+            runRestoreCPSMethod.invoke(service, boostrapProperties, overridesProperties, filePath);
+        } catch (InvocationTargetException | IllegalAccessException | IllegalArgumentException e) {
+            throw new LauncherException(e.getCause());
+        }
+
+    }
     
     public void runWebApiServer(Properties boostrapProperties, Properties overridesProperties, List<String> bundles,
             Integer metrics, Integer health) throws LauncherException  {


### PR DESCRIPTION
Reworked the feature that was originally presented in PR #192 

> Would've done it in the same branch, but there was an awful duplication of commits and the new PR / branch seemed cleaner than force-pushing.

Restores properties from flat-file to CPS using option `--restorecps` combined with `--file` or `-f`.

This should resolve and close galasa-dev/projectmanagement#405 "QoL: Restore CPS properties"

Changes requested in PR #192 included 
* Passing the initialisation of the InputStream to try as a parameter for auto-closure.
* Throw errors rather than simply logging them, to enable upstream jobs to fail.
* Ensuring keys are output in alphabetical order
* Further discussion on line-by-line vs table output. Decided on (and implemented) line-by-line for simplicity.
* Reduce cyclomatic complexity by converting nested if statements to method calls.
* Convert `isNamespaceRestorePermitted()` method to one line of code.

All requested changes have been implemented as of this PR.