### PR TITLE
Bump framework and boot version to 0.27.0

### DIFF
--- a/galasa-parent/dev.galasa.framework.api.bootstrap/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api.bootstrap/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 description = 'Galasa API - Bootstrap'
 
-version = '0.25.0'
+version = '0.27.0'
 
 dependencies {
     implementation project(':dev.galasa.framework')

--- a/galasa-parent/dev.galasa.framework.api/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 description = 'Framework API'
 
-version = '0.25.0'
+version = '0.27.0'
 
 dependencies {
 

--- a/galasa-parent/dev.galasa.framework/settings.gradle
+++ b/galasa-parent/dev.galasa.framework/settings.gradle
@@ -1,3 +1,3 @@
 rootProject.name = "dev.galasa.framework"
 
-bundleVersion = 0.16.0
+bundleVersion = 0.27.0

--- a/release.yaml
+++ b/release.yaml
@@ -25,7 +25,7 @@ framework:
     codecoverage: true
     
   - artifact: galasa-boot
-    version: 0.26.0
+    version: 0.27.0
     mvp: true
     codecoverage: true
 
@@ -84,7 +84,7 @@ api:
     codecoverage: true
     
   - artifact: dev.galasa.framework.api.bootstrap
-    version: 0.25.0
+    version: 0.27.0
     obr: true
     isolated: true
     codecoverage: true

--- a/run-locally.sh
+++ b/run-locally.sh
@@ -110,7 +110,7 @@ boot_jar_name=$(ls ${BOOT_FOLDER}/galasa-boot-*.jar | grep -v "sources" | grep -
 info "Boot jar is at ${BOOT_FOLDER}/${boot_jar_name}"
 
 # Work out where the locally-build-OBR is held...
-OBR_VERSION="0.26.0"
+OBR_VERSION="0.27.0"
 
 M2_PATH=~/.m2
 


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

- [x] Bump up galasa-boot jar to v0.27.0
- [x] Bump up framework jar to v0.27.0
