### PR TITLE
Load properties prior to writing them out to reduce the race timing window length

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ package-lock.json
 build/
 .gradle/
 **/.idea/
+**/heapdump*

--- a/build-locally.sh
+++ b/build-locally.sh
@@ -115,7 +115,7 @@ info "Build type is --'${build_type}'"
 # Debug or not debug ? Override using the DEBUG flag.
 if [[ -z ${DEBUG} ]]; then
     export DEBUG=0
-    # export DEBUG=1
+    #export DEBUG=1
     info "DEBUG defaulting to ${DEBUG}."
     info "Over-ride this variable if you wish. Valid values are 0 and 1."
 else
@@ -201,7 +201,7 @@ ${CONSOLE_FLAG} \
 -PsourceMaven=${SOURCE_MAVEN} ${OPTIONAL_DEBUG_FLAG} \
 build check \
 2>&1 >> ${log_file}
-rc=$? ; if [[ "${rc}" != "0" ]]; then cat ${log_file} ; error "Failed to build ${project}" ; exit 1 ; fi
+rc=$? ; if [[ "${rc}" != "0" ]]; then error "Failed to build ${project} log is at ${log_file}" ; exit 1 ; fi
 success "Built OK"
 
 
@@ -214,7 +214,7 @@ ${CONSOLE_FLAG} \
 -PsourceMaven=${SOURCE_MAVEN} ${OPTIONAL_DEBUG_FLAG} \
 publishToMavenLocal \
 2>&1 >> ${log_file}
-rc=$? ; if [[ "${rc}" != "0" ]]; then cat ${log_file} ; error "Failed to publish ${project}" ; exit 1 ; fi
+rc=$? ; if [[ "${rc}" != "0" ]]; then error "Failed to publish ${project} log is at ${log_file}" ; exit 1 ; fi
 success "Published OK"
 
 success "Project ${project} built - OK - log is at ${log_file}"

--- a/galasa-parent/galasa-boot/build.gradle
+++ b/galasa-parent/galasa-boot/build.gradle
@@ -15,7 +15,7 @@ configurations {
 
 }
 
-version = "0.24.0"
+version = "0.26.0"
 
 jar {
     manifest {

--- a/run-locally.sh
+++ b/run-locally.sh
@@ -110,7 +110,7 @@ boot_jar_name=$(ls ${BOOT_FOLDER}/galasa-boot-*.jar | grep -v "sources" | grep -
 info "Boot jar is at ${BOOT_FOLDER}/${boot_jar_name}"
 
 # Work out where the locally-build-OBR is held...
-OBR_VERSION="0.25.0"
+OBR_VERSION="0.26.0"
 
 M2_PATH=~/.m2
 


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>
