### PR TITLE
Fixed Jenkins build so that extensions has a parent pom.

### DIFF
--- a/Jenkinsfile.gradle
+++ b/Jenkinsfile.gradle
@@ -16,6 +16,8 @@ pipeline {
    stages {
       stage('prep-workspace') { 
          steps {
+            configFileProvider([configFile(fileId: '86dde059-684b-4300-b595-64e83c2dd217', targetLocation: 'settings.xml')]) {
+            }
             configFileProvider([configFile(fileId: 'galasa-init-gradle', targetLocation: '.gradle/init.gradle')]) {
             }
          }

--- a/Jenkinsfile.gradle
+++ b/Jenkinsfile.gradle
@@ -21,6 +21,20 @@ pipeline {
          }
       }
 
+      stage('maven') {
+         // Unavoidable until all other projects are no longer dependent on using galasa-parent pom.xml as a parent.
+         steps {
+            withCredentials([string(credentialsId: 'galasa-gpg', variable: 'GPG')]) {
+               withFolderProperties { withSonarQubeEnv('GalasaSonarQube') {
+                  dir('galasa-parent') {
+                     sh "mvn --settings ${workspace}/settings.xml -Dmaven.repo.local=${workspace}/repository -Dgpg.skip=${GPG_SKIP} -Dgpg.passphrase=$GPG -P ${MAVEN_PROFILE} -B -e -fae --non-recursive ${MAVEN_GOAL}"
+                  }
+               }
+               }
+            }
+         }
+      }
+
       stage('gradle') {
          steps {
             withCredentials([


### PR DESCRIPTION
Added galasa-parent to the Jenkins build file so that Galasa extensions may use the resulting pom as a "parent".

Signed-off-by: Matthew Chivers <matthewchivers@outlook.com>