### PR TITLE
Altered the repositories we're using for Gradle builds and updated the build to 0.15.0-SNAPSHOT.

### DIFF
--- a/Jenkinsfile.gradle
+++ b/Jenkinsfile.gradle
@@ -30,7 +30,7 @@ pipeline {
             ]) {
                withFolderProperties { 
                   dir('galasa-parent') {
-                     sh "gradle -Dgradle.user.home=${workspace}/.gradle -Psigning.gnupg.keyName=8534E695 -Psigning.gnupg.passphrase=$GPG ${GRADLE_CACHE} ${GRADLE_TASKS}"
+                     sh "gradle -s -Dgradle.user.home=${workspace}/.gradle -Psigning.gnupg.keyName=8534E695 -Psigning.gnupg.passphrase=$GPG ${GRADLE_CACHE} ${GRADLE_TASKS}"
                   }
                }
             }

--- a/Jenkinsfile.gradle
+++ b/Jenkinsfile.gradle
@@ -1,15 +1,18 @@
 pipeline {
+
    agent {
       label 'codesigning'
    }
+
    environment {
-//Configure Gradnel from the tools definition in Jenkins
+      // Configure Gradle from the tools definition in Jenkins
       def gradleHome = tool 'gradle'
       PATH = "${gradleHome}/bin:${env.PATH}"
       
-//Set some defaults
+      //Set some defaults
       def workspace = pwd()
    }
+
    stages {
       stage('prep-workspace') { 
          steps {
@@ -17,18 +20,18 @@ pipeline {
             }
          }
       }
-   
+
       stage('gradle') {
          steps {
-            withCredentials([string(credentialsId: 'galasa-gpg', variable: 'GPG'),
-                             usernamePassword(credentialsId: 'galasa-nexus', usernameVariable: 'MAVENUSERNAME', passwordVariable: 'MAVENPASSWORD'),
-                             usernamePassword(credentialsId: 'gradle-cache', usernameVariable: 'CACHEUSERNAME', passwordVariable: 'CACHEPASSWORD')]) {
+            withCredentials([
+               string(credentialsId: 'galasa-gpg', variable: 'GPG'),
+               usernamePassword(credentialsId: 'galasa-nexus', usernameVariable: 'MAVENUSERNAME', passwordVariable: 'MAVENPASSWORD'),
+               usernamePassword(credentialsId: 'gradle-cache', usernameVariable: 'CACHEUSERNAME', passwordVariable: 'CACHEPASSWORD')
+            ]) {
                withFolderProperties { 
-             //     withSonarQubeEnv('GalasaSonarQube') {
-                     dir('galasa-parent') {
-                        sh "gradle -Dgradle.user.home=${workspace}/.gradle -Psigning.gnupg.keyName=8534E695 -Psigning.gnupg.passphrase=$GPG ${GRADLE_CACHE} ${GRADLE_TASKS}"
-                     } 
-                //  }
+                  dir('galasa-parent') {
+                     sh "gradle -Dgradle.user.home=${workspace}/.gradle -Psigning.gnupg.keyName=8534E695 -Psigning.gnupg.passphrase=$GPG ${GRADLE_CACHE} ${GRADLE_TASKS}"
+                  }
                }
             }
          }

--- a/galasa-parent/build.gradle
+++ b/galasa-parent/build.gradle
@@ -41,7 +41,6 @@ subprojects {
     }
 
     repositories {
-        mavenLocal()
         maven {
             url mavenrepo
         }

--- a/galasa-parent/build.gradle
+++ b/galasa-parent/build.gradle
@@ -21,7 +21,7 @@ subprojects {
 
     ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
-    def mavenrepo = System.getenv('MAVEN_REPO') ?: "https://nexus.galasa.dev/repository/maven-gradle"
+    def mavenrepo = System.getenv('MAVEN_REPO') ?: "https://nexus.galasa.dev/repository/maven-grade"
 
     tasks.withType(Sign) {
         onlyIf { isReleaseVersion }
@@ -54,79 +54,79 @@ subprojects {
                 from components.java
                 
                 pom {
-                     name = 'Galasa Testers Programmer Interface (TPI)'
-                     url = 'https://galasa.dev'
-                     licenses {
-                         license {
-                             name = 'Eclipse Public License - v 2.0'
-                             url = 'https://www.eclipse.org/legal/epl-2.0/t'
-                         }
-                     }
-                     developers {
-                         developer {
-                             name = 'Michael Baylis'
-                             email = 'Michael.Baylis@uk.ibm.com'
-                             organization = 'IBM'
-                             organizationUrl = 'https://www.ibm.com'
-                         }
-                         developer {
-                             name = 'William Yates'
-                             email = 'wyates@uk.ibm.com'
-                             organization = 'IBM'
-                             organizationUrl = 'https://www.ibm.com'
-                         }
-                         developer {
-                             name = 'David Roberts'
-                             email = 'david.roberts@uk.ibm.com'
-                             organization = 'IBM'
-                             organizationUrl = 'https://www.ibm.com'
-                         }
-                         developer {
-                             name = 'James Davies'
-                             email = 'james.davies@ibm.com'
-                             organization = 'IBM'
-                             organizationUrl = 'https://www.ibm.com'
-                         }
-                         developer {
-                             name = 'Matthew Chivers'
-                             email = 'matthew.chivers@ibm.com'
-                             organization = 'IBM'
-                             organizationUrl = 'https://www.ibm.com'
-                         }
-                         developer {
-                             name = 'Charlie Meek'
-                             email = 'charlie.meek@ibm.com'
-                             organization = 'IBM'
-                             organizationUrl = 'https://www.ibm.com'
-                         }
-                         developer {
-                             name = 'Diana Slepikaite'
-                             email = 'diana.slepikaite@ibm.com'
-                             organization = 'IBM'
-                             organizationUrl = 'https://www.ibm.com'
-                         }
-                     }
-                     scm {
-                         connection = 'scm:git:git:://github.com/galasa-dev/framework'
-                         developerConnection = 'scm:git:git:://github.com/galasa-dev/framework'
-                         url = 'https://github.com/galasa-dev/framework'
-                     }
-                     issueManagement {
-                         system = 'GitHub'
-                         url = 'https://github.com/galasa-dev/projectmanagement/issues'
-                     }
+                    name = 'Galasa Testers Programmer Interface (TPI)'
+                    url = 'https://galasa.dev'
+                    licenses {
+                        license {
+                            name = 'Eclipse Public License - v 2.0'
+                            url = 'https://www.eclipse.org/legal/epl-2.0/t'
+                        }
+                    }
+                    developers {
+                        developer {
+                            name = 'Michael Baylis'
+                            email = 'Michael.Baylis@uk.ibm.com'
+                            organization = 'IBM'
+                            organizationUrl = 'https://www.ibm.com'
+                        }
+                        developer {
+                            name = 'William Yates'
+                            email = 'wyates@uk.ibm.com'
+                            organization = 'IBM'
+                            organizationUrl = 'https://www.ibm.com'
+                        }
+                        developer {
+                            name = 'David Roberts'
+                            email = 'david.roberts@uk.ibm.com'
+                            organization = 'IBM'
+                            organizationUrl = 'https://www.ibm.com'
+                        }
+                        developer {
+                            name = 'James Davies'
+                            email = 'james.davies@ibm.com'
+                            organization = 'IBM'
+                            organizationUrl = 'https://www.ibm.com'
+                        }
+                        developer {
+                            name = 'Matthew Chivers'
+                            email = 'matthew.chivers@ibm.com'
+                            organization = 'IBM'
+                            organizationUrl = 'https://www.ibm.com'
+                        }
+                        developer {
+                            name = 'Charlie Meek'
+                            email = 'charlie.meek@ibm.com'
+                            organization = 'IBM'
+                            organizationUrl = 'https://www.ibm.com'
+                        }
+                        developer {
+                            name = 'Diana Slepikaite'
+                            email = 'diana.slepikaite@ibm.com'
+                            organization = 'IBM'
+                            organizationUrl = 'https://www.ibm.com'
+                        }
+                    }
+                    scm {
+                        connection = 'scm:git:git:://github.com/galasa-dev/framework'
+                        developerConnection = 'scm:git:git:://github.com/galasa-dev/framework'
+                        url = 'https://github.com/galasa-dev/framework'
+                    }
+                    issueManagement {
+                        system = 'GitHub'
+                        url = 'https://github.com/galasa-dev/projectmanagement/issues'
+                    }
                 }
             }
-         }
-         repositories {
-             maven {
-                 credentials {
-                     username System.getenv('MAVENUSERNAME')
-                     password System.getenv('MAVENPASSWORD')
-                 }
-                 url = mavenrepo
-             }
-         }
+        }
+        repositories {
+            maven {
+                credentials {
+                    username System.getenv('MAVENUSERNAME')
+                    password System.getenv('MAVENPASSWORD')
+                }
+                url = mavenrepo
+            }
+        }
     }
 
     signing {

--- a/galasa-parent/build.gradle
+++ b/galasa-parent/build.gradle
@@ -21,7 +21,7 @@ subprojects {
 
     ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
-    def mavenrepo = System.getenv('MAVEN_REPO') ?: "https://nexus.galasa.dev/repository/maven-development"
+    def mavenrepo = System.getenv('MAVEN_REPO') ?: "https://nexus.galasa.dev/repository/maven-gradle"
 
     tasks.withType(Sign) {
         onlyIf { isReleaseVersion }
@@ -115,8 +115,8 @@ subprojects {
                          system = 'GitHub'
                          url = 'https://github.com/galasa-dev/projectmanagement/issues'
                      }
-                 }
-             }
+                }
+            }
          }
          repositories {
              maven {

--- a/galasa-parent/build.gradle
+++ b/galasa-parent/build.gradle
@@ -21,7 +21,7 @@ subprojects {
 
     ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
-    def mavenrepo = System.getenv('MAVEN_REPO') ?: "https://nexus.galasa.dev/repository/maven-grade"
+    def mavenrepo = System.getenv('MAVEN_REPO') ?: "https://nexus.galasa.dev/repository/maven-development"
 
     tasks.withType(Sign) {
         onlyIf { isReleaseVersion }

--- a/galasa-parent/gradle.properties
+++ b/galasa-parent/gradle.properties
@@ -1,5 +1,5 @@
 galasaGroup=dev.galasa
 galasaName=galasa
-galasaVersion=0.14.0-SNAPSHOT
+galasaVersion=0.15.0-SNAPSHOT
 galasaSourceCompatibility=1.8
 galasaTargetCompatibility=1.8


### PR DESCRIPTION
- Removed 'mavenLocal()' repository from requirements, as it is [against best practice](https://docs.gradle.org/current/userguide/declaring_repositories.html#sec:case-for-maven-local) (and ultimately should not be required).
- Changed publish repository to `maven-gradle` - at least for development purposes. Either way we probably don't want Gradle builds going in to `maven-development`.
- Changed version to 0.15.0-SNAPSHOT to keep up with main stream.
- Lastly, added the `-s` flag to the Gradle command-line call so that we get verbose output from the build.