### PR TITLE
Bump docker-java-core to 3.2.14

### DIFF
--- a/galasa-parent/dev.galasa.framework.docker.controller/bnd.bnd
+++ b/galasa-parent/dev.galasa.framework.docker.controller/bnd.bnd
@@ -12,20 +12,20 @@ Import-Package: dev.galasa.framework,\
                 javax.net.ssl
 Embed-Transitive: true
 Embed-Dependency: *;scope=compile
--includeresource: docker-java-core-3.2.5.jar; lib:=true,\
-    docker-java-transport-httpclient5-3.2.5.jar; lib:=true,\
-    docker-java-api-3.2.5.jar; lib:=true,\
-    docker-java-transport-3.2.5.jar; lib:=true,\
-    httpclient5-5.0.jar; lib:=true,\
+-includeresource: docker-java-core-3.2.14.jar; lib:=true,\
+    docker-java-transport-httpclient5-3.2.14.jar; lib:=true,\
+    docker-java-api-3.2.14.jar; lib:=true,\
+    docker-java-transport-3.2.14.jar; lib:=true,\
+    httpclient5-5.0.3.jar; lib:=true,\
     slf4j-api-1.7.30.jar; lib:=true,\
     commons-io-2.6.jar; lib:=true,\
-    commons-lang-2.6.jar; lib:=true,\
+    commons-lang3-3.12.0.jar; lib:=true,\
     jackson-databind-2.10.3.jar; lib:=true,\
     guava-19.0.jar; lib:=true,\
     bcpkix-jdk15on-1.60.jar; lib:=true,\
-    jna-5.5.0.jar; lib:=true,\
+    jna-5.12.1.jar; lib:=true,\
     jackson-annotations-2.10.3.jar; lib:=true,\
     jackson-core-2.10.3.jar; lib:=true,\
     bcprov-jdk15on-1.60.jar; lib:=true,\
-    httpcore5-5.0.jar; lib:=true,\
+    httpcore5-5.0.2.jar; lib:=true,\
     commons-codec-1.15.jar; lib:=true

--- a/galasa-parent/dev.galasa.framework.docker.controller/build.gradle
+++ b/galasa-parent/dev.galasa.framework.docker.controller/build.gradle
@@ -22,8 +22,8 @@ dependencies {
     implementation 'io.prometheus:simpleclient_httpserver:0.6.0'
     implementation 'io.prometheus:simpleclient_hotspot:0.6.0'
 
-    implementation 'com.github.docker-java:docker-java-core:3.2.5'
-    implementation 'com.github.docker-java:docker-java-transport-httpclient5:3.2.5'
+    implementation 'com.github.docker-java:docker-java-core:3.2.14'
+    implementation 'com.github.docker-java:docker-java-transport-httpclient5:3.2.14'
     implementation ('org.bouncycastle:bcpkix-jdk15on') {
         version {
             strictly '1.60'


### PR DESCRIPTION
For https://github.com/galasa-dev/projectmanagement/issues/1087
See https://mvnrepository.com/artifact/com.github.docker-java/docker-java-core/3.2.14