### PR TITLE
Adjusted structure of CPS restore and added Delete functionality.

### DIFF
--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/RestoreCPS.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/RestoreCPS.java
@@ -12,11 +12,13 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -43,8 +45,11 @@ public class RestoreCPS {
     
     List<String> forbiddenNamespaces = new ArrayList<>();
     
+    /**
+     * Constructor - No params
+     */
     public RestoreCPS(){
-    	forbiddenNamespaces.add("dss");
+        forbiddenNamespaces.add("dss");
         forbiddenNamespaces.add("certificate");
         forbiddenNamespaces.add("secure");
     }
@@ -62,8 +67,7 @@ public class RestoreCPS {
     public void restore(Properties bootstrapProperties, Properties overrideProperties, String filePath, boolean dryRun) throws FrameworkException, IOException {
         logger.info("Initialising CPS Restore Service");
         
-        DRY_RUN = dryRun;
-        
+        // Initialise Framework
         FrameworkInitialisation frameworkInitialisation = null;
         try {
             frameworkInitialisation = new FrameworkInitialisation(bootstrapProperties, overrideProperties);
@@ -73,15 +77,60 @@ public class RestoreCPS {
         
         framework = frameworkInitialisation.getFramework();
         
-        Properties properties = getProperties(filePath);
-        if (!properties.isEmpty()) {
-            restoreProperties(properties);
-        } else {
-            frameworkInitialisation.shutdownFramework();
-            throw new FrameworkException("Cannot restore properties. The specified file is either empty or was not found.");
+        // Ensure we know the run characteristic(s)
+        DRY_RUN = dryRun;
+        
+        // Fetch all properties from file
+        Properties propsFromFile = getPropertiesFromFile(filePath);
+        
+        if (propsFromFile.isEmpty()) {
+          frameworkInitialisation.shutdownFramework();
+          throw new FrameworkException("Cannot restore properties. The specified file is either empty or was not found.");
         }
         
+        // Fetch all properties from current cps
+        Properties propsFromCPS = getPropertiesFromCPS();
+        
+        // Get all properties in current CPS store but not in restoration file
+        Properties propsToDelete = getComplement(propsFromCPS, propsFromFile);
+        
+        // Get all properties in restoration file but not in current CPS store
+        Properties propsToCreate = getComplement(propsFromFile, propsFromCPS);
+        
+        // Get all properties in both restoration and current properties
+        Properties propsToUpdate = getIntersect(propsFromFile, propsFromCPS);
+        
+        createProperties(propsToCreate);
+        updateProperties(propsToUpdate);
+        deleteProperties(propsToDelete);
+        
+        logger.info("Finished restoring properties to CPS ");
+        
         frameworkInitialisation.shutdownFramework();
+    }
+    
+    private void outputSectionStart(String message) {
+        logger.info("");
+        outputSectionMessage("CPS RESTORATION    " + getDryRunTitleText(), 
+                "", message, "", ">>> START <<<");
+        logger.info("");
+    }
+    
+    private void outputSectionStop() {
+        logger.info("");
+        outputSectionMessage(">>> STOP <<<");
+        logger.info("");
+    }
+    
+    private void outputSectionMessage(String... messages) {
+        String bannerStars = "********************************************************************";
+        logger.info(bannerStars);
+        
+        for(String message : messages) {
+            logger.info(String.format("*  %-62s *", message));
+        }
+        
+        logger.info(bannerStars);
     }
     
     /**
@@ -91,7 +140,7 @@ public class RestoreCPS {
      * @return properties
      * @throws IOException 
      */
-    private Properties getProperties(String filePath) throws IOException {
+    private Properties getPropertiesFromFile(String filePath) throws IOException {
         
         Properties properties = new Properties();
 
@@ -102,61 +151,192 @@ public class RestoreCPS {
         }
         
         return properties;
-
     }
     
-    /**
-     * <p>Iterates through the properties in the supplied object, restoring them one-by-one to the Configuration Property Store<p>
-     * 
-     * @param properties (instance of object: Properties)
-     * @return 
-     */
-    private void restoreProperties(Properties properties) throws ConfigurationPropertyStoreException {
-
-        List<String> keys = new ArrayList<>(properties.stringPropertyNames());
-
-        java.util.Collections.sort(keys, java.text.Collator.getInstance());
-
-        for(String key : keys){
-            if (isValidProperty(key)) {
-                restoreProperty(key, properties.getProperty(key));
-            } else {
-                logPropertyRestore("invalid", "n/a", "n/a", "n/a", "n/a");
+    private Properties getPropertiesFromCPS() throws ConfigurationPropertyStoreException {
+        Properties properties = new Properties();
+        
+        // Retrieve all namespaces
+        List<String> namespaces = framework.getConfigurationPropertyService("framework").getCPSNamespaces();
+        
+        // Retrieve properties from those namespaces
+        for (String namespace : namespaces) {
+            if(!forbiddenNamespaces.contains(namespace)) {
+                properties.putAll(getNamespaceProperties(namespace));
             }
-        }                
+        }
+        
+        return properties;
     }
     
-    /**
-     * <p>Restores individual property to CPS</p>
-     * 
-     * @param key (String)
-     * @param value (String)
-     * @return
-     * @throws ConfigurationPropertyStoreException
-     */
-    private void restoreProperty(String key, String newValue) throws ConfigurationPropertyStoreException {
+    private Properties getNamespaceProperties(String namespace) throws ConfigurationPropertyStoreException {
+        Properties properties = new Properties();
         
-        String namespace = getPropertyPrefix(key);
-        String property = getPropertySuffix(key);
+        ensureCPSExists(namespace);
+        Map<String, String> nsProperties = namespaceCPS.get(namespace).getAllProperties();
+        for(Entry<String, String> prop: nsProperties.entrySet()) {
+            properties.put(prop.getKey(), prop.getValue());
+        }
         
-        if (!forbiddenNamespaces.contains(namespace)){
+        return properties;
+    }
+    
+    private Properties getComplement(Properties propsA, Properties propsB){
+        // Get relative complement of propsA \ propsB
+        Properties properties = new Properties();
+
+        Set<Object> propsIntersect = new HashSet<>();
+        
+        propsIntersect.addAll(propsA.keySet());
+        propsIntersect.removeAll(propsB.keySet());
+        
+        for (Object key : propsIntersect) {
+            properties.put(key, propsA.getProperty(key.toString()));
+        }
+        
+        return properties;
+    }
+    
+    private Properties getIntersect(Properties propsA, Properties propsB){
+        // Get intesection of propsA /\ propsB
+        Properties properties = new Properties();
+
+        Set<Object> propsIntersect = new HashSet<>();
+        
+        propsIntersect.addAll(propsA.keySet());
+        propsIntersect.retainAll(propsB.keySet());
+
+        for (Object key : propsIntersect) {
+            properties.put(key, propsA.getProperty(key.toString()));
+        }
+        
+        return properties;
+    }
+    
+    private void createProperties(Properties props) throws ConfigurationPropertyStoreException {
+        
+        outputSectionStart("CREATING PROPERTIES");
+        
+        // Convert to list and then sort the list alphabetically        
+        List<String> propsList = new ArrayList<>(props.stringPropertyNames());
+        java.util.Collections.sort(propsList, java.text.Collator.getInstance());
+        
+        for (String key : propsList) {
+            if (!isValidProperty(key)) {
+                logger.warn("Invalid Property: " + key);
+                continue;
+            }
+            String namespace = getPropertyPrefix(key);
+            String property = getPropertySuffix(key);
+            String value = props.getProperty(key);
             
             ensureCPSExists(namespace);
             
-            String currentValue = getExistingValue(namespace, property);
+            logger.info(property + " = " + value);
+            
+            // Create the property
             
             if(!DRY_RUN) { 
-            	namespaceCPS.get(namespace).setProperty(property, newValue);
-            	};
-
-            logPropertyRestore(getStatusCRU(newValue, currentValue), namespace, property, currentValue, newValue);
-
-        } else {
-            logPropertyRestore("denied", namespace, property, "n/a", "n/a");
+                 namespaceCPS.get(namespace).setProperty(property, value);
+            }
         }
+        
+        outputSectionStop();
+    }
+    
+    private void updateProperties(Properties props) throws ConfigurationPropertyStoreException {
+        
+        // Convert to list and then sort the list alphabetically        
+        List<String> propsList = new ArrayList<>(props.stringPropertyNames());
+        java.util.Collections.sort(propsList, java.text.Collator.getInstance());
+        
+        List<String> propsNotUpdated = new ArrayList<>();
+        
+        outputSectionStart("UPDATING PROPERTIES");
+        
+        for (String key : propsList) {
+            if (!isValidProperty(key)) {
+                logger.warn("Invalid Property: " + key);
+                continue;
+            }
+            String namespace = getPropertyPrefix(key);
+            String property = getPropertySuffix(key);
+            String value = props.getProperty(key);
+            
+            ensureCPSExists(namespace);
+            
+            String oldValue = namespaceCPS.get(namespace).getProperty(getPropertyPrefix(property), getPropertySuffix(property));
+            
+            if(oldValue.equals(value)){
+                propsNotUpdated.add(key);
+            } else {
+                logger.info(key);
+                logger.info("\tOLD VALUE: " + oldValue);
+                logger.info("\tNEW VALUE: " + value);
+                
+                if(!DRY_RUN) { 
+                    namespaceCPS.get(namespace).setProperty(property, value);
+                }
+            }
+            
+            
+        }
+
+        outputSectionStop();
+        
+        
+        outputSectionStart("KEEPING PROPERTIES");
+        
+        for (String key : propsNotUpdated) {
+            logger.info(key + " = " + props.getProperty(key));
+        }
+        
+        outputSectionStop();
         
     }
 
+    private void deleteProperties(Properties props) throws ConfigurationPropertyStoreException {
+        
+        outputSectionStart("DELETING PROPERTIES");
+        
+        // Convert to list and then sort the list alphabetically
+        List<String> propsList = new ArrayList<>(props.stringPropertyNames());
+        java.util.Collections.sort(propsList, java.text.Collator.getInstance());
+        
+        for (String key : propsList) {
+            if (!isValidProperty(key)) {
+                logger.warn("Invalid Property: " + key);
+                continue;
+            }
+            String namespace = getPropertyPrefix(key);
+            String property = getPropertySuffix(key);
+            String value = props.getProperty(key);
+            
+            ensureCPSExists(namespace);
+            
+            logger.info(property + " = " + value);
+            
+            // Delete the property
+            
+            if(!DRY_RUN) {
+                 // namespaceCPS.get(namespace).setProperty(property, value);
+            }
+        }
+        
+        outputSectionStop();
+    }
+    
+    private String getDryRunTitleText() {
+        String dryRunText = "DRY RUN";
+        
+        String output = "";
+        
+        if (DRY_RUN) {
+            output = "[ " + dryRunText + " ]";
+        }
+        return output;
+    }
+    
     /**
      * <p>Initialise an instance of IConfigurationPropertyStoreService for the specified namespace if one doesn't already exist.</p>
      * @param namespace
@@ -167,34 +347,6 @@ public class RestoreCPS {
             namespaceCPS.put(namespace, framework.getConfigurationPropertyService(namespace));
         }
     }
-
-    /**
-     * <p>Returns the status message to be displayed based on the new and current value of the property that was set<p>
-     * @param newValue
-     * @param currentValue
-     * @return
-     */
-    private String getStatusCRU(String newValue, String currentValue) {
-        if (currentValue != null) {
-            return getValueChangeStatus(newValue, currentValue);
-        } else {
-            return "created";
-        }
-    }
-
-    /**
-     * <p>Returns status message to identify whether a property's value was updated or remained the same<p>
-     * @param newValue
-     * @param currentValue
-     * @return
-     */
-    private String getValueChangeStatus(String newValue, String currentValue) {
-        if (currentValue.equals(newValue)) {
-            return "no_change";
-        } else {
-            return "updated";
-        }
-    }
     
     /**
      * <p>Retrieves Property Prefix (after first dot ".")</p>
@@ -202,7 +354,7 @@ public class RestoreCPS {
      * @param propertyName
      * @return
      */
-    private String getPropertyPrefix(String propertyName) throws ConfigurationPropertyStoreException {
+    private String getPropertyPrefix(String propertyName) {
         return propSplit(propertyName, 0);
     }
     
@@ -212,7 +364,7 @@ public class RestoreCPS {
      * @param propertyName
      * @return
      */
-    private String getPropertySuffix(String propertyName) throws ConfigurationPropertyStoreException {
+    private String getPropertySuffix(String propertyName) {
         return propSplit(propertyName, 1);
     }
     
@@ -227,12 +379,10 @@ public class RestoreCPS {
      * @param position
      * @return dashes
      */
-    private String propSplit(String str, int position) throws ConfigurationPropertyStoreException {
+    private String propSplit(String str, int position) {
         
         String[] kvp = str.split("\\.", 2);
-        if (kvp.length <= 1) {
-            throw new ConfigurationPropertyStoreException("Invalid Property Format: " + str);
-        }
+
         return kvp[position];
     }
     
@@ -250,39 +400,7 @@ public class RestoreCPS {
         
         Pattern pattern = Pattern.compile("^([a-zA-Z0-9]+\\.){2,}[a-zA-Z0-9]+$");
         Matcher matcher = pattern.matcher(key);
-        boolean matchFound = matcher.find();
-        return matchFound;
+        return matcher.find();
     }
-       
-    /**
-     * <p>Retrieves the current/existing value for a specified property.</p>
-     * <p>This wrapper is required due to properties only being retrievable using both a prefix and a suffix.</p>
-     * 
-     * @param namespace
-     * @param property
-     * @return existingValue
-     * @throws ConfigurationPropertyStoreException 
-     */
-    private String getExistingValue(String namespace, String property) throws ConfigurationPropertyStoreException {
-     
-        String existingValue = 
-                namespaceCPS.get(namespace).getProperty(getPropertyPrefix(property), getPropertySuffix(property));
-                
-        return existingValue;
-        
-    }
-
-    /**
-     * <p>Log property restore status</p>
-     * @param status
-     * @param namespace
-     * @param property
-     * @param currentValue
-     * @param newValue
-     */
-    private void logPropertyRestore(String status, String namespace, String property, String currentValue, String newValue){
-    	String message = String.format("STATUS: %-10s\tNAMESPACE: %s\tPROPERTY: %s\tOLDVALUE: %s\tNEWVALUE: %s", status, namespace, property, currentValue, newValue);
-        logger.info((DRY_RUN == true ? "[[ DRY RUN ]]\t" : "") + message);
-    }
-
+    
 }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/RestoreCPS.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/RestoreCPS.java
@@ -1,7 +1,7 @@
 /*
  * Licensed Materials - Property of IBM
  * 
- * (c) Copyright IBM Corp. 2020.
+ * (c) Copyright IBM Corp. 2020, 2021.
  */
 
 package dev.galasa.framework;
@@ -39,11 +39,11 @@ public class RestoreCPS {
     
     private IFramework      framework;
     
-    private Map<String, IConfigurationPropertyStoreService>     namespaceCPS = new HashMap<>();
+    private Map<String, IConfigurationPropertyStoreService>         namespaceCPS = new HashMap<>();
     
-    private boolean DRY_RUN = false;
+    private boolean         DRY_RUN = false;
     
-    List<String> forbiddenNamespaces = new ArrayList<>();
+    List<String>            forbiddenNamespaces = new ArrayList<>();
     
     /**
      * Constructor - No params
@@ -242,13 +242,12 @@ public class RestoreCPS {
             String property = getPropertySuffix(key);
             String value = props.getProperty(key);
             
-            ensureCPSExists(namespace);
-            
             logger.info(key + " = " + value);
             
             if(!DRY_RUN) { 
-                 // Create the property
-                 namespaceCPS.get(namespace).setProperty(property, value);
+                // Create the property
+                ensureCPSExists(namespace);
+                namespaceCPS.get(namespace).setProperty(property, value);
             }
         }
         
@@ -330,14 +329,13 @@ public class RestoreCPS {
             String property = getPropertySuffix(key);
             String value = props.getProperty(key);
             
-            ensureCPSExists(namespace);
-            
             logger.info(property + " = " + value);
             
             // Delete the property
             
             if(!DRY_RUN) {
-                 // namespaceCPS.get(namespace).setProperty(property, value);
+                ensureCPSExists(namespace);
+                namespaceCPS.get(namespace).deleteProperty(property);
             }
         }
         

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/cps/FpfConfigurationPropertyStore.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/cps/FpfConfigurationPropertyStore.java
@@ -1,7 +1,7 @@
 /*
  * Licensed Materials - Property of IBM
  * 
- * (c) Copyright IBM Corp. 2019.
+ * (c) Copyright IBM Corp. 2019, 2021.
  */
 package dev.galasa.framework.internal.cps;
 
@@ -25,6 +25,7 @@ import dev.galasa.framework.spi.IConfigurationPropertyStore;
  * </p>
  * 
  * @author James Davies
+ * @author Matthew Chivers
  */
 
 public class FpfConfigurationPropertyStore implements IConfigurationPropertyStore {
@@ -73,6 +74,15 @@ public class FpfConfigurationPropertyStore implements IConfigurationPropertyStor
     public void setProperty(@NotNull String key, @NotNull String value) throws ConfigurationPropertyStoreException {
         try {
             fpf.set(key, value);
+        } catch (FrameworkPropertyFileException e) {
+            throw new ConfigurationPropertyStoreException("Unable to set property value", e);
+        }
+    }
+    
+    @Override
+    public void deleteProperty(@NotNull String key) throws ConfigurationPropertyStoreException {
+        try {
+            fpf.delete(key);
         } catch (FrameworkPropertyFileException e) {
             throw new ConfigurationPropertyStoreException("Unable to set property value", e);
         }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/cps/FrameworkConfigurationPropertyService.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/cps/FrameworkConfigurationPropertyService.java
@@ -1,7 +1,7 @@
 /*
  * Licensed Materials - Property of IBM
  * 
- * (c) Copyright IBM Corp. 2019.
+ * (c) Copyright IBM Corp. 2019, 2021.
  */
 package dev.galasa.framework.internal.cps;
 
@@ -28,6 +28,7 @@ import dev.galasa.framework.spi.IFramework;
  * </p>
  * 
  * @author James Davies
+ * @author Matthew Chivers
  */
 public class FrameworkConfigurationPropertyService implements IConfigurationPropertyStoreService {
     private String                      namespace;
@@ -119,6 +120,19 @@ public class FrameworkConfigurationPropertyService implements IConfigurationProp
     public void setProperty(@NotNull String name, @NotNull String value)
             throws ConfigurationPropertyStoreException {
     	cpsStore.setProperty(namespace + "." + name, value);
+    }
+    
+    /**
+     * <p>
+     * This method deletes a cps propetty with a given name within the provided namespace
+     * </p>
+     * 
+     * @param name
+     */
+    public void deleteProperty(@NotNull String name) 
+            throws ConfigurationPropertyStoreException {
+        cpsStore.deleteProperty(namespace + "." + name);
+        
     }
 
     /**

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IConfigurationPropertyStore.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IConfigurationPropertyStore.java
@@ -1,7 +1,7 @@
 /*
  * Licensed Materials - Property of IBM
  * 
- * (c) Copyright IBM Corp. 2019.
+ * (c) Copyright IBM Corp. 2019, 2021.
  */
 package dev.galasa.framework.spi;
 
@@ -26,6 +26,7 @@ import javax.validation.constraints.Null;
  * </p>
  * 
  * @author Michael Baylis
+ * @author Matthew Chivers
  *
  */
 public interface IConfigurationPropertyStore {
@@ -78,6 +79,21 @@ public interface IConfigurationPropertyStore {
     @Null
     void setProperty(@NotNull String key, @NotNull String value) throws ConfigurationPropertyStoreException;
 
+    /**
+     * <p>
+     * Delete the property from the underlying configuration property store.
+     * </p>
+     * 
+     * <p>
+     * The framework will prefix with the appropriate namespace and apply the
+     * infixes before calling this method
+     * </p>
+     * 
+     * @param key
+     * @throws ConfigurationPropertyStoreException
+     */
+    void deleteProperty(@NotNull String key) throws ConfigurationPropertyStoreException;
+    
     /**
      * <p>
      * Retrieves all possible different properties set from a given namespace

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IConfigurationPropertyStoreService.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IConfigurationPropertyStoreService.java
@@ -1,7 +1,7 @@
 /*
  * Licensed Materials - Property of IBM
  * 
- * (c) Copyright IBM Corp. 2019.
+ * (c) Copyright IBM Corp. 2019, 2021.
  */
 package dev.galasa.framework.spi;
 
@@ -32,6 +32,7 @@ import javax.validation.constraints.Null;
  * </p>
  * 
  * @author Michael Baylis
+ * @author Matthew Chivers
  *
  */
 public interface IConfigurationPropertyStoreService {
@@ -123,6 +124,31 @@ public interface IConfigurationPropertyStoreService {
      */
     @Null
     void setProperty(@NotNull String name, @NotNull String value) throws ConfigurationPropertyStoreException;
+    
+    /**
+     * <p>
+     * Removes a string property from the Configuration Property Store within the
+     * namespace for this object.
+     * </p>
+     * 
+     * <p>
+     * deleteProperty will delete the property from the standard Configuration Property Store.
+     * </p>
+     * 
+     * <p>
+     * As an example, if we called deleteProperty("image.PLEXMA.credentialid") within the zos
+     * namespace, then the following property will be deleted:-<br>
+     * zos.image.PLEXMA.credentialid=VALUE
+     * </p>
+     * 
+     * <p>
+     * If a property could not be deleted, a ConfigurationPropertyStoreException is thrown.
+     * </p>
+     * 
+     * @param name The property name within the namespace.
+     * @throws ConfigurationPropertyStoreException
+     */
+    void deleteProperty(@NotNull String name) throws ConfigurationPropertyStoreException;
 
     /**
      * <p>

--- a/galasa-parent/galasa-testharness/src/main/java/dev/galasa/testharness/InMemoryCps.java
+++ b/galasa-parent/galasa-testharness/src/main/java/dev/galasa/testharness/InMemoryCps.java
@@ -1,7 +1,7 @@
 /*
  * Licensed Materials - Property of IBM
  * 
- * (c) Copyright IBM Corp. 2020.
+ * (c) Copyright IBM Corp. 2020, 2021.
  */
 package dev.galasa.testharness;
 
@@ -46,6 +46,11 @@ public class InMemoryCps implements IConfigurationPropertyStore {
     @Override
     public void setProperty(@NotNull String key, @NotNull String value) throws ConfigurationPropertyStoreException {
         this.properties.put(key, value);
+    }
+    
+    @Override
+    public void deleteProperty(@NotNull String key) throws ConfigurationPropertyStoreException {
+        this.properties.remove(key);
     }
 
     @Override


### PR DESCRIPTION
Implements deletion functionality for CPS properties.

Also restructures the restoreCPS class massively. This has enabled better-structured output. Now properties will output in sections: all properties created, followed by all properties updated, followed by all properties that remain the same, followed by all properties deleted. This is opposed to every property line-by-line in a somewhat messy output as previously.

Closes galasa-dev/projectmanagement#569