### PR TITLE
Corrected Plugin Management

### DIFF
--- a/galasa-parent/dev.galasa.framework.obr/settings.gradle
+++ b/galasa-parent/dev.galasa.framework.obr/settings.gradle
@@ -1,10 +1,1 @@
-pluginManagement {
-    repositories {
-        maven {
-            url "https://nexus.galasa.dev/repository/maven-gradle"
-        }
-        gradlePluginPortal()
-    }
-}
-
 rootProject.name = 'dev.galasa.framework.obr'

--- a/galasa-parent/settings.gradle
+++ b/galasa-parent/settings.gradle
@@ -1,7 +1,7 @@
 pluginManagement {
     repositories {
         maven {
-            url "https://nexus.galasa.dev/repository/maven-gradle"
+            url = System.getenv('MAVEN_REPO') ?: "https://nexus.galasa.dev/repository/maven-development"
         }
         gradlePluginPortal()
     }


### PR DESCRIPTION
Removed pluginManagement from obr settings (already exists in project settings) and set default URL for the plugin repository.

Signed-off-by: Matthew Chivers <matthewchivers@outlook.com>