### PR TITLE
Fixed delete CPS to output namespace of property being deleted as well as the property name.

### DIFF
--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/RestoreCPS.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/RestoreCPS.java
@@ -329,7 +329,7 @@ public class RestoreCPS {
             String property = getPropertySuffix(key);
             String value = props.getProperty(key);
             
-            logger.info(property + " = " + value);
+            logger.info(key + " = " + value);
             
             // Delete the property
             


### PR DESCRIPTION
Ensured entire property key (namespace + property name) will be output rather than just the property name

Signed-off-by: Matthew Chivers <matthewchivers@outlook.com>