### PR TITLE
Fixed Bug in CPS Restore

### DIFF
--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/RestoreCPS.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/RestoreCPS.java
@@ -37,10 +37,9 @@ public class RestoreCPS {
     
     private IFramework      framework;
     
-    private Map<String, IConfigurationPropertyStoreService>     namespaceCPS 
-                            = new HashMap<String ,IConfigurationPropertyStoreService>();
+    private Map<String, IConfigurationPropertyStoreService>     namespaceCPS = new HashMap<>();
     
-    List<String> forbiddenNamespaces = new ArrayList<String>();
+    List<String> forbiddenNamespaces = new ArrayList<>();
     
     public RestoreCPS(){
     	forbiddenNamespaces.add("dss");
@@ -113,7 +112,7 @@ public class RestoreCPS {
 
         for(String key : keys){
             if (isValidProperty(key)) {
-                restoreProperty(key, properties.getProperty(key).toString());
+                restoreProperty(key, properties.getProperty(key));
             } else {
                 logPropertyRestore("invalid", "n/a", "n/a", "n/a", "n/a");
             }
@@ -141,7 +140,7 @@ public class RestoreCPS {
             
             namespaceCPS.get(namespace).setProperty(property, newValue);
 
-            logPropertyRestore(getStatusCRU(newValue, currentValue), namespace, property, newValue, currentValue);
+            logPropertyRestore(getStatusCRU(newValue, currentValue), namespace, property, currentValue, newValue);
 
         } else {
             logPropertyRestore("denied", namespace, property, "n/a", "n/a");

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/RestoreCPS.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/RestoreCPS.java
@@ -39,6 +39,8 @@ public class RestoreCPS {
     
     private Map<String, IConfigurationPropertyStoreService>     namespaceCPS = new HashMap<>();
     
+    private boolean DRY_RUN = false;
+    
     List<String> forbiddenNamespaces = new ArrayList<>();
     
     public RestoreCPS(){
@@ -57,8 +59,10 @@ public class RestoreCPS {
      * @throws FrameworkException
      * @throws IOException 
      */
-    public void restore(Properties bootstrapProperties, Properties overrideProperties, String filePath) throws FrameworkException, IOException {
+    public void restore(Properties bootstrapProperties, Properties overrideProperties, String filePath, boolean dryRun) throws FrameworkException, IOException {
         logger.info("Initialising CPS Restore Service");
+        
+        DRY_RUN = dryRun;
         
         FrameworkInitialisation frameworkInitialisation = null;
         try {
@@ -138,7 +142,9 @@ public class RestoreCPS {
             
             String currentValue = getExistingValue(namespace, property);
             
-            namespaceCPS.get(namespace).setProperty(property, newValue);
+            if(!DRY_RUN) { 
+            	namespaceCPS.get(namespace).setProperty(property, newValue);
+            	};
 
             logPropertyRestore(getStatusCRU(newValue, currentValue), namespace, property, currentValue, newValue);
 
@@ -272,7 +278,8 @@ public class RestoreCPS {
      * @param newValue
      */
     private void logPropertyRestore(String status, String namespace, String property, String currentValue, String newValue){
-        logger.info(String.format("STATUS: %-10s\tNAMESPACE: %s\tPROPERTY: %s\tOLDVALUE: %s\tNEWVALUE: %s", status, namespace, property, currentValue, newValue));
+    	String message = String.format("STATUS: %-10s\tNAMESPACE: %s\tPROPERTY: %s\tOLDVALUE: %s\tNEWVALUE: %s", status, namespace, property, currentValue, newValue);
+        logger.info((DRY_RUN == true ? "[[ DRY RUN ]]\t" : "") + message);
     }
 
 }

--- a/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/Launcher.java
+++ b/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/Launcher.java
@@ -358,7 +358,15 @@ public class Launcher {
         }
 
         commandLineError(
-                "Error: Must select either --test, --run, --gherkin, --k8scontroller, --metricserver, --resourcemanagement or --webbundle");
+                "Error: Must select either --" + TEST_OPTION
+                		+ ", --" + RUN_OPTION
+                		+ ", --" + GHERKIN_OPTION
+                		+ ", --" + K8SCONTROLLER_OPTION
+                		+ ", --" + METRICSERVER_OPTION
+                		+ ", --" + RESOURCEMANAGEMENT_OPTION
+                		+ ", --" + BUNDLE_OPTION
+                		+ ", --" + BACKUPCPS_OPTION
+                		+ ", or --" + RESTORECPS_OPTION);
     }
     
     private void filePathError(String option) {

--- a/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/Launcher.java
+++ b/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/Launcher.java
@@ -180,7 +180,7 @@ public class Launcher {
                 logger.debug("Back Up CPS Properties");
                 felixFramework.runBackupCPS(boostrapProperties, overridesProperties, filePath);
             } else if (restoreCPS) {
-                felixFramework.runRestoreCPS(boostrapProperties, overridesProperties, filePath);
+                felixFramework.runRestoreCPS(boostrapProperties, overridesProperties, filePath, dryRun);
             }
 
         } catch (LauncherException e) {
@@ -244,7 +244,7 @@ public class Launcher {
         options.addOption(null, BACKUPCPS_OPTION, false, "Back up CPS properties to file");
         options.addOption(null, RESTORECPS_OPTION, false, "Restore CPS properties from file");
         options.addOption(FILE_OPTION, FILE_OPTION_LONG, true, "File for data input/output");
-        options.addOption(null, DRY_RUN_OPTION, true, "Perform a dry-run of the specified actions. Can be combined with \"" + FILE_OPTION_LONG + "\"");
+        options.addOption(null, DRY_RUN_OPTION, false, "Perform a dry-run of the specified actions. Can be combined with \"" + FILE_OPTION_LONG + "\"");
         
 
         CommandLineParser parser = new DefaultParser();

--- a/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/Launcher.java
+++ b/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/Launcher.java
@@ -69,6 +69,7 @@ public class Launcher {
     private static final String     RESTORECPS_OPTION         = "restorecps";
     private static final String     FILE_OPTION               = "f";
     private static final String     FILE_OPTION_LONG          = "file";
+    private static final String     DRY_RUN_OPTION    		  = "dryrun";
     
 
 
@@ -97,6 +98,7 @@ public class Launcher {
     private boolean                 api;
     private boolean                 backupCPS;
     private boolean                 restoreCPS;
+    private boolean 				dryRun;
 
     private Integer                 metrics;
     private Integer                 health;
@@ -242,6 +244,8 @@ public class Launcher {
         options.addOption(null, BACKUPCPS_OPTION, false, "Back up CPS properties to file");
         options.addOption(null, RESTORECPS_OPTION, false, "Restore CPS properties from file");
         options.addOption(FILE_OPTION, FILE_OPTION_LONG, true, "File for data input/output");
+        options.addOption(null, DRY_RUN_OPTION, true, "Perform a dry-run of the specified actions. Can be combined with \"" + FILE_OPTION_LONG + "\"");
+        
 
         CommandLineParser parser = new DefaultParser();
         CommandLine commandLine = null;
@@ -283,6 +287,7 @@ public class Launcher {
         api = commandLine.hasOption(API_OPTION);
         backupCPS = commandLine.hasOption(BACKUPCPS_OPTION);
         restoreCPS = commandLine.hasOption(RESTORECPS_OPTION);
+        dryRun = commandLine.hasOption(DRY_RUN_OPTION);
 
         if (testRun) {
             runName = commandLine.getOptionValue(RUN_OPTION);
@@ -344,6 +349,12 @@ public class Launcher {
                 }
             }
             return;
+        }
+        
+        if (dryRun) {
+        	commandLineError(
+        			"Must be combined with \"" + RESTORECPS_OPTION + "\"");
+        	return;
         }
 
         commandLineError(

--- a/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/felix/FelixFramework.java
+++ b/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/felix/FelixFramework.java
@@ -495,7 +495,7 @@ public class FelixFramework {
      * @param filePath 
      * @throws LauncherException
      */
-    public void runRestoreCPS(Properties boostrapProperties, Properties overridesProperties, String filePath) throws LauncherException {
+    public void runRestoreCPS(Properties boostrapProperties, Properties overridesProperties, String filePath, boolean dryRun) throws LauncherException {
 
         // Get the framework bundle
         Bundle frameWorkBundle = getBundle("dev.galasa.framework");
@@ -526,7 +526,7 @@ public class FelixFramework {
         // Get the dev.galasa.framework.RestoreCPS#restore() method
         Method runRestoreCPSMethod;
         try {
-            runRestoreCPSMethod = service.getClass().getMethod(methodName, Properties.class, Properties.class, String.class);
+            runRestoreCPSMethod = service.getClass().getMethod(methodName, Properties.class, Properties.class, String.class, boolean.class);
         } catch (NoSuchMethodException | SecurityException e) {
             throw new LauncherException("Unable to get Framework " + className + " " + methodName + " method", e);
         }
@@ -534,7 +534,7 @@ public class FelixFramework {
         // Invoke the runBackupCPSMethod method
         logger.debug("Invoking " + className + " " + methodName + "()");
         try {
-            runRestoreCPSMethod.invoke(service, boostrapProperties, overridesProperties, filePath);
+            runRestoreCPSMethod.invoke(service, boostrapProperties, overridesProperties, filePath, dryRun);
         } catch (InvocationTargetException | IllegalAccessException | IllegalArgumentException e) {
             throw new LauncherException(e.getCause());
         }


### PR DESCRIPTION
`currentValue` and `newValue parameters` were being passed in the wrong order (originally line 144 of `RestoreCPS.java`)

Also cleaned up some other parts of the code that were flagged by a linter (e.g. diamond operator preferred over explicit constructor, and `toString()` was unnecessary because the method already returns a string)

Signed-off-by: Matthew Chivers <matthewchivers@outlook.com>