### PR TITLE
Removed dependency on EnvVar GRADLE_CLEAN

### DIFF
--- a/Jenkinsfile.gradle
+++ b/Jenkinsfile.gradle
@@ -55,7 +55,7 @@ pipeline {
             ]) {
                withFolderProperties { 
                   dir('galasa-parent') {
-                     sh "gradle -s -Dgradle.user.home=${workspace}/.gradle -Psigning.gnupg.keyName=8534E695 -Psigning.gnupg.passphrase=$GPG ${GRADLE_CACHE} ${GRADLE_CLEAN} ${GRADLE_TASKS}"
+                     sh "gradle -s -Dgradle.user.home=${workspace}/.gradle -Psigning.gnupg.keyName=8534E695 -Psigning.gnupg.passphrase=$GPG ${GRADLE_CACHE} ${GRADLE_TASKS}"
                   }
                   dir('galasa-parent/dev.galasa.framework.obr') {
                      // sh "gradle -s -Dgradle.user.home=${workspace}/.gradle -Psigning.gnupg.keyName=8534E695 -Psigning.gnupg.passphrase=$GPG ${GRADLE_CACHE} genobr ${GRADLE_TASKS} --rerun-tasks --refresh-dependencies"


### PR DESCRIPTION
Removed dependency on GRADLE_CLEAN, to align functionality of GRADLE_TASKS with MAVEN_GOAL.
> If `clean` is required it should be specified in GRADLE_TASKS, as it **is** a task.
