### PR TITLE
Update io.kubernetes:client-java from 1.0.0 to 16.0.2

### DIFF
--- a/galasa-parent/dev.galasa.framework.k8s.controller/bnd.bnd
+++ b/galasa-parent/dev.galasa.framework.k8s.controller/bnd.bnd
@@ -5,8 +5,6 @@ Import-Package: dev.galasa.framework,\
                 dev.galasa.framework.spi,\
                 dev.galasa.framework.k8s.controller,\
                 org.apache.commons.logging,\
-                io.prometheus.client,\
-                io.prometheus.client.exporter,\
                 com.sun.net.httpserver,\
                 org.yaml.snakeyaml*,\
                 org.xml.sax,\
@@ -15,6 +13,9 @@ Import-Package: dev.galasa.framework,\
                 javax.naming,\
                 javax.net.ssl,\
                 javax.net,\
+                javax.crypto,\
+                javax.crypto.spec,\
+                javax.security.auth.x500,\
                 com.google.gson,\
                 com.google.gson.reflect,\
                 com.google.gson.stream
@@ -22,6 +23,8 @@ Embed-Transitive: true
 Embed-Dependency: *;scope=compile
 -includeresource: client-java-16.0.2.jar; lib:=true,\
     bcpkix-jdk18on-1.71.jar; lib:=true,\
+    bcprov-jdk18on-1.71.jar; lib:=true,\
+    bcutil-jdk18on-1.71.jar; lib:=true,\
     client-java-api-16.0.2.jar; lib:=true,\
     client-java-proto-16.0.2.jar; lib:=true,\
     commons-codec-1.15.jar; lib:=true,\
@@ -36,7 +39,11 @@ Embed-Dependency: *;scope=compile
     swagger-annotations-1.6.6.jar; lib:=true,\
     logging-interceptor-4.9.2.jar; lib:=true,\
     okhttp-4.9.2.jar; lib:=true,\
+    org.apache.servicemix.bundles.okio-2.8.0_1.jar; lib:=true,\
+    kotlin-osgi-bundle-1.4.0.jar; lib:=true,\
     gson-2.9.0.jar; lib:=true,\
     gson-fire-1.8.5.jar; lib:=true,\
-    javax.annotation-api-1.3.2.jar; lib:=true
+    javax.annotation-api-1.3.2.jar; lib:=true,\
+    simpleclient-0.15.0.jar; lib:=true,\
+    simpleclient_httpserver-0.15.0.jar; lib:=true
 -fixupmessages "Classes found in the wrong directory"; restrict:=error; is:=warning

--- a/galasa-parent/dev.galasa.framework.k8s.controller/bnd.bnd
+++ b/galasa-parent/dev.galasa.framework.k8s.controller/bnd.bnd
@@ -21,4 +21,22 @@ Import-Package: dev.galasa.framework,\
 Embed-Transitive: true
 Embed-Dependency: *;scope=compile
 -includeresource: client-java-16.0.2.jar; lib:=true,\
-    commons-codec-1.15.jar; lib:=true
+    bcpkix-jdk18on-1.71.jar; lib:=true,\
+    client-java-api-16.0.2.jar; lib:=true,\
+    client-java-proto-16.0.2.jar; lib:=true,\
+    commons-codec-1.15.jar; lib:=true,\
+    commons-io-2.11.0.jar; lib:=true,\
+    commons-compress-1.21.jar; lib:=true,\
+    commons-lang3-3.12.0.jar; lib:=true,\
+    commons-collections4-4.4.jar; lib:=true,\
+    jose4j-0.7.12.jar; lib:=true,\
+    slf4j-api-1.7.36.jar; lib:=true,\
+    protobuf-java-3.21.2.jar; lib:=true,\
+    jsr305-3.0.2.jar; lib:=true,\
+    swagger-annotations-1.6.6.jar; lib:=true,\
+    logging-interceptor-4.9.2.jar; lib:=true,\
+    okhttp-4.9.2.jar; lib:=true,\
+    gson-2.9.0.jar; lib:=true,\
+    gson-fire-1.8.5.jar; lib:=true,\
+    javax.annotation-api-1.3.2.jar; lib:=true
+-fixupmessages "Classes found in the wrong directory"; restrict:=error; is:=warning

--- a/galasa-parent/dev.galasa.framework.k8s.controller/bnd.bnd
+++ b/galasa-parent/dev.galasa.framework.k8s.controller/bnd.bnd
@@ -20,28 +20,5 @@ Import-Package: dev.galasa.framework,\
                 com.google.gson.stream
 Embed-Transitive: true
 Embed-Dependency: *;scope=compile
--includeresource: client-java-1.0.0.jar; lib:=true,\
-    guava-24.1.1-jre.jar; lib:=true,\
-    bcpkix-jdk15on-1.60.jar; lib:=true,\
-    bcprov-jdk15on-1.60.jar; lib:=true,\
-    jsr305-1.3.9.jar; lib:=true,\
-    checker-compat-qual-2.0.0.jar; lib:=true,\
-    error_prone_annotations-2.1.3.jar; lib:=true,\
-    j2objc-annotations-1.1.jar; lib:=true,\
-    animal-sniffer-annotations-1.14.jar; lib:=true,\
-    client-java-api-1.0.0.jar; lib:=true,\
-    client-java-proto-1.0.0.jar; lib:=true,\
-    commons-codec-1.15.jar; lib:=true,\
-    commons-lang3-3.7.jar; lib:=true,\
-    okhttp-ws-2.7.5.jar; lib:=true,\
-    logback-classic-1.2.3.jar; lib:=true,\
-    slf4j-api-1.7.25.jar; lib:=true,\
-    bcprov-ext-jdk15on-1.59.jar; lib:=true,\
-    protobuf-java-3.4.0.jar; lib:=true,\
-    swagger-annotations-1.5.12.jar; lib:=true,\
-    logging-interceptor-2.7.5.jar; lib:=true,\
-    okhttp-2.7.5.jar; lib:=true,\
-    gson-2.6.2.jar; lib:=true,\
-    joda-time-2.9.3.jar; lib:=true,\
-    logback-core-1.2.3.jar; lib:=true,\
-    okio-1.6.0.jar; lib:=true
+-includeresource: client-java-16.0.2.jar; lib:=true,\
+    commons-codec-1.15.jar; lib:=true

--- a/galasa-parent/dev.galasa.framework.k8s.controller/build.gradle
+++ b/galasa-parent/dev.galasa.framework.k8s.controller/build.gradle
@@ -14,10 +14,15 @@ dependencies {
     
     implementation 'commons-codec:commons-codec:1.15'
 
-    implementation 'io.prometheus:simpleclient:0.6.0'
-    implementation 'io.prometheus:simpleclient_httpserver:0.6.0'
-    implementation 'io.prometheus:simpleclient_hotspot:0.6.0'
+    implementation 'io.prometheus:simpleclient:0.15.0'
+    implementation 'io.prometheus:simpleclient_httpserver:0.15.0'
+    implementation 'io.prometheus:simpleclient_hotspot:0.15.0'
 
+    implementation 'com.squareup.okhttp3:okhttp:4.9.2'
+    implementation 'org.apache.servicemix.bundles:org.apache.servicemix.bundles.okio:2.8.0_1'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle:1.4.0'
+    implementation 'org.bouncycastle:bcpkix-jdk18on:1.71'
+    implementation 'org.bouncycastle:bcprov-jdk18on:1.71'
     implementation 'io.kubernetes:client-java:16.0.2'
     implementation ('org.yaml:snakeyaml'){
         version {

--- a/galasa-parent/dev.galasa.framework.k8s.controller/build.gradle
+++ b/galasa-parent/dev.galasa.framework.k8s.controller/build.gradle
@@ -18,19 +18,7 @@ dependencies {
     implementation 'io.prometheus:simpleclient_httpserver:0.6.0'
     implementation 'io.prometheus:simpleclient_hotspot:0.6.0'
 
-    implementation 'com.google.guava:guava:24.1.1-jre'
-    implementation 'io.kubernetes:client-java:1.0.0'
-
-    implementation ('org.bouncycastle:bcpkix-jdk15on') {
-        version {
-            strictly '1.60'
-        }
-    }
-    implementation ('org.bouncycastle:bcprov-jdk15on') {
-        version {
-            strictly '1.60'
-        }
-    }
+    implementation 'io.kubernetes:client-java:16.0.2'
     implementation ('org.yaml:snakeyaml'){
         version {
             strictly '1.30'

--- a/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/K8sController.java
+++ b/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/K8sController.java
@@ -1,7 +1,5 @@
 /*
- * Licensed Materials - Property of IBM
- * 
- * (c) Copyright IBM Corp. 2019.
+ * Copyright contributors to the Galasa project 
  */
 package dev.galasa.framework.k8s.controller;
 
@@ -21,10 +19,10 @@ import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
 import dev.galasa.framework.spi.IDynamicStatusStoreService;
 import dev.galasa.framework.spi.IFramework;
-import io.kubernetes.client.ApiClient;
-import io.kubernetes.client.Configuration;
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.Configuration;
 import io.kubernetes.client.ProtoClient;
-import io.kubernetes.client.apis.CoreV1Api;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.util.Config;
 import io.prometheus.client.exporter.HTTPServer;
 

--- a/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/RunDeleted.java
+++ b/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/RunDeleted.java
@@ -1,7 +1,5 @@
 /*
- * Licensed Materials - Property of IBM
- * 
- * (c) Copyright IBM Corp. 2019.
+ * Copyright contributors to the Galasa project 
  */
 package dev.galasa.framework.k8s.controller;
 
@@ -13,10 +11,10 @@ import org.apache.commons.logging.LogFactory;
 
 import dev.galasa.framework.spi.IFrameworkRuns;
 import dev.galasa.framework.spi.IRun;
-import io.kubernetes.client.ApiException;
+import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.ProtoClient;
-import io.kubernetes.client.apis.CoreV1Api;
-import io.kubernetes.client.models.V1Pod;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.proto.V1.Namespace;
 
 public class RunDeleted implements Runnable {

--- a/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/RunPoll.java
+++ b/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/RunPoll.java
@@ -1,7 +1,5 @@
 /*
- * Licensed Materials - Property of IBM
- * 
- * (c) Copyright IBM Corp. 2019,2021.
+ * Copyright contributors to the Galasa project 
  */
 package dev.galasa.framework.k8s.controller;
 
@@ -23,25 +21,25 @@ import org.apache.commons.logging.LogFactory;
 import dev.galasa.framework.spi.IDynamicStatusStoreService;
 import dev.galasa.framework.spi.IFrameworkRuns;
 import dev.galasa.framework.spi.IRun;
-import io.kubernetes.client.ApiException;
-import io.kubernetes.client.apis.CoreV1Api;
-import io.kubernetes.client.models.V1Affinity;
-import io.kubernetes.client.models.V1ConfigMapKeySelector;
-import io.kubernetes.client.models.V1Container;
-import io.kubernetes.client.models.V1EnvVar;
-import io.kubernetes.client.models.V1EnvVarSource;
-import io.kubernetes.client.models.V1NodeAffinity;
-import io.kubernetes.client.models.V1NodeSelectorRequirement;
-import io.kubernetes.client.models.V1NodeSelectorTerm;
-import io.kubernetes.client.models.V1ObjectFieldSelector;
-import io.kubernetes.client.models.V1ObjectMeta;
-import io.kubernetes.client.models.V1Pod;
-import io.kubernetes.client.models.V1PodList;
-import io.kubernetes.client.models.V1PodSpec;
-import io.kubernetes.client.models.V1PodStatus;
-import io.kubernetes.client.models.V1PreferredSchedulingTerm;
-import io.kubernetes.client.models.V1ResourceRequirements;
-import io.kubernetes.client.models.V1SecretKeySelector;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.V1Affinity;
+import io.kubernetes.client.openapi.models.V1ConfigMapKeySelector;
+import io.kubernetes.client.openapi.models.V1Container;
+import io.kubernetes.client.openapi.models.V1EnvVar;
+import io.kubernetes.client.openapi.models.V1EnvVarSource;
+import io.kubernetes.client.openapi.models.V1NodeAffinity;
+import io.kubernetes.client.openapi.models.V1NodeSelectorRequirement;
+import io.kubernetes.client.openapi.models.V1NodeSelectorTerm;
+import io.kubernetes.client.openapi.models.V1ObjectFieldSelector;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1PodList;
+import io.kubernetes.client.openapi.models.V1PodSpec;
+import io.kubernetes.client.openapi.models.V1PodStatus;
+import io.kubernetes.client.openapi.models.V1PreferredSchedulingTerm;
+import io.kubernetes.client.openapi.models.V1ResourceRequirements;
+import io.kubernetes.client.openapi.models.V1SecretKeySelector;
 import io.prometheus.client.Counter;
 
 public class RunPoll implements Runnable {
@@ -268,7 +266,7 @@ public class RunPoll implements Runnable {
             while (!successful) {
                 try {
                     // System.out.println(newPod.toString());
-                    api.createNamespacedPod(namespace, newPod, "true");
+                    api.createNamespacedPod(namespace, newPod, "true", null, null, null);
 
                     logger.info("Engine Pod " + newPod.getMetadata().getName() + " started");
                     successful = true;
@@ -328,8 +326,8 @@ public class RunPoll implements Runnable {
         LinkedList<V1Pod> pods = new LinkedList<>();
 
         try {
-            V1PodList list = api.listNamespacedPod(settings.getNamespace(), null, null, null, true,
-                    "galasa-engine-controller=" + settings.getEngineLabel(), null, null, null, null);
+            V1PodList list = api.listNamespacedPod(settings.getNamespace(), null, null, null, null,
+                    "galasa-engine-controller=" + settings.getEngineLabel(), null, null, null, null, null);
             for (V1Pod pod : list.getItems()) {
                 pods.add(pod);
             }

--- a/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/Settings.java
+++ b/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/Settings.java
@@ -1,7 +1,5 @@
 /*
- * Licensed Materials - Property of IBM
- * 
- * (c) Copyright IBM Corp. 2019.
+ * Copyright contributors to the Galasa project 
  */
 package dev.galasa.framework.k8s.controller;
 
@@ -12,9 +10,9 @@ import java.util.List;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import io.kubernetes.client.ApiException;
-import io.kubernetes.client.apis.CoreV1Api;
-import io.kubernetes.client.models.V1ConfigMap;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.V1ConfigMap;
 
 public class Settings implements Runnable {
 
@@ -67,7 +65,7 @@ public class Settings implements Runnable {
 
         V1ConfigMap configMap = null;
         try {
-            configMap = api.readNamespacedConfigMap(configMapName, namespace, "true", false, false);
+            configMap = api.readNamespacedConfigMap(configMapName, namespace, "true");
         } catch (ApiException e) {
             throw new K8sControllerException("Failed to read configmap '" + configMapName + "' in namespace '" + namespace + "'", e);
         }

--- a/galasa-parent/gradle.properties
+++ b/galasa-parent/gradle.properties
@@ -1,3 +1,5 @@
+org.gradle.jvmargs=-Xmx4096M
+
 isRelease=false
 
 sourceMaven=https://repo.maven.apache.org/maven2/

--- a/galasa-parent/gradle.properties
+++ b/galasa-parent/gradle.properties
@@ -2,6 +2,6 @@ org.gradle.jvmargs=-Xmx4096M
 
 isRelease=false
 
-sourceMaven=https://development.galasa.dev/main/maven-repo/obr/
+sourceMaven=https://repo.maven.apache.org/maven2/
 centralMaven=https://repo.maven.apache.org/maven2/
 targetMaven=https://repo.maven.apache.org/maven2/


### PR DESCRIPTION
For https://github.com/galasa-dev/projectmanagement/issues/1083

- Updated build.gradle to use client-java 16.0.2 and removed dependencies that are no longer used by client-java
- Updated included jars in OSGi bundle
- Fixed compilation errors as a result of client-java's new project structure and updated APIs