### PR TITLE
dss namespace hidden, secure namespace redacted values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ node_modules
 package-lock.json
 build/
 .gradle/
+**/.idea/

--- a/galasa-parent/build.gradle
+++ b/galasa-parent/build.gradle
@@ -21,3 +21,9 @@ gradle.taskGraph.afterTask { Task task, TaskState state ->
     int sec = secs - mins * 60
     println " -> took " + mins + ( ( 1 == mins ) ? " min " : " mins " ) + sec + ( ( 1 == sec ) ? " sec" : " secs" )
 }
+
+allprojects {
+   tasks.withType(Javadoc) {
+      options.addStringOption('Xdoclint:none', '-quiet')
+   }
+}

--- a/galasa-parent/dev.galasa.framework.api.cps/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api.cps/build.gradle
@@ -9,7 +9,8 @@ description = 'Galasa API - CPS'
 version = '0.25.0'
 
 dependencies {
-    implementation project(':dev.galasa.framework')   
+    implementation project(':dev.galasa.framework')
+    testImplementation 'org.assertj:assertj-core:3.23.1'
 }
 
 openApiGenerate {

--- a/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/AccessCps.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/AccessCps.java
@@ -1,7 +1,5 @@
 /*
- * Licensed Materials - Property of IBM
- * 
- * (c) Copyright IBM Corp. 2019.
+ * Copyright contributors to the Galasa project
  */
 package dev.galasa.framework.api.cps.internal;
 

--- a/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/AccessCps.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/AccessCps.java
@@ -8,12 +8,10 @@ package dev.galasa.framework.api.cps.internal;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.text.*;
 
 import javax.servlet.Servlet;
 import javax.servlet.ServletException;
@@ -25,6 +23,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
+import dev.galasa.framework.ResourceNameValidator;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.osgi.service.component.annotations.Activate;
@@ -34,9 +33,7 @@ import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ServiceScope;
 
-import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
-import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
-import dev.galasa.framework.spi.IFramework;
+import dev.galasa.framework.spi.*;
 import dev.galasa.framework.spi.utils.GalasaGsonBuilder;
 
 /**
@@ -50,22 +47,67 @@ import dev.galasa.framework.spi.utils.GalasaGsonBuilder;
 public class AccessCps extends HttpServlet {
     private static final long serialVersionUID = 1L;
 
-    private Log logger = LogFactory.getLog(getClass());
+    // Normally this logger would be private, but we made it protected so that
+    // junit tests can set it to capture logging, without the need to use
+    // byte-code manipulation used by Mockito... which messes with the class
+    // loading in some circumstances.
+    protected Log logger = LogFactory.getLog(getClass());
 
     private final Gson gson = GalasaGsonBuilder.build();
 
+    // We match on things which are not slash (^/) so we can do finder-grained
+    // validation of object names later in the code.
+    // That way we can centralise the validation to share it between various
+    // parts of the ecosystem which do a similar job.
     private static final Pattern pattern1 = Pattern.compile("/namespace/?");
-    private static final Pattern pattern2 = Pattern.compile("/namespace/([A-z0-9]+)/?");
-    private static final Pattern pattern3 = Pattern.compile("/namespace/([A-z0-9]+)/prefix/([A-z0-9._\\-]+)/suffix/([A-z0-9._\\-]+)/?");
-    private static final Pattern pattern4 = Pattern.compile("/namespace/([A-z0-9]+)/property/([A-z0-9._\\-]+)/?");
+    private static final Pattern pattern2 = Pattern.compile("/namespace/([^/]*)/?");
+    private static final Pattern pattern3 = Pattern.compile("/namespace/([^/]*)/prefix/([^/]*)/suffix/([^/]*)/?");
+    private static final Pattern pattern4 = Pattern.compile("/namespace/([^/]*)/property/([^/]*)/?");
 
     @Reference
     public IFramework framework; // NOSONAR
 
+    private static final ResourceNameValidator nameValidator = new ResourceNameValidator();
+
+    /**
+     * Some namespaces are hidden from view, and should not be exposed to a user.
+     *
+     * If the user queries them, they get resource-not-found, as if they aren't there.
+     */
+    private final static Set<String> hiddenNameSpaces = new HashSet<>();
+    static {
+        hiddenNameSpaces.add("dss");
+    }
+
+    /**
+     * Some namespaces are able to be set, but cannot be queried.
+     *
+     * When they are queried, the values are redacted
+     */
+    private final static Set<String> writeOnlyNameSpaces = new HashSet<>();
+    static {
+        writeOnlyNameSpaces.add("secure");
+    }
+
+    /**
+     * The value returned if anyone queries any property values in a write-only namespace.
+     */
+    private static final String REDACTED_PROPERTY_VALUE = "********";
+
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException {
         try {
-            resp.setHeader("Content-Type", "Application/json");
+            resp.setHeader("Content-Type", "application/json");
+
+            Enumeration<String> headerNames = req.getHeaderNames();
+            if (headerNames != null ) {
+                while (headerNames.hasMoreElements()) {
+                    String headerName = headerNames.nextElement();
+                    String headerValue = req.getHeader(headerName);
+                    logger.debug("@@Request has this header: " + headerName + " = " + headerValue);
+                }
+            }
+
             Matcher matcher1 = pattern1.matcher(req.getPathInfo());
             if (matcher1.matches()) {
                 getNamespaces(resp);
@@ -73,63 +115,163 @@ public class AccessCps extends HttpServlet {
             }
             Matcher matcher2 = pattern2.matcher(req.getPathInfo());
             if (matcher2.matches()) {
-                getNamespaceProperties(resp, matcher2.group(1));
+                String namespace = matcher2.group(1);
+                nameValidator.assertNamespaceCharPatternIsValid(namespace);
+                getNamespaceProperties(resp,namespace);
                 return;
             }
             Matcher matcher3 = pattern3.matcher(req.getPathInfo());
             if (matcher3.matches()) {
-                getCPSProperty(resp, matcher3.group(1), matcher3.group(2), matcher3.group(3), req.getQueryString());
+                String namespace = matcher3.group(1);
+                nameValidator.assertNamespaceCharPatternIsValid(namespace);
+                String prefix = matcher3.group(2);
+                nameValidator.assertPropertyCharPatternPrefixIsValid(prefix);
+                String suffix = matcher3.group(3);
+                nameValidator.assertPropertyCharPatternSuffixIsValid(suffix);
+                getCPSProperty(resp, namespace, prefix, suffix, req.getQueryString());
                 return;
             }
-            sendError(resp, "Invalid GET URL - " + req.getPathInfo());
-        } catch (IOException | ConfigurationPropertyStoreException e) {
-            sendError(resp, e);
+
+            sendError(resp, "Invalid GET URL - " + req.getPathInfo()
+                     , 400 // Bad Request
+                     );
+
+        } catch (IOException e) {
+            sendServerInternalError(resp, e);
+        } catch (FrameworkException e) {
+            switch( e.getErrorCode() ) {
+
+                case INVALID_PROPERTY:
+                case INVALID_NAMESPACE:
+                    {
+                        String message = MessageFormat.format("Invalid request: {0}",e.getMessage());
+                        logger.info(message);
+                        sendError(resp, message
+                            , 400 // Invalid URL
+                            );
+                    }
+                    break;
+
+                case UNKNOWN:
+                default:
+                    sendServerInternalError(resp, e);
+            }
         }
     }
 
     @Override
     public void doPut(HttpServletRequest req, HttpServletResponse resp) throws ServletException {
         try {
-            resp.setHeader("Content-Type", "Application/json");
+            resp.setHeader("Content-Type", "application/json");
             Matcher matcher4 = pattern4.matcher(req.getPathInfo());
+
             if (matcher4.matches()) {
-                addCPSProperty(resp, req, matcher4.group(1), matcher4.group(2));
+                String namespace = matcher4.group(1);
+                nameValidator.assertNamespaceCharPatternIsValid(namespace);
+
+                String propertyName = matcher4.group(2);
+                nameValidator.assertPropertyNameCharPatternIsValid(propertyName);
+
+                addCPSProperty(resp, req, namespace, propertyName);
                 return;
             }
-            sendError(resp, "Invalid PUT URL - " + req.getPathInfo());
-        } catch (IOException | ConfigurationPropertyStoreException e) {
-            sendError(resp, e);
+            sendError(resp, "Invalid PUT URL - " + req.getPathInfo()
+                     ,400 // Bad Request
+                     );
+
+        } catch (IOException e) {
+            sendServerInternalError(resp, e);
+        } catch (FrameworkException e) {
+            switch( e.getErrorCode() ) {
+
+                case INVALID_PROPERTY:
+                case INVALID_NAMESPACE:
+                    sendError(resp, MessageFormat.format("Invalid request: {0}",e.getMessage())
+                            , 400 // Bad request.
+                    );
+                    break;
+
+                case UNKNOWN:
+                default:
+                    sendServerInternalError(resp, e);
+            }
         }
     }
 
     private void getNamespaces(HttpServletResponse resp) throws IOException, ConfigurationPropertyStoreException {
+        logger.debug("@@getting the list of namespaces");
         JsonArray namespaceArray = new JsonArray();
         List<String> namespaces = framework.getConfigurationPropertyService("framework").getCPSNamespaces();
         for (String name : namespaces) {
-            namespaceArray.add(name);
+            logger.debug("@@looking at namespace "+name);
+            if ( ! hiddenNameSpaces.contains(name) ) {
+                namespaceArray.add(name);
+            }
         }
         resp.getWriter().write(gson.toJson(namespaceArray));
         resp.setStatus(200);
-        return;
     }
 
     private void getNamespaceProperties(HttpServletResponse resp, String namespace)
             throws IOException, ConfigurationPropertyStoreException {
+
+        if (hiddenNameSpaces.contains(namespace)) {
+
+            logger.info(MessageFormat.format("User tried to get properties from protected namespace \"{0}\""
+                    ,namespace));
+
+            String messageTemplate = "Namespace ''{0}'' is not found.";
+            String message = MessageFormat.format(messageTemplate, namespace);
+            sendError(resp, message , 404 ); // Resource not found
+            return;
+        }
+
         JsonArray propertyArray = new JsonArray();
         Map<String, String> properties = framework.getConfigurationPropertyService(namespace).getAllProperties();
         for (String prop : properties.keySet()) {
             JsonObject cpsProp = new JsonObject();
             cpsProp.addProperty("name", prop);
-            cpsProp.addProperty("value", properties.get(prop));
+            cpsProp.addProperty("value", getProtectedValue(properties.get(prop),namespace));
             propertyArray.add(cpsProp);
         }
         resp.getWriter().write(gson.toJson(propertyArray));
         resp.setStatus(200);
-        return;
     }
+
+    /**
+     * When we are about to return a value to the user, just check to see if we should be
+     * protected this value by redacting it, so the user can't read the actual value.
+     *
+     * @param actualValue The value we return if we don't redact the value for this namespace.
+     * @param namespace The namespace. Some namespaces are write-only.
+     * @return The redacted value if the namespace is write-only, otherwise the actualValue which is passed-in.
+     */
+    private String getProtectedValue(String actualValue , String namespace) {
+        String protectedValue ;
+        if (writeOnlyNameSpaces.contains(namespace)) {
+            // The namespace is protected, write-only, so should not be readable.
+            protectedValue = REDACTED_PROPERTY_VALUE;
+        } else {
+            protectedValue = actualValue ;
+        }
+        return protectedValue ;
+    }
+
 
     private void getCPSProperty(HttpServletResponse resp, String namespace, String prefix, String suffix,
             String infixQuery) throws IOException, ConfigurationPropertyStoreException {
+
+        if (hiddenNameSpaces.contains(namespace)) {
+
+            logger.info(MessageFormat.format("User tried to get properties from protected namespace \"{0}\""
+                    ,namespace));
+
+            String messageTemplate = "Namespace ''{0}'' is not found.";
+            String message = MessageFormat.format(messageTemplate, namespace);
+            sendError(resp, message , 404 ); // Resource not found
+            return;
+        }
+
         String[] infixArray = null;
         if (infixQuery == null) {
             infixArray = new String[0];
@@ -154,17 +296,27 @@ public class AccessCps extends HttpServlet {
         for (String key : pairs.keySet()) {
             if (pairs.get(key).equals(propValue) && key.startsWith(namespace + "." + prefix) && key.endsWith(suffix)) {
                 respJson.addProperty("name", key);
-                respJson.addProperty("value", pairs.get(key));
+                respJson.addProperty("value", getProtectedValue(pairs.get(key),namespace));
                 break;
             }
         }
         resp.getWriter().write(gson.toJson(respJson));
         resp.setStatus(200);
-        return;
     }
 
     private void addCPSProperty(HttpServletResponse resp, HttpServletRequest req, String namespace, String property)
             throws IOException, ConfigurationPropertyStoreException {
+
+        if (hiddenNameSpaces.contains(namespace)) {
+            logger.info(MessageFormat.format("User tried to set properties in a protected namespace \"{0}\""
+                    ,namespace));
+
+            String messageTemplate = "Namespace ''{0}'' is not found.";
+            String message = MessageFormat.format(messageTemplate, namespace);
+            sendError(resp, message , 404 ); // Resource not found
+            return;
+        }
+
         JsonObject reqJson = gson.fromJson(new InputStreamReader(req.getInputStream()),JsonObject.class);
         if(!property.equals(reqJson.get("name").getAsString())) {
             sendError(resp, "Different CPS property name in url and request: " + property + ", " + reqJson.get("name"));
@@ -172,22 +324,28 @@ public class AccessCps extends HttpServlet {
             IConfigurationPropertyStoreService cps = framework.getConfigurationPropertyService(namespace);
             cps.setProperty(reqJson.get("name").getAsString(), reqJson.get("value").getAsString());
             resp.setStatus(200);
-            resp.getWriter().write(gson.toJson(reqJson));
+            PrintWriter writer = resp.getWriter();
+            writer.write(gson.toJson(reqJson));
+            writer.flush();
         }
     }
 
-    public void sendError(HttpServletResponse resp, Exception e) {
-        StringWriter sw = new StringWriter();
-        e.printStackTrace(new PrintWriter(sw));
-        sendError(resp, sw.toString());
+    public void sendServerInternalError(HttpServletResponse resp, Exception e) {
+        logger.error(e.getMessage() ,e);
+        // We should never return the stack trace on a REST call.
+        sendError(resp,MessageFormat.format("Internal server error. {0}",e.getMessage()));
+        resp.setStatus(500); // Internal server error.
     }
 
-    public void sendError(HttpServletResponse resp, String errorMessage) {
-        resp.setStatus(500);
+    public void sendError(HttpServletResponse resp, String errorMessage ) {
+        sendError(resp, errorMessage, 500);
+    }
+
+    public void sendError(HttpServletResponse resp, String errorMessage, int httpStatusCode ) {
+        resp.setStatus(httpStatusCode);
         JsonObject json = new JsonObject();
         json.addProperty("error", errorMessage);
         try {
-
             resp.getWriter().write(gson.toJson(json));
         } catch (IOException e) {
             logger.fatal("Unable to respond", e);

--- a/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/AccessCpsTest.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/AccessCpsTest.java
@@ -1,0 +1,609 @@
+/*
+ * Copyright contributors to the Galasa project
+ */
+package dev.galasa.framework.api.cps.internal;
+import com.google.gson.Gson;
+import com.google.gson.stream.JsonReader;
+import dev.galasa.framework.api.cps.mocks.*;
+import dev.galasa.framework.spi.*;
+import dev.galasa.framework.spi.utils.GalasaGsonBuilder;
+import org.junit.Ignore;
+import org.junit.Test;
+import java.text.*;
+
+import static org.assertj.core.api.Assertions.*;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.*;
+
+public class AccessCpsTest {
+
+    private final Gson gson = GalasaGsonBuilder.build();
+
+
+    /**
+     * A subclass of AccessCps servlet solely so that we can set the logger into the superclass.
+     * ... so we can suppress exceptions appearing in the test console, and also check the contents
+     * of the log against what we expect to be there.
+     */
+    static class LogCapturingAccessCps extends AccessCps {
+        public LogCapturingAccessCps() {
+            super();
+            super.logger = new MockLogger();
+        }
+
+        public MockLogger getLogger() {
+            return (MockLogger) super.logger ;
+        }
+    }
+
+    @Test
+    public void malformedGetUrlReturnsBadRequestError() throws Exception {
+        getUsingBadUrl("/badUrl");
+    }
+
+    @Test
+    public void malformedPutUrlReturnsBadRequestError() throws Exception {
+        // Given...
+
+        // A mock framework which passes back the property store.
+        IFramework mockFramework = new MockFramework();
+
+        // Inject our mock framework into the servlet.
+        LogCapturingAccessCps servlet = new LogCapturingAccessCps();
+        servlet.framework = mockFramework ;
+
+        HttpServletRequest request = new MockHttpRequest("/badUrl");
+
+        MockHttpResponse response = new MockHttpResponse();
+
+        // When...
+        servlet.doPut(request,response);
+
+        // Then...
+        assertThat(response.getHeader("Content-Type")).isEqualTo("application/json");
+
+        String errorMessage = response.getPayloadAsErrorMessage();
+        assertThat(errorMessage).isEqualTo("Invalid PUT URL - /badUrl");
+        assertThat(response.getStatus()).isEqualTo(400); // Bad request
+    }
+
+    @Test
+    public void getNamespacesSecureFailureCausesErrorReportedAndExceptionIsLogged() throws Exception {
+
+        // A mock framework which fails to pass back the property store.
+        IFramework mockFramework = new MockFramework() {
+            @Override
+            public IConfigurationPropertyStoreService getConfigurationPropertyService(String namespace) throws ConfigurationPropertyStoreException {
+                assertThat(namespace).isEqualTo("framework");
+                throw new ConfigurationPropertyStoreException("Failed on purpose in a unit test");
+            }
+        };
+
+        // Inject our mock framework into the servlet.
+        LogCapturingAccessCps servlet = new LogCapturingAccessCps();
+        servlet.framework = mockFramework ;
+
+        HttpServletRequest request = new MockHttpRequest("/namespace");
+
+        MockHttpResponse response = new MockHttpResponse();
+
+        // When...
+        servlet.doGet(request,response);
+
+        // Then...
+        assertThat(response.getHeader("Content-Type")).isEqualTo("application/json");
+        assertThat(response.getStatus()).isEqualTo(500); // Expect server error.
+
+        String errorMessage = response.getPayloadAsErrorMessage();
+        assertThat(errorMessage).isEqualTo("Internal server error. Failed on purpose in a unit test");
+
+        // Check that the exception was logged as an error in the log.
+        LogRecord errorLogRecord = servlet.getLogger().getFirstLogRecordContainingText("Failed on purpose in a unit test");
+        assertThat(errorLogRecord).isNotNull();
+        assertThat(errorLogRecord.getCause()).isNotNull().isInstanceOf(ConfigurationPropertyStoreException.class);
+        assertThat(errorLogRecord.getType()).isEqualTo(LogRecordType.ERROR);
+    }
+
+    @Test
+    public void getNamespacesDoesNotListDSSNoTrailingSlash() throws Exception {
+        getNamespacesDoesNotListDSS("/namespace");
+    }
+
+    @Test
+    public void getNamespacesDoesNotListDSSWithTrailingSlash() throws Exception {
+        getNamespacesDoesNotListDSS("/namespace/");
+    }
+
+    public void getNamespacesDoesNotListDSS(String path) throws Exception {
+
+        // Given...
+
+        // We pretend some namespaces exist.
+        List<String> nameSpacesWhichExist = new LinkedList<>();
+        nameSpacesWhichExist.add("dss");
+        nameSpacesWhichExist.add("myNameSpace");
+
+        // A property store which can serve-up namespaces that exist.
+        IConfigurationPropertyStoreService mockPropsStoreService = new MockConfigurationPropertyStoreService() {
+            @Override
+            public List<String> getCPSNamespaces() {
+                return nameSpacesWhichExist;
+            }
+        };
+
+        // A mock framework which passes back the property store.
+        IFramework mockFramework = new MockFramework() {
+            @Override
+            public IConfigurationPropertyStoreService getConfigurationPropertyService(String namespace) throws ConfigurationPropertyStoreException {
+                assertThat(namespace).isEqualTo("framework");
+                return mockPropsStoreService;
+            }
+        };
+
+        // Inject our mock framework into the servlet.
+        LogCapturingAccessCps servlet = new LogCapturingAccessCps();
+        servlet.framework = mockFramework ;
+
+        HttpServletRequest request = new MockHttpRequest(path);
+
+        MockHttpResponse response = new MockHttpResponse();
+
+        // When...
+        servlet.doGet(request,response);
+
+        // Then...
+        assertThat(response.getHeader("Content-Type")).isEqualTo("application/json");
+        assertThat(response.getStatus()).isEqualTo(200);
+
+        // The result should be an array of namespaces
+        JsonReader jReader = response.getPayloadAsJsonReader();
+        String[] nameSpacesArray = gson.fromJson(jReader , String[].class);
+
+        assertThat(nameSpacesArray)
+                .isNotNull().isNotEmpty()
+                .containsExactly("myNameSpace")
+                .doesNotContain("dss");
+    }
+
+    @Test
+    public void getAllPropertiesInANamespaceNamespaceUsesInvalidCharacters() throws Exception {
+
+        // Given...
+
+        // A mock framework which passes back the property store.
+        IFramework mockFramework = new MockFramework() {
+            @Override
+            public IConfigurationPropertyStoreService getConfigurationPropertyService(String namespace) throws ConfigurationPropertyStoreException {
+                FrameworkException originalCause = new FrameworkException(FrameworkErrorCode.INVALID_NAMESPACE,
+                        "bad namespace characters - for unit testing");
+                throw new ConfigurationPropertyStoreException(originalCause);
+            }
+        };
+
+        // Inject our mock framework into the servlet.
+        LogCapturingAccessCps servlet = new LogCapturingAccessCps();
+        servlet.framework = mockFramework ;
+
+        HttpServletRequest request = new MockHttpRequest("/namespace/namespaceUsing$invalid£characters");
+
+        MockHttpResponse response = new MockHttpResponse();
+
+        // When...
+        servlet.doGet(request,response);
+
+        // Then...
+        assertThat(response.getHeader("Content-Type")).isEqualTo("application/json");
+        assertThat(response.getStatus()).isEqualTo(400); // Resource not found.
+
+        // Check that the error was good.
+        String errorMessage = response.getPayloadAsErrorMessage();
+        assertThat(errorMessage)
+                .doesNotContain("Internal server error.")
+                .contains("Invalid namespace");
+    }
+
+    @Test
+    public void getUsingPartOfNamespaceLiteralShouldFailBadUrl() throws Exception {
+        getUsingBadUrl("/namespa");
+    }
+
+    @Test
+    public void getUsingBadlySpeltPrefixShouldFailBadUrl() throws Exception {
+        getUsingBadUrl("/namespace/myValidNamespace/prefi");
+    }
+
+    @Test
+    public void getUsingBadUrlWithoutLeadingSlashShouldFailBadUrl() throws Exception {
+        getUsingBadUrl("namespa");
+    }
+
+    public void getUsingBadUrl(String path) throws Exception {
+        // Given...
+
+        // Inject our mock framework into the servlet.
+        AccessCps servlet = new LogCapturingAccessCps();
+
+        HttpServletRequest request = new MockHttpRequest(path);
+
+        MockHttpResponse response = new MockHttpResponse();
+
+        // When...
+        servlet.doGet(request,response);
+
+        // Then...
+        assertThat(response.getHeader("Content-Type")).isEqualTo("application/json");
+        assertThat(response.getStatus()).isEqualTo(400); // Bad URL.
+
+        // Check that the error was good.
+        String errorMessage = response.getPayloadAsErrorMessage();
+        assertThat(errorMessage)
+                .doesNotContain("Internal server error.")
+                .contains("Invalid GET URL - ")
+                .contains(path);
+    }
+
+    @Test
+    public void getNamespacesPropertiesDoesNotListDSSOnes() throws Exception {
+
+        // Given...
+
+        // A mock framework which passes back the property store.
+        IFramework mockFramework = new MockFramework() {
+            @Override
+            public IConfigurationPropertyStoreService getConfigurationPropertyService(String namespace) throws ConfigurationPropertyStoreException {
+                fail("did not expect the servlet to query the property store for the dss component");
+                return null ;
+            }
+        };
+
+        // Inject our mock framework into the servlet.
+        LogCapturingAccessCps servlet = new LogCapturingAccessCps();
+        servlet.framework = mockFramework ;
+
+        HttpServletRequest request = new MockHttpRequest("/namespace/dss");
+
+        MockHttpResponse response = new MockHttpResponse();
+
+        // When...
+        servlet.doGet(request,response);
+
+        // Then...
+        assertThat(response.getHeader("Content-Type")).isEqualTo("application/json");
+        assertThat(response.getStatus()).isEqualTo(404); // Resource not found
+
+        // Check that the error was good.
+        String errorMessage = response.getPayloadAsErrorMessage();
+        assertThat(errorMessage)
+                .doesNotContain("Internal server error.")
+                .contains("dss")
+                .contains("is not found")
+                ;
+
+        // Check that the exception was logged as an error in the log.
+        LogRecord infoLogRecord = servlet.getLogger().getFirstLogRecordContainingText("User tried to get properties from protected namespace");
+        assertThat(infoLogRecord).isNotNull();
+        assertThat(infoLogRecord.getType()).isEqualTo(LogRecordType.INFO);
+    }
+
+
+    @Test
+    public void getNamespacesPropertiesListAllowableOnes() throws Exception {
+
+        // Given...
+
+        // A property store which can serve-up namespaces that exist.
+        IConfigurationPropertyStoreService mockPropsStoreService = new MockConfigurationPropertyStoreService() {
+            @Override
+            public Map<String, String> getAllProperties() {
+                return new HashMap<>() {{ put("a","aValue"); put("c","cValue"); }};
+            }
+        };
+
+        // A mock framework which passes back the property store.
+        IFramework mockFramework = new MockFramework() {
+            @Override
+            public IConfigurationPropertyStoreService getConfigurationPropertyService(String namespace) throws ConfigurationPropertyStoreException {
+                assertThat(namespace).isEqualTo("notdss");
+                return mockPropsStoreService ;
+            }
+        };
+
+        // Inject our mock framework into the servlet.
+        LogCapturingAccessCps servlet = new LogCapturingAccessCps();
+        servlet.framework = mockFramework ;
+
+        HttpServletRequest request = new MockHttpRequest("/namespace/notdss");
+
+        MockHttpResponse response = new MockHttpResponse();
+
+        // When...
+        servlet.doGet(request,response);
+
+        // Then...
+        assertThat(response.getHeader("Content-Type")).isEqualTo("application/json");
+        assertThat(response.getStatus()).isEqualTo(200); // OK
+
+        // The result should be an array of namespaces
+        JsonReader jReader = response.getPayloadAsJsonReader();
+
+
+        NameValuePair[] propertiesArray = gson.fromJson(jReader , NameValuePair[].class);
+
+        // Transfer values into a java map.
+        Map<String,String> properties = new HashMap<>();
+        for ( NameValuePair pair : propertiesArray ) {
+            properties.put(pair.name, pair.value);
+        }
+
+        assertThat(properties)
+                .containsKey("a")
+                .containsKey("c");
+        assertThat(properties.get("a")).isEqualTo("aValue");
+        assertThat(properties.get("c")).isEqualTo("cValue");
+    }
+
+    public static class NameValuePair {
+        String name ;
+        String value ;
+    }
+
+    @Test
+    public void setNamespacePropertyOK() throws Exception {
+
+        // Given...
+
+        // A property store which can serve-up namespaces that exist.
+        IConfigurationPropertyStoreService mockPropsStoreService = new MockConfigurationPropertyStoreService() {
+            @Override
+            public void setProperty(String name, String value) throws ConfigurationPropertyStoreException {
+                assertThat(name).isEqualTo("myprop");
+                assertThat(value).isEqualTo("myvalue");
+            }
+        };
+
+        // A mock framework which passes back the property store.
+        IFramework mockFramework = new MockFramework() {
+            @Override
+            public IConfigurationPropertyStoreService getConfigurationPropertyService(String namespace) throws ConfigurationPropertyStoreException {
+                assertThat(namespace).isEqualTo("notdssbutvalid");
+                return mockPropsStoreService ;
+            }
+        };
+
+        // Inject our mock framework into the servlet.
+        LogCapturingAccessCps servlet = new LogCapturingAccessCps();
+        servlet.framework = mockFramework ;
+
+        MockHttpRequest request = new MockHttpRequest("/namespace/notdssbutvalid/property/myprop");
+        request.setBody(
+                "{\n"+
+                "  \"name\":\"myprop\",\n"+
+                "  \"value\":\"myvalue\"\n"+
+                "}\n");
+        MockHttpResponse response = new MockHttpResponse();
+
+        // When...
+        servlet.doPut(request,response);
+
+        // Then...
+        assertThat(response.getHeader("Content-Type")).isEqualTo("application/json");
+        assertThat(response.getStatus()).isEqualTo(200); // Unauthorised.
+
+        // The result should be an array of namespaces
+        response.getWriter().close();
+        JsonReader jReader = response.getPayloadAsJsonReader();
+
+
+        NameValuePair property = gson.fromJson(jReader , NameValuePair.class);
+
+        assertThat(property.name).isEqualTo("myprop");
+        assertThat(property.value).isEqualTo("myvalue");
+    }
+
+
+
+    @Test
+    public void setPropertyOnDSSFailsUnauthorised() throws Exception {
+
+        // Given...
+
+        // A property store which can serve-up namespaces that exist.
+        IConfigurationPropertyStoreService mockPropsStoreService = new MockConfigurationPropertyStoreService() {
+            @Override
+            public void setProperty(String name, String value) throws ConfigurationPropertyStoreException {
+                assertThat(name).isEqualTo("myprop");
+                assertThat(value).isEqualTo("myvalue");
+            }
+        };
+
+        // A mock framework which passes back the property store.
+        IFramework mockFramework = new MockFramework() {
+            @Override
+            public IConfigurationPropertyStoreService getConfigurationPropertyService(String namespace) throws ConfigurationPropertyStoreException {
+                assertThat(namespace).isEqualTo("dss");
+                return mockPropsStoreService ;
+            }
+        };
+
+        // Inject our mock framework into the servlet.
+        LogCapturingAccessCps servlet = new LogCapturingAccessCps();
+        servlet.framework = mockFramework ;
+
+        MockHttpRequest request = new MockHttpRequest("/namespace/dss/property/myprop");
+        request.setBody(
+                "{\n"+
+                        "  \"name\":\"myprop\",\n"+
+                        "  \"value\":\"myvalue\"\n"+
+                        "}\n");
+        MockHttpResponse response = new MockHttpResponse();
+
+        // When...
+        servlet.doPut(request,response);
+
+        // Then...
+        assertThat(response.getHeader("Content-Type")).isEqualTo("application/json");
+        assertThat(response.getStatus()).isEqualTo(404); // resource not found.
+
+        // Check that the error was good.
+        String errorMessage = response.getPayloadAsErrorMessage();
+        assertThat(errorMessage)
+                .doesNotContain("Internal server error.")
+                .contains("dss")
+                .contains("is not found.")
+        ;
+    }
+
+
+
+    @Test
+    public void getPropertiesFromSecureGetRedacted() throws Exception {
+
+        // Given...
+
+        // A property store which can serve-up some test properties 'a' and 'c'
+        IConfigurationPropertyStoreService mockPropsStoreService = new MockConfigurationPropertyStoreService() {
+            @Override
+            public Map<String, String> getAllProperties() {
+                return new HashMap<>() {{ put("a","aValue"); put("c","cValue"); }};
+            }
+        };
+
+        // A mock framework which passes back the property store.
+        IFramework mockFramework = new MockFramework() {
+            @Override
+            public IConfigurationPropertyStoreService getConfigurationPropertyService(String namespace) throws ConfigurationPropertyStoreException {
+                assertThat(namespace).isEqualTo("secure"); // Secure is write-enabled, but never read.
+                return mockPropsStoreService ;
+            }
+        };
+
+        // Inject our mock framework into the servlet.
+        LogCapturingAccessCps servlet = new LogCapturingAccessCps();
+        servlet.framework = mockFramework ;
+
+        HttpServletRequest request = new MockHttpRequest("/namespace/secure");
+
+        MockHttpResponse response = new MockHttpResponse();
+
+        // When...
+        servlet.doGet(request,response);
+
+        // Then...
+        assertThat(response.getHeader("Content-Type")).isEqualTo("application/json");
+        assertThat(response.getStatus()).isEqualTo(200); // OK
+
+        // The result should be an array of namespaces
+        JsonReader jReader = response.getPayloadAsJsonReader();
+        NameValuePair[] propertiesArray = gson.fromJson(jReader , NameValuePair[].class);
+
+        // Transfer values into a java map.
+        Map<String,String> properties = new HashMap<>();
+        for ( NameValuePair pair : propertiesArray ) {
+            properties.put(pair.name, pair.value);
+        }
+
+        assertThat(properties)
+                .containsKey("a")
+                .containsKey("c");
+        assertThat(properties.get("a")).isEqualTo("********"); // The redacted value.
+        assertThat(properties.get("c")).isEqualTo("********"); // The redacted value.
+    }
+
+/*
+    @Test
+    public void testCanGetPropertiesUsingPrefixAndSuffixOk(String prefix, String suffix) {
+
+        // Given...
+
+        // A property store which can serve-up some test properties 'a' and 'c'
+        IConfigurationPropertyStoreService mockPropsStoreService = new MockConfigurationPropertyStoreService() {
+            @Override
+            public Map<String, String> getAllProperties() {
+                return new HashMap<>() {{ put("a","aValue"); put("c","cValue"); }};
+            }
+        };
+
+        // A mock framework which passes back the property store.
+        IFramework mockFramework = new MockFramework() {
+            @Override
+            public IConfigurationPropertyStoreService getConfigurationPropertyService(String namespace) throws ConfigurationPropertyStoreException {
+                return mockPropsStoreService ;
+            }
+        };
+
+        // Inject our mock framework into the servlet.
+        LogCapturingAccessCps servlet = new LogCapturingAccessCps();
+        servlet.framework = mockFramework ;
+
+        String path = MessageFormat.format( "/namespace/oknamespace/prefix/{0}/suffix/{1}",prefix,suffix);
+        HttpServletRequest request = new MockHttpRequest(path);
+
+        MockHttpResponse response = new MockHttpResponse();
+
+        // When...
+        servlet.doGet(request,response);
+
+        // Then...
+        assertThat(response.getHeader("Content-Type")).isEqualTo("application/json");
+        assertThat(response.getStatus()).isEqualTo(200); // OK
+
+        // The result should be an array of namespaces
+        JsonReader jReader = response.getPayloadAsJsonReader();
+        NameValuePair[] propertiesArray = gson.fromJson(jReader , NameValuePair[].class);
+
+        // Transfer values into a java map.
+        Map<String,String> properties = new HashMap<>();
+        for ( NameValuePair pair : propertiesArray ) {
+            properties.put(pair.name, pair.value);
+        }
+
+        assertThat(properties)
+                .containsKey("a")
+                .containsKey("c");
+        assertThat(properties.get("a")).isEqualTo("********"); // The redacted value.
+        assertThat(properties.get("c")).isEqualTo("********"); // The redacted value.
+    }
+
+    @Test
+    public void testCanGetPropertiesUsingPrefixAndSuffixAndInfixOk() {
+        fail("Not implemented yet");
+    }
+
+    @Ignore
+    @Test
+    public void testCanGetPropertiesUsingPrefixButNoSuffixFailsBadUrl() {
+        fail("Not implemented yet");
+    }
+
+    @Ignore
+    @Test
+    public void testCanGetPropertiesUsingPrefixButNoSuffixPlusExtraPartToUrlFailsBadUrl() {
+        fail("Not implemented yet");
+    }
+
+    @Ignore
+    @Test
+    public void testGetPropertiesUsingPrefixAndSuffixButPrefixSpeltBadlyFailsInvalidUrl() {
+        fail("Not implemented yet");
+    }
+
+    @Ignore
+    @Test
+    public void testGetPropertiesUsingPrefixAndSuffixButSuffixSpeltBadlyFailsInvalidUrl() {
+        fail("Not implemented yet");
+    }
+
+    @Ignore
+    @Test
+    public void testGetPropertiesUsingPrefixAndSuffixButSuffixPropertyIsInvalidFailsBadUrl() {
+        fail("Not implemented yet");
+    }
+
+    @Ignore
+    @Test
+    public void testGetPropertiesUsingPrefixAndSuffixButPrefixPropertyIsInvalidFailsBadUrl() {
+        fail("Not implemented yet");
+    }
+*/
+}

--- a/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/AccessCpsTest.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/AccessCpsTest.java
@@ -510,17 +510,26 @@ public class AccessCpsTest {
         assertThat(properties.get("c")).isEqualTo("********"); // The redacted value.
     }
 
-/*
     @Test
-    public void testCanGetPropertiesUsingPrefixAndSuffixOk(String prefix, String suffix) {
+    public void testCanGetPropertiesUsingPrefixAndSuffixOk() throws Exception {
 
         // Given...
+        String prefix = "abc";
+        String suffix = "xyz";
 
         // A property store which can serve-up some test properties 'a' and 'c'
         IConfigurationPropertyStoreService mockPropsStoreService = new MockConfigurationPropertyStoreService() {
             @Override
             public Map<String, String> getAllProperties() {
-                return new HashMap<>() {{ put("a","aValue"); put("c","cValue"); }};
+                return new HashMap<>() {{
+                    put("oknamespace.abc.a.xyz","abcValue");
+                    put("oknamespace.abc.b.xyz","cValue");
+                }};
+            }
+            @Override
+            public String getProperty(String prefix, String suffix, String... infixes
+                ) throws ConfigurationPropertyStoreException {
+                return "abcValue";
             }
         };
 
@@ -537,7 +546,8 @@ public class AccessCpsTest {
         servlet.framework = mockFramework ;
 
         String path = MessageFormat.format( "/namespace/oknamespace/prefix/{0}/suffix/{1}",prefix,suffix);
-        HttpServletRequest request = new MockHttpRequest(path);
+        String query = "infix=a";
+        HttpServletRequest request = new MockHttpRequest(path,query);
 
         MockHttpResponse response = new MockHttpResponse();
 
@@ -548,62 +558,12 @@ public class AccessCpsTest {
         assertThat(response.getHeader("Content-Type")).isEqualTo("application/json");
         assertThat(response.getStatus()).isEqualTo(200); // OK
 
-        // The result should be an array of namespaces
+        // The result should be a single object with a name, value pair
         JsonReader jReader = response.getPayloadAsJsonReader();
-        NameValuePair[] propertiesArray = gson.fromJson(jReader , NameValuePair[].class);
-
-        // Transfer values into a java map.
-        Map<String,String> properties = new HashMap<>();
-        for ( NameValuePair pair : propertiesArray ) {
-            properties.put(pair.name, pair.value);
-        }
-
-        assertThat(properties)
-                .containsKey("a")
-                .containsKey("c");
-        assertThat(properties.get("a")).isEqualTo("********"); // The redacted value.
-        assertThat(properties.get("c")).isEqualTo("********"); // The redacted value.
+        NameValuePair property = gson.fromJson(jReader , NameValuePair.class);
+        assertThat(property).isNotNull();
+        assertThat(property.name).isNotNull().isEqualTo("oknamespace.abc.a.xyz");
+        assertThat(property.value).isNotNull().isEqualTo("abcValue");
     }
 
-    @Test
-    public void testCanGetPropertiesUsingPrefixAndSuffixAndInfixOk() {
-        fail("Not implemented yet");
-    }
-
-    @Ignore
-    @Test
-    public void testCanGetPropertiesUsingPrefixButNoSuffixFailsBadUrl() {
-        fail("Not implemented yet");
-    }
-
-    @Ignore
-    @Test
-    public void testCanGetPropertiesUsingPrefixButNoSuffixPlusExtraPartToUrlFailsBadUrl() {
-        fail("Not implemented yet");
-    }
-
-    @Ignore
-    @Test
-    public void testGetPropertiesUsingPrefixAndSuffixButPrefixSpeltBadlyFailsInvalidUrl() {
-        fail("Not implemented yet");
-    }
-
-    @Ignore
-    @Test
-    public void testGetPropertiesUsingPrefixAndSuffixButSuffixSpeltBadlyFailsInvalidUrl() {
-        fail("Not implemented yet");
-    }
-
-    @Ignore
-    @Test
-    public void testGetPropertiesUsingPrefixAndSuffixButSuffixPropertyIsInvalidFailsBadUrl() {
-        fail("Not implemented yet");
-    }
-
-    @Ignore
-    @Test
-    public void testGetPropertiesUsingPrefixAndSuffixButPrefixPropertyIsInvalidFailsBadUrl() {
-        fail("Not implemented yet");
-    }
-*/
 }

--- a/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/mocks/LogRecord.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/mocks/LogRecord.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright contributors to the Galasa project
+ */
+package dev.galasa.framework.api.cps.mocks;
+
+public class LogRecord {
+    private String text;
+    private LogRecordType type;
+    private Throwable cause;
+
+    public LogRecord(LogRecordType type, String text) {
+        this(type, text, null);
+    }
+
+    public LogRecord(LogRecordType type, String text, Throwable cause) {
+        this.text = text;
+        this.type = type;
+        this.cause = cause;
+    }
+
+    public String getText() {
+        return this.text;
+    }
+
+    public LogRecordType getType() {
+        return this.type;
+    }
+
+    public Throwable getCause() {
+        return this.cause;
+    }
+}

--- a/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/mocks/LogRecordType.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/mocks/LogRecordType.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright contributors to the Galasa project
+ */
+package dev.galasa.framework.api.cps.mocks;
+
+public enum LogRecordType {
+    DEBUG, INFO, WARNING, ERROR, FATAL, TRACE
+}

--- a/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/mocks/MockConfigurationPropertyStoreService.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/mocks/MockConfigurationPropertyStoreService.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright contributors to the Galasa project
+ */
+package dev.galasa.framework.api.cps.mocks;
+
+import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
+import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
+
+import java.util.List;
+import java.util.Map;
+
+public class MockConfigurationPropertyStoreService implements IConfigurationPropertyStoreService {
+
+    @Override
+    public String getProperty(String prefix, String suffix, String... infixes) throws ConfigurationPropertyStoreException {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public Map<String, String> getPrefixedProperties(String prefix) throws ConfigurationPropertyStoreException {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public void setProperty(String name, String value) throws ConfigurationPropertyStoreException {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public void deleteProperty(String name) throws ConfigurationPropertyStoreException {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public Map<String, String> getAllProperties() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public String[] reportPropertyVariants(String prefix, String suffix, String... infixes) {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public String reportPropertyVariantsString(String prefix, String suffix, String... infixes) {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public List<String> getCPSNamespaces() {
+        throw new MockMethodNotImplementedException();
+    }
+}

--- a/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/mocks/MockFramework.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/mocks/MockFramework.java
@@ -1,93 +1,93 @@
-    /*
-     * Copyright contributors to the Galasa project
-     */
-    package dev.galasa.framework.api.cps.mocks;
+/*
+ * Copyright contributors to the Galasa project
+ */
+package dev.galasa.framework.api.cps.mocks;
 
-    import dev.galasa.framework.spi.*;
-    import dev.galasa.framework.spi.creds.CredentialsException;
-    import dev.galasa.framework.spi.creds.ICredentialsService;
-    import java.net.URL;
-    import java.util.*;
+import dev.galasa.framework.spi.*;
+import dev.galasa.framework.spi.creds.CredentialsException;
+import dev.galasa.framework.spi.creds.ICredentialsService;
+import java.net.URL;
+import java.util.*;
 
-    public class MockFramework implements IFramework {
+public class MockFramework implements IFramework {
 
-        @Override
-        public void setFrameworkProperties(Properties overrideProperties) {
-            throw new MockMethodNotImplementedException();
-        }
-
-        @Override
-        public boolean isInitialised() {
-            throw new MockMethodNotImplementedException();
-        }
-
-        @Override
-        public IConfigurationPropertyStoreService getConfigurationPropertyService(String namespace) throws ConfigurationPropertyStoreException {
-            throw new MockMethodNotImplementedException();
-        }
-
-        @Override
-        public IDynamicStatusStoreService getDynamicStatusStoreService(String namespace) throws DynamicStatusStoreException {
-            throw new MockMethodNotImplementedException();
-        }
-
-        @Override
-        public ICertificateStoreService getCertificateStoreService() {
-            throw new MockMethodNotImplementedException();
-        }
-
-        @Override
-        public IResultArchiveStore getResultArchiveStore() {
-            throw new MockMethodNotImplementedException();
-        }
-
-        @Override
-        public IResourcePoolingService getResourcePoolingService() {
-            throw new MockMethodNotImplementedException();
-        }
-
-        @Override
-        public IConfidentialTextService getConfidentialTextService() {
-            throw new MockMethodNotImplementedException();
-        }
-
-        @Override
-        public ICredentialsService getCredentialsService() throws CredentialsException {
-            throw new MockMethodNotImplementedException();
-        }
-
-        @Override
-        public String getTestRunName() {
-            throw new MockMethodNotImplementedException();
-        }
-
-        @Override
-        public Random getRandom() {
-            throw new MockMethodNotImplementedException();
-        }
-
-        @Override
-        public IFrameworkRuns getFrameworkRuns() throws FrameworkException {
-            throw new MockMethodNotImplementedException();
-        }
-
-        @Override
-        public IRun getTestRun() {
-            throw new MockMethodNotImplementedException();
-        }
-
-        @Override
-        public Properties getRecordProperties() {
-            throw new MockMethodNotImplementedException();
-        }
-
-        @Override
-        public URL getApiUrl(Api api) throws FrameworkException {
-            throw new MockMethodNotImplementedException();
-        }
-
-        @Override
-        public SharedEnvironmentRunType getSharedEnvironmentRunType() throws ConfigurationPropertyStoreException {
-            throw new MockMethodNotImplementedException();
-        }
+    @Override
+    public void setFrameworkProperties(Properties overrideProperties) {
+        throw new MockMethodNotImplementedException();
     }
+
+    @Override
+    public boolean isInitialised() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public IConfigurationPropertyStoreService getConfigurationPropertyService(String namespace) throws ConfigurationPropertyStoreException {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public IDynamicStatusStoreService getDynamicStatusStoreService(String namespace) throws DynamicStatusStoreException {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public ICertificateStoreService getCertificateStoreService() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public IResultArchiveStore getResultArchiveStore() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public IResourcePoolingService getResourcePoolingService() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public IConfidentialTextService getConfidentialTextService() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public ICredentialsService getCredentialsService() throws CredentialsException {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public String getTestRunName() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public Random getRandom() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public IFrameworkRuns getFrameworkRuns() throws FrameworkException {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public IRun getTestRun() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public Properties getRecordProperties() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public URL getApiUrl(Api api) throws FrameworkException {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public SharedEnvironmentRunType getSharedEnvironmentRunType() throws ConfigurationPropertyStoreException {
+        throw new MockMethodNotImplementedException();
+    }
+}

--- a/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/mocks/MockFramework.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/mocks/MockFramework.java
@@ -1,0 +1,93 @@
+    /*
+     * Copyright contributors to the Galasa project
+     */
+    package dev.galasa.framework.api.cps.mocks;
+
+    import dev.galasa.framework.spi.*;
+    import dev.galasa.framework.spi.creds.CredentialsException;
+    import dev.galasa.framework.spi.creds.ICredentialsService;
+    import java.net.URL;
+    import java.util.*;
+
+    public class MockFramework implements IFramework {
+
+        @Override
+        public void setFrameworkProperties(Properties overrideProperties) {
+            throw new MockMethodNotImplementedException();
+        }
+
+        @Override
+        public boolean isInitialised() {
+            throw new MockMethodNotImplementedException();
+        }
+
+        @Override
+        public IConfigurationPropertyStoreService getConfigurationPropertyService(String namespace) throws ConfigurationPropertyStoreException {
+            throw new MockMethodNotImplementedException();
+        }
+
+        @Override
+        public IDynamicStatusStoreService getDynamicStatusStoreService(String namespace) throws DynamicStatusStoreException {
+            throw new MockMethodNotImplementedException();
+        }
+
+        @Override
+        public ICertificateStoreService getCertificateStoreService() {
+            throw new MockMethodNotImplementedException();
+        }
+
+        @Override
+        public IResultArchiveStore getResultArchiveStore() {
+            throw new MockMethodNotImplementedException();
+        }
+
+        @Override
+        public IResourcePoolingService getResourcePoolingService() {
+            throw new MockMethodNotImplementedException();
+        }
+
+        @Override
+        public IConfidentialTextService getConfidentialTextService() {
+            throw new MockMethodNotImplementedException();
+        }
+
+        @Override
+        public ICredentialsService getCredentialsService() throws CredentialsException {
+            throw new MockMethodNotImplementedException();
+        }
+
+        @Override
+        public String getTestRunName() {
+            throw new MockMethodNotImplementedException();
+        }
+
+        @Override
+        public Random getRandom() {
+            throw new MockMethodNotImplementedException();
+        }
+
+        @Override
+        public IFrameworkRuns getFrameworkRuns() throws FrameworkException {
+            throw new MockMethodNotImplementedException();
+        }
+
+        @Override
+        public IRun getTestRun() {
+            throw new MockMethodNotImplementedException();
+        }
+
+        @Override
+        public Properties getRecordProperties() {
+            throw new MockMethodNotImplementedException();
+        }
+
+        @Override
+        public URL getApiUrl(Api api) throws FrameworkException {
+            throw new MockMethodNotImplementedException();
+        }
+
+        @Override
+        public SharedEnvironmentRunType getSharedEnvironmentRunType() throws ConfigurationPropertyStoreException {
+            throw new MockMethodNotImplementedException();
+        }
+    }

--- a/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/mocks/MockHttpRequest.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/mocks/MockHttpRequest.java
@@ -17,10 +17,17 @@ import java.util.Map;
 public class MockHttpRequest implements HttpServletRequest {
 
     private String path ;
+    private String query ;
 
     public MockHttpRequest(String path) {
-        this.path = path ;
+        this(path,null);
     }
+
+    public MockHttpRequest(String path , String query ) {
+        this.path = path;
+        this.query = query;
+    }
+
     @Override
     public String getAuthType() {
         throw new MockMethodNotImplementedException();
@@ -78,7 +85,7 @@ public class MockHttpRequest implements HttpServletRequest {
 
     @Override
     public String getQueryString() {
-        throw new MockMethodNotImplementedException();
+        return this.query;
     }
 
     @Override

--- a/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/mocks/MockHttpRequest.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/mocks/MockHttpRequest.java
@@ -1,0 +1,409 @@
+/*
+ * Copyright contributors to the Galasa project
+ */
+package dev.galasa.framework.api.cps.mocks;
+
+import javax.servlet.*;
+import javax.servlet.http.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.security.Principal;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.Locale;
+import java.util.Map;
+
+public class MockHttpRequest implements HttpServletRequest {
+
+    private String path ;
+
+    public MockHttpRequest(String path) {
+        this.path = path ;
+    }
+    @Override
+    public String getAuthType() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public Cookie[] getCookies() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public long getDateHeader(String name) {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public String getHeader(String name) {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public Enumeration<String> getHeaders(String name) {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public Enumeration<String> getHeaderNames() {
+        return null;
+    }
+
+    @Override
+    public int getIntHeader(String name) {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public String getMethod() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public String getPathInfo() {
+        return path ;
+    }
+
+    @Override
+    public String getPathTranslated() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public String getContextPath() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public String getQueryString() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public String getRemoteUser() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public boolean isUserInRole(String role) {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public Principal getUserPrincipal() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public String getRequestedSessionId() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public String getRequestURI() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public StringBuffer getRequestURL() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public String getServletPath() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public HttpSession getSession(boolean create) {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public HttpSession getSession() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public String changeSessionId() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public boolean isRequestedSessionIdValid() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public boolean isRequestedSessionIdFromCookie() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public boolean isRequestedSessionIdFromURL() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public boolean isRequestedSessionIdFromUrl() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public boolean authenticate(HttpServletResponse response) throws IOException, ServletException {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public void login(String username, String password) throws ServletException {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public void logout() throws ServletException {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public Collection<Part> getParts() throws IOException, ServletException {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public Part getPart(String name) throws IOException, ServletException {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public <T extends HttpUpgradeHandler> T upgrade(Class<T> handlerClass) throws IOException, ServletException {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public Object getAttribute(String name) {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public Enumeration<String> getAttributeNames() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public String getCharacterEncoding() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public void setCharacterEncoding(String env) throws UnsupportedEncodingException {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public int getContentLength() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public long getContentLengthLong() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public String getContentType() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    public void setBody( String jsonPayload ) {
+        this.jsonBody = jsonPayload ;
+    }
+
+    String jsonBody ;
+
+    public static class MockServletInputStream extends ServletInputStream {
+
+        byte[] bodyBytes ;
+        int bodyBytesIndex = 0 ;
+
+        public MockServletInputStream(String body) {
+            this.bodyBytes = body.getBytes();
+        }
+
+        @Override
+        public boolean isFinished() {
+            return false;
+        }
+
+        @Override
+        public boolean isReady() {
+            return false;
+        }
+
+        @Override
+        public void setReadListener(ReadListener readListener) {
+        }
+
+        @Override
+        public int read() throws IOException {
+            int result;
+            if( bodyBytesIndex < bodyBytes.length) {
+                result = this.bodyBytes[bodyBytesIndex++];
+            } else {
+                result = -1;
+            }
+            return result;
+        }
+    }
+
+    @Override
+    public ServletInputStream getInputStream() throws IOException {
+        return new MockServletInputStream(this.jsonBody);
+    }
+
+    @Override
+    public String getParameter(String name) {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public Enumeration<String> getParameterNames() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public String[] getParameterValues(String name) {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public Map<String, String[]> getParameterMap() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public String getProtocol() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public String getScheme() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public String getServerName() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public int getServerPort() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public BufferedReader getReader() throws IOException {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public String getRemoteAddr() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public String getRemoteHost() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public void setAttribute(String name, Object o) {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public void removeAttribute(String name) {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public Locale getLocale() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public Enumeration<Locale> getLocales() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public boolean isSecure() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public RequestDispatcher getRequestDispatcher(String path) {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public String getRealPath(String path) {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public int getRemotePort() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public String getLocalName() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public String getLocalAddr() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public int getLocalPort() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public ServletContext getServletContext() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public AsyncContext startAsync() throws IllegalStateException {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse) throws IllegalStateException {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public boolean isAsyncStarted() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public boolean isAsyncSupported() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public AsyncContext getAsyncContext() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public DispatcherType getDispatcherType() {
+        throw new MockMethodNotImplementedException();
+    }
+}

--- a/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/mocks/MockHttpResponse.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/mocks/MockHttpResponse.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright contributors to the Galasa project
+ */
+package dev.galasa.framework.api.cps.mocks;
+
+import com.google.gson.Gson;
+import com.google.gson.stream.JsonReader;
+import dev.galasa.framework.spi.utils.GalasaGsonBuilder;
+
+import static org.assertj.core.api.Assertions.*;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringReader;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+public class MockHttpResponse implements HttpServletResponse {
+
+
+
+    private ByteArrayOutputStream payload = new ByteArrayOutputStream();
+    private PrintWriter writer = new PrintWriter(payload);
+
+    private final Gson gson = GalasaGsonBuilder.build();
+
+    private int statusCode ;
+
+    public int getStatus() {
+        return statusCode ;
+    }
+
+    @Override
+    public PrintWriter getWriter() throws IOException {
+        return writer;
+    }
+
+    @Override
+    public void setStatus(int sc) {
+        this.statusCode = sc;
+    }
+
+    public JsonReader getPayloadAsJsonReader() {
+        writer.flush(); // Make sure all half-written data gets to the underlying byte array.
+
+        String payloadGotBack = payload.toString();
+        JsonReader jReader = gson.newJsonReader(new StringReader(payloadGotBack));
+        return jReader;
+    }
+
+
+    static class ErrorMessage {
+        private String error;
+
+        public ErrorMessage(String error) {
+            this.error = error;
+        }
+    }
+
+    public String getPayloadAsErrorMessage() {
+        writer.flush(); // Make sure all half-written data gets to the underlying byte array.
+
+        String payloadGotBack = payload.toString();
+        JsonReader jReader = gson.newJsonReader(new StringReader(payloadGotBack));
+
+        ErrorMessage errorMessage = gson.fromJson(jReader , ErrorMessage.class);
+
+        assertThat(errorMessage).isNotNull();
+        return errorMessage.error;
+    }
+
+    public String getPayloadAsString() {
+        writer.flush(); // Make sure all half-written data gets to the underlying byte array.
+        String payloadGotBack = payload.toString();
+        return payloadGotBack;
+    }
+
+    @Override
+    public void addCookie(Cookie cookie) {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public boolean containsHeader(String name) {
+        return false;
+    }
+
+    @Override
+    public String encodeURL(String url) {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public String encodeRedirectURL(String url) {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public String encodeUrl(String url) {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public String encodeRedirectUrl(String url) {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public void sendError(int sc, String msg) throws IOException {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public void sendError(int sc) throws IOException {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public void sendRedirect(String location) throws IOException {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public void setDateHeader(String name, long date) {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public void addDateHeader(String name, long date) {
+        throw new MockMethodNotImplementedException();
+    }
+
+    public Map<String, String> headers = new HashMap<String, String>();
+
+
+    @Override
+    public void setHeader(String name, String value) {
+        headers.put(name, value);
+    }
+
+    @Override
+    public void addHeader(String name, String value) {
+        headers.put(name, value);
+    }
+
+    @Override
+    public String getHeader(String name) {
+        return headers.get(name);
+    }
+
+    @Override
+    public void setIntHeader(String name, int value) {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public void addIntHeader(String name, int value) {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public void setStatus(int sc, String sm) {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public Collection<String> getHeaders(String name) {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public Collection<String> getHeaderNames() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public String getCharacterEncoding() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public String getContentType() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public ServletOutputStream getOutputStream() throws IOException {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public void setCharacterEncoding(String charset) {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public void setContentLength(int len) {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public void setContentLengthLong(long len) {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public void setContentType(String type) {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public void setBufferSize(int size) {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public int getBufferSize() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public void flushBuffer() throws IOException {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public void resetBuffer() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public boolean isCommitted() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public void reset() {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public void setLocale(Locale loc) {
+        throw new MockMethodNotImplementedException();
+    }
+
+    @Override
+    public Locale getLocale() {
+        throw new MockMethodNotImplementedException();
+    }
+}

--- a/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/mocks/MockLogger.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/mocks/MockLogger.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright contributors to the Galasa project
+ */
+package dev.galasa.framework.api.cps.mocks;
+
+import org.apache.commons.logging.Log;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MockLogger implements Log {
+
+    private boolean isDebugEnabled = true;
+    private boolean isErrorEnabled = true;
+    private boolean isFatalEnabled = true;
+    private boolean isInfoEnabled  = true;
+    private boolean isTraceEnabled  = true;
+    private boolean isWarnEnabled  = true;
+
+    private List<LogRecord> logContent = new ArrayList<LogRecord>();
+
+    public LogRecord getFirstLogRecordContainingText(String textToLookFor) {
+        for (LogRecord record : logContent ) {
+            if (record.getText().contains(textToLookFor)) {
+                return record ;
+            }
+        }
+        return null ;
+    }
+
+    public void setDebugEnabled(boolean debugEnabled) {
+        isDebugEnabled = debugEnabled;
+    }
+
+    public void setErrorEnabled(boolean errorEnabled) {
+        isErrorEnabled = errorEnabled;
+    }
+
+    public void setFatalEnabled(boolean fatalEnabled) {
+        isFatalEnabled = fatalEnabled;
+    }
+
+    public void setInfoEnabled(boolean infoEnabled) {
+        isInfoEnabled = infoEnabled;
+    }
+
+    public void setTraceEnabled(boolean traceEnabled) {
+        isTraceEnabled = traceEnabled;
+    }
+
+    public void setWarnEnabled(boolean warnEnabled) {
+        isWarnEnabled = warnEnabled;
+    }
+
+    public List<LogRecord> getLogRecords() {
+        return this.logContent;
+    }
+
+    @Override
+    public void debug(Object message) {
+        logContent.add( new LogRecord( LogRecordType.DEBUG , message.toString() ));
+    }
+
+    @Override
+    public void debug(Object message, Throwable t) {
+        logContent.add( new LogRecord( LogRecordType.DEBUG , message.toString() , t ));
+    }
+
+    @Override
+    public void error(Object message) {
+        logContent.add( new LogRecord( LogRecordType.ERROR , message.toString() ));
+    }
+
+    @Override
+    public void error(Object message, Throwable t) {
+        logContent.add( new LogRecord( LogRecordType.ERROR , message.toString() , t ));
+    }
+
+    @Override
+    public void fatal(Object message) {
+        logContent.add( new LogRecord( LogRecordType.FATAL , message.toString() ));
+    }
+
+    @Override
+    public void fatal(Object message, Throwable t) {
+        logContent.add( new LogRecord( LogRecordType.FATAL , message.toString() , t ));
+    }
+
+    @Override
+    public void info(Object message) {
+        logContent.add( new LogRecord( LogRecordType.INFO , message.toString() ));
+    }
+
+    @Override
+    public void info(Object message, Throwable t) {
+        logContent.add( new LogRecord( LogRecordType.INFO , message.toString() ,t));
+    }
+
+
+
+    @Override
+    public boolean isDebugEnabled() {
+        return this.isDebugEnabled;
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        return this.isErrorEnabled;
+    }
+
+    @Override
+    public boolean isFatalEnabled() {
+        return this.isFatalEnabled;
+    }
+
+    @Override
+    public boolean isInfoEnabled() {
+        return this.isInfoEnabled;
+    }
+
+    @Override
+    public boolean isTraceEnabled() {
+        return this.isTraceEnabled;
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return this.isWarnEnabled;
+    }
+
+    @Override
+    public void trace(Object message) {
+        logContent.add( new LogRecord( LogRecordType.TRACE , message.toString() ));
+    }
+
+    @Override
+    public void trace(Object message, Throwable t) {
+        logContent.add( new LogRecord( LogRecordType.TRACE , message.toString() ,t));
+    }
+
+    @Override
+    public void warn(Object message) {
+        logContent.add( new LogRecord( LogRecordType.WARNING , message.toString() ));
+    }
+
+    @Override
+    public void warn(Object message, Throwable t) {
+        logContent.add( new LogRecord( LogRecordType.WARNING , message.toString() ,t));
+    }
+}

--- a/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/mocks/MockMethodNotImplementedException.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/mocks/MockMethodNotImplementedException.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright contributors to the Galasa project
+ */
+package dev.galasa.framework.api.cps.mocks;
+
+public class MockMethodNotImplementedException extends RuntimeException {
+    public MockMethodNotImplementedException() {
+    }
+}

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/Framework.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/Framework.java
@@ -11,6 +11,7 @@ import java.util.regex.Pattern;
 
 import javax.validation.constraints.NotNull;
 
+import dev.galasa.framework.spi.*;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.osgi.framework.BundleContext;
@@ -24,28 +25,6 @@ import dev.galasa.framework.internal.cps.FrameworkConfigurationPropertyService;
 import dev.galasa.framework.internal.creds.FrameworkCredentialsService;
 import dev.galasa.framework.internal.dss.FrameworkDynamicStatusStoreService;
 import dev.galasa.framework.internal.ras.FrameworkMultipleResultArchiveStore;
-import dev.galasa.framework.spi.AbstractManager;
-import dev.galasa.framework.spi.Api;
-import dev.galasa.framework.spi.CertificateStoreException;
-import dev.galasa.framework.spi.ConfidentialTextException;
-import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
-import dev.galasa.framework.spi.DynamicStatusStoreException;
-import dev.galasa.framework.spi.FrameworkException;
-import dev.galasa.framework.spi.FrameworkResourcePoolingService;
-import dev.galasa.framework.spi.ICertificateStoreService;
-import dev.galasa.framework.spi.IConfidentialTextService;
-import dev.galasa.framework.spi.IConfigurationPropertyStore;
-import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
-import dev.galasa.framework.spi.IDynamicStatusStore;
-import dev.galasa.framework.spi.IDynamicStatusStoreService;
-import dev.galasa.framework.spi.IFramework;
-import dev.galasa.framework.spi.IFrameworkRuns;
-import dev.galasa.framework.spi.IResourcePoolingService;
-import dev.galasa.framework.spi.IResultArchiveStore;
-import dev.galasa.framework.spi.IResultArchiveStoreService;
-import dev.galasa.framework.spi.IRun;
-import dev.galasa.framework.spi.ResultArchiveStoreException;
-import dev.galasa.framework.spi.SharedEnvironmentRunType;
 import dev.galasa.framework.spi.creds.CredentialsException;
 import dev.galasa.framework.spi.creds.ICredentialsService;
 import dev.galasa.framework.spi.creds.ICredentialsStore;
@@ -56,6 +35,8 @@ public class Framework implements IFramework {
     private final static Log                   logger           = LogFactory.getLog(Framework.class);
 
     private static final Pattern               namespacePattern = Pattern.compile("[a-z0-9]+");
+    private static final String                ERROR_MESSAGE_TEMPLATE_NAMESPACE_INVALID_CHARACTERS =
+        "Invalid namespace '%s'. Valid namespaces are 1 or more characters of 'a'-'z' and '0'-'9'.";
 
     private Properties                         overrideProperties;
     private final Properties                   recordProperties = new Properties();
@@ -173,12 +154,14 @@ public class Framework implements IFramework {
      */
     private void validateNamespace(String namespace) throws FrameworkException {
         if (namespace == null) {
-            throw new FrameworkException("Namespace has not been provided");
+            throw new FrameworkException(FrameworkErrorCode.INVALID_NAMESPACE, "Namespace has not been provided");
         }
 
         final Matcher matcher = namespacePattern.matcher(namespace);
         if (!matcher.matches()) {
-            throw new FrameworkException("Invalid namespace");
+            throw new FrameworkException(FrameworkErrorCode.INVALID_NAMESPACE,
+                                         String.format(ERROR_MESSAGE_TEMPLATE_NAMESPACE_INVALID_CHARACTERS,namespace));
+
         }
     }
 

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/ResourceNameValidator.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/ResourceNameValidator.java
@@ -1,0 +1,151 @@
+package dev.galasa.framework;
+
+import dev.galasa.framework.spi.FrameworkErrorCode;
+import dev.galasa.framework.spi.FrameworkException;
+
+/**
+ * A class which can validate whether a resources use valid characters or not.
+ */
+public class ResourceNameValidator {
+
+    public static final String letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    public static final String digits = "0123456789";
+
+
+
+    public static final String namespaceValidFirstCharacters = letters ;
+    public static final String namespaceValidFollowingCharacters = namespaceValidFirstCharacters + digits ;
+
+    public static final String propertyValidFirstCharacters = letters ;
+    public static final String propertySeparators = ".-_";
+    public static final String propertyValidFollowingCharacters = propertyValidFirstCharacters
+            + digits + propertySeparators ;
+
+    public void assertNamespaceCharPatternIsValid(String possibleNamespaceName) throws FrameworkException {
+
+
+        // Guard against null or empty namespace name.
+        if (possibleNamespaceName == null || possibleNamespaceName.isEmpty() ) {
+            throw new FrameworkException(FrameworkErrorCode.INVALID_NAMESPACE,
+                    "Invalid namespace. Namespace is empty.");
+        }
+
+        for(int charIndex = 0 ; charIndex < possibleNamespaceName.length() ; charIndex +=1 ) {
+            int c = possibleNamespaceName.charAt(charIndex);
+            if (charIndex==0) {
+                // Check the first character.
+                if (namespaceValidFirstCharacters.indexOf(c) < 0) {
+                    String messageTemplate = "Invalid namespace name. '%s' must not start with the '%s' character." +
+                            " Allowable first characters are 'a'-'z' or 'A'-'Z'.";
+                    String message = String.format(messageTemplate, possibleNamespaceName, Character.toString(c));
+                    throw new FrameworkException(FrameworkErrorCode.INVALID_NAMESPACE, message);
+                }
+            } else {
+                // Check a following character.
+                if(namespaceValidFollowingCharacters.indexOf(c) < 0 ) {
+                    String messageTemplate = "Invalid namespace name. '%s' must not contain the '%s' character." +
+                            " Allowable characters after the first character are 'a'-'z', 'A'-'Z', '0'-'9'.";
+                    String message = String.format(messageTemplate, possibleNamespaceName, Character.toString(c));
+                    throw new FrameworkException(FrameworkErrorCode.INVALID_NAMESPACE, message);
+                }
+            }
+        }
+    }
+
+
+    /**
+     * Validate the prefix of a cps property.
+     * @param prefix The prefix to validate.
+     * @throws FrameworkException If the property prefix is invalid.
+     */
+    public void assertPropertyCharPatternPrefixIsValid(String prefix) throws FrameworkException {
+
+        // Guard against null or empty prefix
+        if (prefix == null || prefix.isEmpty() ) {
+            throw new FrameworkException(FrameworkErrorCode.INVALID_PROPERTY,
+                    "Invalid property name prefix. Prefix is missing or empty.");
+        }
+
+        for(int charIndex = 0 ; charIndex < prefix.length() ; charIndex +=1 ) {
+            int c = prefix.charAt(charIndex);
+            if (charIndex==0) {
+                // Check the first character.
+                if (propertyValidFirstCharacters.indexOf(c) < 0) {
+                    String messageTemplate = "Invalid property name prefix. '%s' must not start with the '%s' character." +
+                            " Allowable first characters are 'a'-'z' or 'A'-'Z'.";
+                    String message = String.format(messageTemplate, prefix, Character.toString(c));
+                    throw new FrameworkException(FrameworkErrorCode.INVALID_PROPERTY, message);
+                }
+            } else {
+                // Check a following character.
+                if(propertyValidFollowingCharacters.indexOf(c) < 0 ) {
+                    String messageTemplate = "Invalid property name prefix. '%s' must not contain the '%s' character." +
+                            " Allowable characters after the first character are 'a'-'z', 'A'-'Z', '0'-'9',"+
+                            " '-' (dash), '.' (dot) and '_' (underscore).";
+                    String message = String.format(messageTemplate, prefix, Character.toString(c));
+                    throw new FrameworkException(FrameworkErrorCode.INVALID_PROPERTY, message);
+                }
+            }
+        }
+    }
+
+    public void assertPropertyCharPatternSuffixIsValid(String suffix) throws FrameworkException {
+        // Guard against null or empty prefix
+        if (suffix == null || suffix.isEmpty() ) {
+            throw new FrameworkException(FrameworkErrorCode.INVALID_PROPERTY,
+                    "Invalid property name. Property name is missing or empty.");
+        }
+
+        for(int charIndex = 0 ; charIndex < suffix.length() ; charIndex +=1 ) {
+            int c = suffix.charAt(charIndex);
+            if (charIndex==0) {
+                // Check the first character.
+                if (propertyValidFirstCharacters.indexOf(c) < 0) {
+                    String messageTemplate = "Invalid property name suffix. '%s' must not start with the '%s' character." +
+                            " Allowable first characters are 'a'-'z' or 'A'-'Z'.";
+                    String message = String.format(messageTemplate, suffix, Character.toString(c));
+                    throw new FrameworkException(FrameworkErrorCode.INVALID_PROPERTY, message);
+                }
+            } else {
+                // Check a following character.
+                if(propertyValidFollowingCharacters.indexOf(c) < 0 ) {
+                    String messageTemplate = "Invalid property name suffix. '%s' must not contain the '%s' character." +
+                            " Allowable characters after the first character are 'a'-'z', 'A'-'Z', '0'-'9',"+
+                            " '-' (dash), '.' (dot) and '_' (underscore).";
+                    String message = String.format(messageTemplate, suffix, Character.toString(c));
+                    throw new FrameworkException(FrameworkErrorCode.INVALID_PROPERTY, message);
+                }
+            }
+        }
+    }
+
+    public void assertPropertyNameCharPatternIsValid(String propertyName) throws FrameworkException {
+        // Guard against null or empty prefix
+        if (propertyName == null || propertyName.isEmpty() ) {
+            throw new FrameworkException(FrameworkErrorCode.INVALID_PROPERTY,
+                    "Invalid property name. Property name is missing or empty.");
+        }
+
+        for(int charIndex = 0 ; charIndex < propertyName.length() ; charIndex +=1 ) {
+            int c = propertyName.charAt(charIndex);
+            if (charIndex==0) {
+                // Check the first character.
+                if (propertyValidFirstCharacters.indexOf(c) < 0) {
+                    String messageTemplate = "Invalid property name. '%s' must not start with the '%s' character." +
+                            " Allowable first characters are 'a'-'z' or 'A'-'Z'.";
+                    String message = String.format(messageTemplate, propertyName, Character.toString(c));
+                    throw new FrameworkException(FrameworkErrorCode.INVALID_PROPERTY, message);
+                }
+            } else {
+                // Check a following character.
+                if(propertyValidFollowingCharacters.indexOf(c) < 0 ) {
+                    String messageTemplate = "Invalid property name. '%s' must not contain the '%s' character." +
+                            " Allowable characters after the first character are 'a'-'z', 'A'-'Z', '0'-'9',"+
+                            " '-' (dash), '.' (dot) and '_' (underscore)";
+                    String message = String.format(messageTemplate, propertyName, Character.toString(c));
+                    throw new FrameworkException(FrameworkErrorCode.INVALID_PROPERTY, message);
+                }
+            }
+        }
+    }
+}

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/ResourceNameValidator.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/ResourceNameValidator.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright contributors to the Galasa project
+ */
 package dev.galasa.framework;
 
 import dev.galasa.framework.spi.FrameworkErrorCode;

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/FrameworkErrorCode.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/FrameworkErrorCode.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright contributors to the Galasa project
+ */
+package dev.galasa.framework.spi;
+
+/**
+ * Exceptions types which support it have an associated FrameworkErrorCode.
+ *
+ * This allows a FrameworkException to have some finer-grained error information
+ * which is programmatically accessible. ie: Not just the failure message text.
+ *
+ * We explicitly set an ID for each enumeration value, so that we have complete
+ * control over it, and it will never move if the enumeration values are re-ordered,
+ * or any are inserted in any order. Using the ordinal leads to issues with support
+ * if the compiler allocates different values over different releases.
+ */
+public enum FrameworkErrorCode {
+    /**
+     * We don't know the nature of the failure beyond the exception type and the message text.
+     */
+    UNKNOWN(0),
+
+    /**
+     * Validation of the namespace name failed for some reason.
+     */
+    INVALID_NAMESPACE(1),
+
+    /**
+     * Validation of the CPS property name failed for some reason.
+     */
+    INVALID_PROPERTY(2);
+
+    
+    private int id ;
+    private FrameworkErrorCode(int errorId) {
+        this.id = errorId;
+    }
+
+    /**
+     * Each error code has an ID value.
+     * @return The id for this error code.
+     */
+    public int getErrorId() {
+        return this.id ;
+    }
+
+    /**
+     * Given the errorId , work out which FrameworkErrorCode corresponds to it.
+     * @param errorIdToFind The error id to search for
+     * @return The FrameworkErrorCode found, else {@link FrameworkErrorCode#UNKNOWN}
+     */
+    public static FrameworkErrorCode findByErrorId(int errorIdToFind) {
+        for ( FrameworkErrorCode value : FrameworkErrorCode.values() ) {
+            if (value.getErrorId() == errorIdToFind ) {
+                // Found it.
+                return value ;
+            }
+        }
+        return UNKNOWN;
+    }
+}

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/FrameworkException.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/FrameworkException.java
@@ -1,30 +1,99 @@
 /*
- * Licensed Materials - Property of IBM
- * 
- * (c) Copyright IBM Corp. 2019.
+ * Copyright contributors to the Galasa project
  */
 package dev.galasa.framework.spi;
 
+/**
+ * An exception which also holds a FrameworkErrorCode to provide more fine-grained detail about the problem
+ * being raised/thrown, which is programmatically accessible. ie: Not just the error text, or instance of the
+ * exception instance.
+ *
+ * Error codes can be explicitly set when the exception is created, or will default to
+ * {@link FrameworkErrorCode#UNKNOWN}, or to the same error code from the cause (when that cause is also a
+ * {@link FrameworkException}.
+ *
+ * This allows one type of FrameworkException to wrap another, and the original cause error code will
+ * be propagated to the top-most FrameworkException in the chain.
+ *
+ */
 public class FrameworkException extends Exception {
     private static final long serialVersionUID = 1L;
 
+    private FrameworkErrorCode errorCode ;
+
     public FrameworkException() {
+        this(FrameworkErrorCode.UNKNOWN);
+    }
+
+
+    public FrameworkException(FrameworkErrorCode code) {
+        super();
+        this.errorCode = code ;
     }
 
     public FrameworkException(String message) {
+        this(FrameworkErrorCode.UNKNOWN , message);
+    }
+
+    public FrameworkException(FrameworkErrorCode code, String message) {
         super(message);
+        this.errorCode = code ;
     }
 
+    /**
+     * If the cause is a framework exception, then the error code from the cause is propagated
+     * into this exception instance.
+     */
     public FrameworkException(Throwable cause) {
+        this( (cause instanceof FrameworkException) ?
+                ((FrameworkException)cause).getErrorCode() :
+                FrameworkErrorCode.UNKNOWN
+            , cause );
+    }
+
+    public FrameworkException(FrameworkErrorCode code, Throwable cause) {
         super(cause);
+        this.errorCode = code ;
     }
 
+    /**
+     * If the cause is a framework exception, then the error code from the cause is propagated
+     * into this exception instance.
+     */
     public FrameworkException(String message, Throwable cause) {
+        this((cause instanceof FrameworkException) ?
+                        ((FrameworkException)cause).getErrorCode() :
+                        FrameworkErrorCode.UNKNOWN,
+                message, cause);
+    }
+
+
+    public FrameworkException(FrameworkErrorCode code, String message, Throwable cause) {
         super(message, cause);
+        this.errorCode = code;
     }
 
+    /**
+     * If the cause is a framework exception, then the error code from the cause is propagated
+     * into this exception instance.
+     */
     public FrameworkException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
-        super(message, cause, enableSuppression, writableStackTrace);
+        this((cause instanceof FrameworkException) ?
+                ((FrameworkException)cause).getErrorCode() :
+                FrameworkErrorCode.UNKNOWN,
+            message, cause, enableSuppression, writableStackTrace);
     }
 
+
+    public FrameworkException(FrameworkErrorCode code, String message, Throwable cause, boolean enableSuppression,
+                              boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+        this.errorCode = code;
+    }
+
+
+
+    public FrameworkErrorCode getErrorCode() {
+        return this.errorCode;
+    }
 }

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestResourceNameValidator.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestResourceNameValidator.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright contributors to the Galasa project
+ */
+package dev.galasa.framework;
+
+import dev.galasa.framework.spi.*;
+
+import org.junit.Test;
+import static org.assertj.core.api.Assertions.*;
+
+public class TestResourceNameValidator {
+
+    private ResourceNameValidator validator = new ResourceNameValidator();
+
+    private void assertValidNamespace(String namespaceToCheck) {
+        Throwable thrown = catchThrowable(() -> {
+            validator.assertNamespaceCharPatternIsValid(namespaceToCheck);
+        });
+
+        assertThat(thrown).isNull();
+    }
+
+    @Test
+    public void testNamespaceCanStartWithLetter() {
+        assertValidNamespace("a");
+        assertValidNamespace("A");
+        assertValidNamespace("z");
+        assertValidNamespace("Z");
+    }
+
+    @Test
+    public void testNamespaceCannotStartWithANumber() {
+        assertInvalidFirstCharacter("5");
+    }
+
+    @Test
+    public void testNamespaceCannotStartWithAWerdCharacter() {
+        assertInvalidFirstCharacter("_");
+        assertInvalidFirstCharacter("-");
+        assertInvalidFirstCharacter(".");
+        assertInvalidFirstCharacter("%");
+        assertInvalidFirstCharacter("@");
+    }
+
+    @Test
+    public void testNamespaceCanContinueWithLetter() {
+        assertValidNamespace("aa");
+        assertValidNamespace("AA");
+        assertValidNamespace("zz");
+        assertValidNamespace("ZZ");
+    }
+
+    @Test
+    public void testNamespaceCanContinueWithADigit() {
+        assertValidNamespace("a0");
+        assertValidNamespace("a9");
+    }
+
+    @Test
+    public void testNamespaceCannotContinueWithAnyWeirdCharacter() {
+        assertInvalidFollowingCharacter("a%");
+        assertInvalidFollowingCharacter("a@");
+        assertInvalidFollowingCharacter("a-a");
+        assertInvalidFollowingCharacter("a_a");
+    }
+
+    private void assertInvalidFirstCharacter(String namespaceToCheck ) {
+
+        Throwable thrown = catchThrowable(() -> {
+            validator.assertNamespaceCharPatternIsValid(namespaceToCheck);
+        });
+
+        assertThat(thrown)
+                .isNotNull()
+                .isInstanceOf(FrameworkException.class)
+                .hasMessageContaining("Invalid namespace name.", namespaceToCheck,
+                                    "must not start with",
+                                    "Allowable first characters are")
+                ;
+    }
+
+    private void assertInvalidFollowingCharacter(String namespaceToCheck ) {
+
+        Throwable thrown = catchThrowable(() -> {
+            validator.assertNamespaceCharPatternIsValid(namespaceToCheck);
+        });
+
+        assertThat(thrown)
+                .isNotNull()
+                .isInstanceOf(FrameworkException.class)
+                .hasMessageContaining("Invalid namespace name.", namespaceToCheck,
+                        "must not contain",
+                        "Valid characters after the first character in the name are")
+        ;
+    }
+
+
+    @Test
+    public void assertPropertyNameIsValid() {
+        assertValidPropertyNameIsOk("a");
+        assertValidPropertyNameIsOk("a0");
+        assertValidPropertyNameIsOk("a.b.c");
+        assertValidPropertyNameIsOk("a-b-c");
+        assertValidPropertyNameIsOk("a_b_c");
+        assertValidPropertyNameIsOk("A");
+        assertValidPropertyNameIsOk("A0");
+        assertValidPropertyNameIsOk("A.B.C");
+        assertValidPropertyNameIsOk("A_B_C");
+        assertValidPropertyNameIsOk("A-B-C");
+    }
+
+    @Test
+    public void assertPropertyNameWithInvalidFirstCharCausesError() {
+        assertInvalidPropertyNameFirstCharacter("0");
+    }
+
+    private void assertInvalidPropertyNameFirstCharacter(String propertyNameToCheck) {
+        Throwable thrown = catchThrowable(() -> {
+            validator.assertPropertyNameCharPatternIsValid(propertyNameToCheck);
+        });
+        assertThat(thrown)
+                .isNotNull()
+                .isInstanceOf(FrameworkException.class)
+                .hasMessageContaining("Invalid property name.", propertyNameToCheck,
+                        "must not contain",
+                        "Valid first characters in the name are")
+        ;
+    }
+
+    private void assertValidPropertyNameIsOk(String propertyNameToCheck) {
+        Throwable thrown = catchThrowable(() -> {
+            validator.assertPropertyNameCharPatternIsValid(propertyNameToCheck);
+        });
+        assertThat(thrown).isNull();
+    }
+}

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/spi/TestFrameworkErrorCode.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/spi/TestFrameworkErrorCode.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright contributors to the Galasa project
+ */
+package dev.galasa.framework.spi;
+
+import org.junit.Test;
+import static org.assertj.core.api.Assertions.*;
+
+public class TestFrameworkErrorCode {
+
+    @Test
+    public void testCanGetEnumerationFromIntValue() {
+        assertThat(FrameworkErrorCode.findByErrorId(1)).isEqualTo(FrameworkErrorCode.INVALID_NAMESPACE);
+    }
+
+    @Test
+    public void testUnknownIntValueTranslatesToUnknown() {
+        assertThat(FrameworkErrorCode.findByErrorId(999)).isEqualTo(FrameworkErrorCode.UNKNOWN);
+    }
+}

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/spi/TestFrameworkException.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/spi/TestFrameworkException.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright contributors to the Galasa project
+ */
+package dev.galasa.framework.spi;
+
+import org.junit.Test;
+import static org.assertj.core.api.Assertions.*;
+
+public class TestFrameworkException {
+
+    @Test
+    public void testRaisingWithNoCodeResultsInUnknownCodeStored() {
+        FrameworkException ex = new FrameworkException();
+        assertThat(ex.getErrorCode()).isEqualTo(FrameworkErrorCode.UNKNOWN);
+    }
+
+    @Test
+    public void testRaisingWithErrorCodeCausesCodeToBeStored() {
+        FrameworkException ex = new FrameworkException(FrameworkErrorCode.INVALID_NAMESPACE);
+        assertThat(ex.getErrorCode()).isEqualTo(FrameworkErrorCode.INVALID_NAMESPACE);
+    }
+
+    @Test
+    public void testRaisingWithRandomExceptionCausesUnknownCodeToBeStored() {
+        Exception cause = new Exception("random exception for unit tests");
+        FrameworkException ex = new FrameworkException(cause);
+        assertThat(ex.getErrorCode()).isEqualTo(FrameworkErrorCode.UNKNOWN);
+    }
+
+    @Test
+    public void testRaisingWithFrameworkExceptionCausesCodeToBeTransferred() {
+        Exception cause = new FrameworkException(FrameworkErrorCode.INVALID_NAMESPACE,
+                "random exception for unit tests");
+        FrameworkException ex = new FrameworkException(cause);
+        assertThat(ex.getErrorCode()).isEqualTo(FrameworkErrorCode.INVALID_NAMESPACE);
+    }
+
+    @Test
+    public void testRaisingWithMessageAndRandomExceptionCausesUnknownToBeTransferred() {
+        Exception cause = new Exception("random exception for unit tests");
+        FrameworkException ex = new FrameworkException("exception for unit testing",cause);
+        assertThat(ex.getErrorCode()).isEqualTo(FrameworkErrorCode.UNKNOWN);
+    }
+
+    @Test
+    public void testRaisingWithMessageAndFrameworkExceptionCausesCodeToBeTransferred() {
+        Exception cause = new FrameworkException(FrameworkErrorCode.INVALID_NAMESPACE,
+                "random exception for unit tests");
+        FrameworkException ex = new FrameworkException("exception for unit testing",cause);
+        assertThat(ex.getErrorCode()).isEqualTo(FrameworkErrorCode.INVALID_NAMESPACE);
+    }
+
+    @Test
+    public void testRaisingWithLoadsOfParametersAndRandomExceptionCausesUnknownToBeStored() {
+        Exception cause = new Exception("random exception for unit tests");
+        FrameworkException ex = new FrameworkException("exception for unit testing",cause,true,true);
+        assertThat(ex.getErrorCode()).isEqualTo(FrameworkErrorCode.UNKNOWN);
+    }
+
+    @Test
+    public void testRaisingWithLoadsOfParametersAndFrameworkExceptionCausesCodeToBeTransferred() {
+        Exception cause = new FrameworkException(FrameworkErrorCode.INVALID_NAMESPACE,
+                "random exception for unit tests");
+        FrameworkException ex = new FrameworkException("exception for unit testing",cause,true,true);
+        assertThat(ex.getErrorCode()).isEqualTo(FrameworkErrorCode.INVALID_NAMESPACE);
+    }
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -49,7 +49,9 @@ paths:
       parameters:
         - name: namespace
           in: path
-          description: Property Namespace
+          description: |
+            Property Namespace. First character of the namespace must be in the 'a'-'z' or 'A'-'Z' ranges,
+            and following characters can be 'a'-'z' or 'A'-'Z' or '0'-'9'
           required: true
           schema:
             type: string
@@ -83,25 +85,33 @@ paths:
       parameters:
       - name: namespace
         in: path
-        description: Property Namespace
+        description: |
+            Property Namespace. The first character of the namespace must be in the 'a'-'z' or 'A'-'Z' ranges,
+            and following characters can be 'a'-'z' or 'A'-'Z' or '0'-'9'
         required: true
         schema:
           type: string
       - name: prefix
         in: path
-        description: Property Prefix
+        description: |
+          Property Prefix. The first character of the namespace must be in the 'a'-'z' or 'A'-'Z' ranges,
+            and following characters can be 'a'-'z', 'A'-'Z', '0'-'9', '.' (period), '-' (dash) or '_' (underscore)
         required: true
         schema:
           type: string
       - name: suffix
         in: path
-        description: Property Suffix
+        description: |
+          Property suffix. The first character of the namespace must be in the 'a'-'z' or 'A'-'Z' ranges,
+          and following characters can be 'a'-'z', 'A'-'Z', '0'-'9', '.' (period), '-' (dash) or '_' (underscore)
         required: true
         schema:
           type: string
       - name: infixes
         in: query
-        description: Property Infixes
+        description: |
+          Property infixes. The first character of the namespace must be in the 'a'-'z' or 'A'-'Z' ranges,
+          and following characters can be 'a'-'z', 'A'-'Z', '0'-'9', '.' (period), '-' (dash) or '_' (underscore)
         schema:
           type: array
           items:
@@ -128,13 +138,18 @@ paths:
       parameters:
       - name: namespace
         in: path
-        description: Property Namespace
+        description: |
+            Property Namespace. First character of the namespace must be in the 'a'-'z' or 'A'-'Z' ranges,
+            and following characters can be 'a'-'z' or 'A'-'Z' or '0'-'9'
         required: true
         schema:
           type: string
       - name: property
         in: path
-        description: Property Name
+        description: |
+          Property Name. 
+          The first character of the namespace must be in the 'a'-'z' or 'A'-'Z' ranges,
+          and following characters can be 'a'-'z', 'A'-'Z', '0'-'9', '.' (period), '-' (dash) or '_' (underscore)
         required: true
         schema:
           type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -37,7 +37,7 @@ paths:
                 items:
                   type: string
         '500':
-          description: Error
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -64,8 +64,14 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/CpsProperty'
+        '400':
+          description: The namespace/prefix/suffix uses invalid characters or is badly formed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsonError'
         '500':
-          description: Error
+          description: Internal Server Error
           content:
             application/json:
               schema:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,5 @@
 #
-# Licensed Materials - Property of IBM
-# 
-# (c) Copyright IBM Corp. 2021.
+# Copyright contributors to the Galasa project
 #
 openapi: 3.0.3
 info:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -133,6 +133,13 @@ paths:
     put:
       operationId: putCpsNamespaceProperty
       summary: Put new CPS Property
+      description: |
+        Searches multiple places in the property store for the first property matching the namespace, 
+        prefix and suffix, and as many of the leading infix strings as possible.
+        This results in a value which is the most specific, given a sparsely populated hierarchical 
+        structure of property names.
+        Over-rides of values (if present) are returned in preference to the normal stored value 
+        of a property.
       tags: 
       - Configuration Property Store API
       parameters:
@@ -568,6 +575,7 @@ components:
       properties:
         name:
           type: string
+          description: The fully-qualified property name, including the 'namespace'.
         value:
           type: string
     JsonError:

--- a/run-locally.sh
+++ b/run-locally.sh
@@ -1,0 +1,147 @@
+#! /usr/bin/env bash 
+
+#-----------------------------------------------------------------------------------------                   
+#
+# Objectives: Run the framework code from local .m2 repository
+#
+# Environment variable over-rides:
+# Invoke with --help and read the output.
+# 
+#-----------------------------------------------------------------------------------------                   
+
+# Where is this script executing from ?
+BASEDIR=$(dirname "$0");pushd $BASEDIR 2>&1 >> /dev/null ;BASEDIR=$(pwd);popd 2>&1 >> /dev/null
+# echo "Running from directory ${BASEDIR}"
+export ORIGINAL_DIR=$(pwd)
+# cd "${BASEDIR}"
+
+cd "${BASEDIR}/.."
+WORKSPACE_DIR=$(pwd)
+
+
+#-----------------------------------------------------------------------------------------                   
+# Set Colors
+#-----------------------------------------------------------------------------------------                   
+bold=$(tput bold)
+underline=$(tput sgr 0 1)
+reset=$(tput sgr0)
+red=$(tput setaf 1)
+green=$(tput setaf 76)
+white=$(tput setaf 7)
+tan=$(tput setaf 202)
+blue=$(tput setaf 25)
+
+#-----------------------------------------------------------------------------------------                   
+# Headers and Logging
+#-----------------------------------------------------------------------------------------                   
+underline() { printf "${underline}${bold}%s${reset}\n" "$@"
+}
+h1() { printf "\n${underline}${bold}${blue}%s${reset}\n" "$@"
+}
+h2() { printf "\n${underline}${bold}${white}%s${reset}\n" "$@"
+}
+debug() { printf "${white}%s${reset}\n" "$@"
+}
+info() { printf "${white}➜ %s${reset}\n" "$@"
+}
+success() { printf "${green}✔ %s${reset}\n" "$@"
+}
+error() { printf "${red}✖ %s${reset}\n" "$@"
+}
+warn() { printf "${tan}➜ %s${reset}\n" "$@"
+}
+bold() { printf "${bold}%s${reset}\n" "$@"
+}
+note() { printf "\n${underline}${bold}${blue}Note:${reset} ${blue}%s${reset}\n" "$@"
+}
+
+#-----------------------------------------------------------------------------------------                   
+# Functions
+#-----------------------------------------------------------------------------------------                   
+function usage {
+    info "Syntax: run-locally.sh [OPTIONS]"
+    cat << EOF
+Options are:
+--api : Run the framework API server
+-h | --help : get this help text.
+
+Environment variables:
+BOOTSTRAP_LOCATION - Optional. 
+    Controls where the galasa bootstrap information can be found.
+    Defaults to file://${HOME}/.galasa/bootstrap.properties
+None
+EOF
+}
+
+
+#-----------------------------------------------------------------------------------------                   
+# Process parameters
+#-----------------------------------------------------------------------------------------                   
+run_component=""
+
+while [ "$1" != "" ]; do
+    case $1 in
+             --api  )           run_component="api"
+                                ;;
+        -h | --help )           usage
+                                exit
+                                ;;
+        * )                     error "Unexpected argument $1"
+                                usage
+                                exit 1
+    esac
+    shift
+done
+
+if [[ "${run_component}" == "" ]]; then
+    error "Need to indicate which component is to be run. eg: --api"
+    usage
+    exit 1  
+fi
+
+
+#-----------------------------------------------------------------------------------------                   
+# Main logic.
+#-----------------------------------------------------------------------------------------                   
+
+# Work out where the framework jar has been built locally...
+BOOT_FOLDER="${BASEDIR}/galasa-parent/galasa-boot/build/libs"
+boot_jar_name=$(ls ${BOOT_FOLDER}/galasa-boot-*.jar | grep -v "sources" | grep -v "javadoc")
+info "Boot jar is at ${BOOT_FOLDER}/${boot_jar_name}"
+
+# Work out where the locally-build-OBR is held...
+OBR_VERSION="0.25.0"
+
+M2_PATH=~/.m2
+
+
+# Allow setting the bootstrap location from the environment.
+if [[ -z ${BOOTSTRAP_LOCATION} ]]; then
+    BOOTSTRAP_LOCATION="file://${HOME}/.galasa/bootstrap.properties"
+    info "Environment variable BOOTSTRAP_LOCATION is not set. Using default value of $BOOTSTRAP_LOCATION"
+fi
+info "Environment variable BOOTSTRAP_LOCATION is $BOOTSTRAP_LOCATION"
+
+
+cat << EOF
+Command is :
+
+${JAVA_HOME}/bin/java \
+    -jar ${boot_jar_name} \
+    --localmaven file:${M2_PATH}/repository/ \
+    --bootstrap ${BOOTSTRAP_LOCATION} \
+    --overrides file://${HOME}/.galasa/overrides.properties \
+    --obr mvn:dev.galasa/dev.galasa.uber.obr/${OBR_VERSION}/obr \
+    --api
+
+EOF
+
+${JAVA_HOME}/bin/java \
+    -jar ${boot_jar_name} \
+    --localmaven file:${M2_PATH}/repository/ \
+    --bootstrap ${BOOTSTRAP_LOCATION} \
+    --overrides file://${HOME}/.galasa/overrides.properties \
+    --obr mvn:dev.galasa/dev.galasa.uber.obr/${OBR_VERSION}/obr \
+    --api
+
+    


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

- [x] Put unit tests around the CSP servlet
- [x] Changed some 500 (internal server error) codes to 400 or 404.
- [x] Added a name validator class to centralise validation of names.
- [x] Servlet supports hiding of the 'dss' namespace entirely if it's there.
- [x] Servlet supports redacting all the values when 'security' namespace is queried.
- [x] Seems to work when tested with curl/soapUI
  - still not working with swagger as a result of CORS stuff I believe.
- [x] New bug found by inspection 
- [x] Unit tests 80% branch coverage.
- [x] Added run-locally script for easy invocation of framework components. 
