### PR TITLE
Ensure directories will be created for backup file.

### DIFF
--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BackupCPS.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BackupCPS.java
@@ -112,13 +112,15 @@ public class BackupCPS {
         
         Path pathParent = path.getParent();
         
-        try {
-            if (!Files.exists(pathParent)) {
-                Files.createDirectories(pathParent);
-                logger.info("Created directory: " + pathParent.toString());
+        if (pathParent != null) {
+            try {
+                if (!Files.exists(pathParent)) {
+                    Files.createDirectories(pathParent);
+                    logger.info("Created directory: " + pathParent.toString());
+                }
+            } catch (IOException e) {
+                throw new FrameworkException("Failed to create directory: " + pathParent.toString(), e);
             }
-        } catch (IOException e) {
-            throw new FrameworkException("Failed to create directory: " + pathParent.toString(), e);
         }
         
         try {

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BackupCPS.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BackupCPS.java
@@ -110,10 +110,22 @@ public class BackupCPS {
     private void outputToFile(String filePath, String message) throws FrameworkException {
         Path path = Paths.get(filePath);
         
+        Path pathParent = path.getParent();
+        
+        try {
+            if (!Files.exists(pathParent)) {
+                Files.createDirectories(pathParent);
+                logger.info("Created directory: " + pathParent.toString());
+            }
+        } catch (IOException e) {
+            throw new FrameworkException("Failed to create directory: " + pathParent.toString(), e);
+        }
+        
         try {
             Files.write(path, message.getBytes(StandardCharsets.UTF_8), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
-        } catch (IOException e) {
-            throw new FrameworkException("Failed to write to file: " + path.toString(), e);
+            logger.info("Written backup to: " + path.toString());
+        } catch (IOException e1) {
+            throw new FrameworkException("Failed to write to file: " + path.toString(), e1);
         }
     }
     


### PR DESCRIPTION
When specifying a location for the backup file, a location where the parent directory didn't yet exist would fail to be written.

This PR introduces a method to check if the parent directory already exists (if a parent directory is specified), and creates the directory if it does not exist.