### PR TITLE
Framework understands GALASA_HOME env var and system property.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,22 @@ Take a look at the [contribution guidelines](https://github.com/galasa-dev/proje
 Use the `build-locally.sh` script. 
 See the comments at the top of the script for options you can use and a list of environment variables you can override.
 
+## Configuration of the framework component
+When the framework runs, it requires some level of configuration to run.
+
+### Environment Variables
+Environment variables are set in several ways. In unix systems use `export X=Y`. In Windows use `set X=Y` or use the user interface to set values. 
+Here are the environment variables used by the framework component:
+- `GALASA_HOME` - holds the path which should be used in preference to the `${HOME}/.galasa` location. Optional. This setting is overridden by the system property of the same name. Defaults to `${HOME}/.galasa` if not specified. For example: /mygalasahome
+
+### System Properties
+System properties are passed to the framework when the JVM is invoked using the `-D{NAME}={VALUE}` syntax. 
+Here are the system properties which the framework understands:
+
+- `GALASA_HOME` - holds the path which should be used in preference to the `${HOME}/.galasa` location. Optional. This setting overrides 
+the environment variable of the same name, which in turn overrides the default of `${HOME}/.galasa` if not specified. 
+
+
 ## License
 
 This code is under the [Eclipse Public License 2.0](https://github.com/galasa-dev/maven/blob/main/LICENSE).

--- a/galasa-parent/dev.galasa.framework/build.gradle
+++ b/galasa-parent/dev.galasa.framework/build.gradle
@@ -23,5 +23,6 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.9'
 
     testImplementation project (':dev.galasa')
+    testImplementation project (':galasa.framework')
 
 }

--- a/galasa-parent/dev.galasa.framework/build.gradle
+++ b/galasa-parent/dev.galasa.framework/build.gradle
@@ -23,6 +23,5 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.9'
 
     testImplementation project (':dev.galasa')
-    testImplementation project (':galasa.framework')
 
 }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/Environment.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/Environment.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright contributors to the Galasa project 
+ */
+package dev.galasa.framework;
+
+/** 
+ * An interface through which we can get environment variable values. 
+ * Allows for easy mocking of the System class, which is notoriously hard to mock
+ * out for unit tests.
+ */
+public interface Environment {
+
+    /** Gets the value of a given environment variable. */
+    String getenv(String propertyName);
+
+    /** Gets a system property */
+    String getProperty(String propertyName);
+}

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FileSystem.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FileSystem.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright contributors to the Galasa project
+ */
 package dev.galasa.framework;
 
 import java.io.IOException;

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FileSystem.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FileSystem.java
@@ -1,0 +1,25 @@
+package dev.galasa.framework;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class FileSystem implements IFileSystem {
+    public FileSystem() {
+    }
+
+    @Override
+    public void createDirectories(Path folderPath) throws IOException {
+        Files.createDirectories(folderPath);
+    }
+
+    @Override
+    public void createFile(Path filePath) throws IOException {
+        Files.createFile(filePath);
+    }
+
+    @Override
+    public boolean exists(Path pathToFolderOrFile ) {
+        return pathToFolderOrFile.toFile().exists();
+    }
+}

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkInitialisation.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkInitialisation.java
@@ -417,10 +417,32 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
             }
         } else {
             logger.info("System property GALASA_HOME used to set value of home location.");
+            // The system property value may be surrounded by " characters. 
+            // If so, strip them off.
+            // We allow this because a path with strings in would be split
+            // into separate system properties otherwise.
+            home = stripLeadingAndTrailingQuotes(home);
         }
         logger.info("Galasa home location is "+home);
 
         return home;
+    }
+
+    /**
+     * String the first double-quote and the last double-quote off
+     * the begining and end of a string.
+     * @param input
+     * @return The stripped (or unaltered) string.
+     */
+    String stripLeadingAndTrailingQuotes(String input ) {
+        String output = input ;
+        if (output.startsWith("\"")) {
+            output = output.replaceFirst("\"", "");
+        }
+        if (output.endsWith("\"")) {
+            output = output.substring(0,output.length()-1);
+        }
+        return output;
     }
 
     // Find the run name of the test run, if it's not a set property 

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkInitialisation.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkInitialisation.java
@@ -194,6 +194,7 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
                     fileSystem.createDirectories(path.getParent());
                 }
                 // Create an empty file.
+                logger.info("File "+path.toString()+" does not exist, so creating it.");
                 fileSystem.createFile(path);
             }
         } catch (IOException e) {
@@ -350,11 +351,17 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
         String propUri = env.getenv("GALASA_CONFIG_STORE");
         if ((propUri == null) || propUri.isEmpty()) {
             propUri = bootstrapProperties.getProperty("framework.config.store");
+            if ((propUri != null) && (!propUri.isEmpty())) {
+                logger.debug("bootstrap property framework.config.store used to determine CPS location.");
+            }
+        } else {
+            logger.debug("GALASA_CONFIG_STORE used to determine CPS location.");
         }
         if ((propUri == null) || propUri.isEmpty()) {
             String galasaHome = getGalasaHome(env);
             Path path = Paths.get(galasaHome , "cps.properties");
             storeUri = path.toUri();
+            logger.debug("galasa home used to determine CPS location.");
             createIfMissing(storeUri,fileSystem);
         } else {
             storeUri = new URI(propUri);
@@ -396,7 +403,6 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
 
     
     private String getGalasaHome(Environment env) {
-        
         // 1st: If GALASA_HOME is set as a system property then use that,
         // 2nd: If GALASA_HOME is set as a system environment variable, then use that.
         // 3rd: otherwise we use the calling users' home folder.
@@ -405,12 +411,17 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
             home = env.getenv(GALASA_HOME);
             if( (home == null) || (home.trim().isEmpty())) {
                 home = env.getProperty(USER_HOME)+"/.galasa";
+                logger.info("System property "+USER_HOME+" used to set value of home location.");
+            } else {
+                logger.info("Environment variable GALASA_HOME used to set value of home location.");
             }
+        } else {
+            logger.info("System property GALASA_HOME used to set value of home location.");
         }
+        logger.info("Galasa home location is "+home);
 
         return home;
     }
-
 
     // Find the run name of the test run, if it's not a set property 
     // ("framework.run.name")
@@ -425,8 +436,10 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
                 testName = AbstractManager.nulled(cpsFramework.getProperty("run", "gherkintest"));
                 testLanguage = "gherkin";
             }
+            logger.info("Submitting test "+testName);
             runName = submitRun(testName, testLanguage);
         }
+        logger.info("Run name is "+runName);
         return runName;
     }
 

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/IFileSystem.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/IFileSystem.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright contributors to the Galasa project
+ */
 package dev.galasa.framework;
 
 import java.io.IOException;

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/IFileSystem.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/IFileSystem.java
@@ -1,0 +1,14 @@
+package dev.galasa.framework;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+public interface IFileSystem {
+
+    void createDirectories(Path folderPath ) throws IOException ;
+
+    void createFile(Path filePath) throws IOException ;
+
+    boolean exists(Path pathToFolderOrFile);
+    
+}

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/SystemEnvironment.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/SystemEnvironment.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright contributors to the Galasa project 
+ */
+package dev.galasa.framework;
+
+/**
+ * An implementation of the Environment interface which allows code to get
+ * environment variables from the real system.
+ */
+public class SystemEnvironment implements Environment {
+
+    @Override
+    public String getenv(String propertyName) {
+        return System.getenv(propertyName);
+    }
+
+    @Override
+    public String getProperty(String propertyName) {
+        return System.getProperty(propertyName);
+    }
+    
+}

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/cps/FpfConfigurationPropertyRegistration.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/cps/FpfConfigurationPropertyRegistration.java
@@ -43,7 +43,7 @@ public class FpfConfigurationPropertyRegistration implements IConfigurationPrope
         File file = new File(cps);
 
         if ((!file.exists())) {
-            throw new ConfigurationPropertyStoreException("CPS file does not exsist");
+            throw new ConfigurationPropertyStoreException("CPS file does not exist");
         }
         if (isFileUri(cps)) {
             frameworkInitialisation.registerConfigurationPropertyStore(new FpfConfigurationPropertyStore(cps));

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IConfigurationPropertyStoreRegistration.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IConfigurationPropertyStoreRegistration.java
@@ -1,15 +1,11 @@
 /*
- * Licensed Materials - Property of IBM
- * 
- * (c) Copyright IBM Corp. 2019.
+ * Copyright contributors to the Galasa project
  */
 package dev.galasa.framework.spi;
 
 import javax.validation.constraints.NotNull;
 
 /**
- * 
- * @author James Davies
  *
  */
 public interface IConfigurationPropertyStoreRegistration {
@@ -30,9 +26,8 @@ public interface IConfigurationPropertyStoreRegistration {
      *                                various initialisation methods
      * @throws ConfigurationPropertyStoreException - If there is a problem
      *                                             initialising the underlying store
-     * @throws ResultArchiveStoreException
      */
     void initialise(@NotNull IFrameworkInitialisation frameworkInitialisation)
-            throws ConfigurationPropertyStoreException, ResultArchiveStoreException;
+            throws ConfigurationPropertyStoreException;
 
 }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IConfigurationPropertyStoreRegistration.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IConfigurationPropertyStoreRegistration.java
@@ -30,8 +30,9 @@ public interface IConfigurationPropertyStoreRegistration {
      *                                various initialisation methods
      * @throws ConfigurationPropertyStoreException - If there is a problem
      *                                             initialising the underlying store
+     * @throws ResultArchiveStoreException
      */
     void initialise(@NotNull IFrameworkInitialisation frameworkInitialisation)
-            throws ConfigurationPropertyStoreException;
+            throws ConfigurationPropertyStoreException, ResultArchiveStoreException;
 
 }

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestFrameworkInitialisation.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestFrameworkInitialisation.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright contributors to the Galasa project
+ */
+package dev.galasa.framework;
+
+import dev.galasa.ICredentials;
+import dev.galasa.framework.mocks.MockBundleContext;
+import dev.galasa.framework.mocks.MockCPSRegistration;
+import dev.galasa.framework.mocks.MockCPSStore;
+import dev.galasa.framework.mocks.MockConfidentialTextStore;
+import dev.galasa.framework.mocks.MockConfidentialTextStoreRegistration;
+import dev.galasa.framework.mocks.MockCredentialsStore;
+import dev.galasa.framework.mocks.MockCredentialsStoreRegistration;
+import dev.galasa.framework.mocks.MockDSSRegistration;
+import dev.galasa.framework.mocks.MockDSSStore;
+import dev.galasa.framework.mocks.MockEnvironment;
+import dev.galasa.framework.mocks.MockFileSystem;
+import dev.galasa.framework.mocks.MockFramework;
+import dev.galasa.framework.mocks.MockLog;
+import dev.galasa.framework.mocks.MockRASRegistration;
+import dev.galasa.framework.mocks.MockRASStoreService;
+import dev.galasa.framework.mocks.MockServiceReference;
+import dev.galasa.framework.spi.*;
+import dev.galasa.framework.spi.creds.ICredentialsStoreRegistration;
+
+import org.apache.commons.logging.Log;
+import org.junit.Test;
+import org.osgi.framework.Bundle;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.net.URI;
+import java.util.*;
+
+public class TestFrameworkInitialisation {
+
+    @Test
+    public void testFrameworkCreatedDefaultPathOk() throws Exception {
+        createFrameworkInit();
+    }
+
+    public FrameworkInitialisation createFrameworkInit() throws Exception {
+        // Given...
+        Properties bootstrapProperties = new Properties();
+        Properties overrideProperties = new Properties();
+        boolean isTestrun = true ;
+        Log logger = new MockLog();
+
+        MockEnvironment mockEnv = new MockEnvironment();
+        mockEnv.setProperty("user.home","/myuser/home");
+
+        // A fake OSGi service registry...
+        Map<String,MockServiceReference<?>> services = new HashMap<String,MockServiceReference<?>>();
+
+        Bundle bundle = null;
+
+        // We want a framework service
+        MockFramework mockFramework = new MockFramework();
+        MockServiceReference<IFramework> mockFrameworkRef = new MockServiceReference<IFramework>(mockFramework, bundle );
+        services.put(IFramework.class.getName(),mockFrameworkRef);
+
+        // We want a CPS service...
+        Map<String,String> cpsProperties = new HashMap<String,String>();
+
+        cpsProperties.put("framework.run.testbundleclass","myTestBundle/myTestClass");
+        
+        // framework.run.name sets the run-name explicitly.
+        // cpsProperties.put("framework.run.name","myRunName");
+
+        MockCPSStore mockCPSStore = new MockCPSStore(cpsProperties);
+        MockCPSRegistration mockCPSRegistration = new MockCPSRegistration(mockCPSStore);
+        MockServiceReference<IConfigurationPropertyStoreRegistration> mockCPSRef = new MockServiceReference<IConfigurationPropertyStoreRegistration>(mockCPSRegistration, bundle );
+        services.put(IConfigurationPropertyStoreRegistration.class.getName(),mockCPSRef);
+
+        // We want a DSS service...
+        Map<String,String> dssProps = new HashMap<String,String>();
+
+        MockDSSStore mockDSSStore = new MockDSSStore(dssProps);
+        MockDSSRegistration mockDSSRegistration = new MockDSSRegistration(mockDSSStore);
+        MockServiceReference<IDynamicStatusStoreRegistration> mockDSSRef = new MockServiceReference<IDynamicStatusStoreRegistration>(mockDSSRegistration, bundle );
+        services.put(IDynamicStatusStoreRegistration.class.getName(),mockDSSRef);
+
+        MockBundleContext bundleContext = new MockBundleContext(services);
+
+        MockFileSystem mockFileSystem = new MockFileSystem();
+
+        // We need a RAS store service also...
+        Map<String,String> rasProps = new HashMap<String,String>();
+        MockRASStoreService mockRASStoreService = new MockRASStoreService(rasProps);
+        MockRASRegistration mockRASRegistration = new MockRASRegistration(mockRASStoreService);
+        MockServiceReference<IResultArchiveStoreRegistration> mockRASRef = new MockServiceReference<IResultArchiveStoreRegistration>(mockRASRegistration, bundle );
+        services.put(IResultArchiveStoreRegistration.class.getName(),mockRASRef);
+
+        // We need a credentials service also...
+        Map<String,ICredentials> credsProps = new HashMap<String,ICredentials>();
+        MockCredentialsStore mockCredentialsStore = new MockCredentialsStore(credsProps);
+        MockCredentialsStoreRegistration mockCredentialsStoreRegistration = new MockCredentialsStoreRegistration(mockCredentialsStore);
+        MockServiceReference<ICredentialsStoreRegistration> mockCredsRegRef = new MockServiceReference<ICredentialsStoreRegistration>(mockCredentialsStoreRegistration, bundle );
+        services.put(ICredentialsStoreRegistration.class.getName(),mockCredsRegRef);
+
+        // We need a confidential text service also...
+        Map<String,String> confidentialTextProps = new HashMap<String,String>();
+        MockConfidentialTextStore mockConfidentialTextStore = new MockConfidentialTextStore(confidentialTextProps);
+        MockConfidentialTextStoreRegistration mockConfidentialTextStoreRegistration = new MockConfidentialTextStoreRegistration(mockConfidentialTextStore);
+        MockServiceReference<IConfidentialTextServiceRegistration> mockConfidentialTextServiceRegRef = new MockServiceReference<IConfidentialTextServiceRegistration>(mockConfidentialTextStoreRegistration, bundle );
+        services.put(IConfidentialTextServiceRegistration.class.getName(),mockConfidentialTextServiceRegRef);
+        
+        // When...
+        FrameworkInitialisation frameworkInitUnderTest = new FrameworkInitialisation( 
+            bootstrapProperties,  
+            overrideProperties, 
+            isTestrun,
+            logger, 
+            mockEnv,
+            bundleContext,
+            mockFileSystem);
+
+        // Then...
+        assertThat(mockFramework.getConfidentialTextService()).isEqualTo(mockConfidentialTextStore);
+        assertThat(mockFramework.getCredentialsStore()).isEqualTo(mockCredentialsStore);
+        assertThat(mockFramework.getConfidentialTextService()).isEqualTo(mockConfidentialTextStore);
+        assertThat(mockFramework.getDynamicStatusStore()).isEqualTo(mockDSSStore);
+        assertThat(mockFramework.getCredentialsStore()).isEqualTo(mockCredentialsStore);
+        assertThat(mockFramework.getResultArchiveStore()).isEqualTo(mockRASStoreService);
+
+        assertThat(frameworkInitUnderTest.getBootstrapConfigurationPropertyStore().getPath()).isEqualTo("/myuser/home/.galasa/cps.properties");
+        assertThat(frameworkInitUnderTest.getDynamicStatusStoreUri().getPath()).isEqualTo("/myuser/home/.galasa/dss.properties");
+
+        List<URI> rasUriList = frameworkInitUnderTest.getResultArchiveStoreUris();
+        
+        assertThat(rasUriList).hasSize(1);
+        assertThat(rasUriList.get(0).getPath()).isEqualTo("/myuser/home/.galasa/ras");
+        assertThat(frameworkInitUnderTest.getCredentialsStoreUri().getPath()).isEqualTo("/myuser/home/.galasa/credentials.properties");
+
+        assertThat(bootstrapProperties).isEmpty();
+        assertThat(overrideProperties).isEmpty();
+
+        return frameworkInitUnderTest;
+    }
+
+
+    // When no framework service has been found... should be an error.
+    @Test
+    public void testFrameworkCreatedNoFrameworkServiceFails() throws Exception {
+
+        // Given...
+        Properties bootstrapProperties = new Properties();
+        Properties overrideProperties = new Properties();
+        boolean isTestrun = true ;
+        Log logger = new MockLog();
+        MockEnvironment mockEnv = new MockEnvironment();
+
+        Map<String,MockServiceReference<?>> services = new HashMap<String,MockServiceReference<?>>();
+
+        MockFramework mockFramework = new MockFramework();
+
+        Bundle bundle = null;
+        MockServiceReference<IFramework> mockFrameworkRef = new MockServiceReference<IFramework>(mockFramework, bundle );
+        
+        // Note: The framework service isn't added as a service reference ! This should cause an error.
+
+        MockBundleContext bundleContext = new MockBundleContext(services);
+        
+        MockFileSystem mockFileSystem = new MockFileSystem();
+
+        // When...
+        FrameworkInitialisation frameworkInitUnderTest ;
+        try {
+            frameworkInitUnderTest = new FrameworkInitialisation( 
+                bootstrapProperties,  
+                overrideProperties, 
+                isTestrun,
+                logger, 
+                mockEnv,
+                bundleContext,
+                mockFileSystem);
+            fail("There is no CPS service configured on purpose, there should have been an error thrown!");
+        } catch( Exception ex ) {
+            assertThat(ex)
+                .hasMessage("The framework service is missing")
+                .isInstanceOf(FrameworkException.class)
+                ;
+        }
+    }
+
+
+    // When no Cps service reference can be found
+    @Test
+    public void testFrameworkCreatedNoCPSServiceFails() throws Exception {
+
+        // Given...
+        Properties bootstrapProperties = new Properties();
+        Properties overrideProperties = new Properties();
+        boolean isTestrun = true ;
+        Log logger = new MockLog();
+        MockEnvironment mockEnv = new MockEnvironment();
+
+        Map<String,MockServiceReference<?>> services = new HashMap<String,MockServiceReference<?>>();
+
+        MockFramework mockFramework = new MockFramework();
+
+        Bundle bundle = null;
+        MockServiceReference<IFramework> mockFrameworkRef = new MockServiceReference<IFramework>(mockFramework, bundle );
+        services.put(IFramework.class.getName(),mockFrameworkRef);
+
+        // Note: The CPS framework service isn't added as a service reference !
+
+        MockBundleContext bundleContext = new MockBundleContext(services);
+        
+        MockFileSystem mockFileSystem = new MockFileSystem();
+
+        // When...
+        FrameworkInitialisation frameworkInitUnderTest = null;
+        try {
+            frameworkInitUnderTest = new FrameworkInitialisation( 
+                bootstrapProperties,  
+                overrideProperties, 
+                isTestrun,
+                logger, 
+                mockEnv,
+                bundleContext,
+                mockFileSystem);
+            fail("There is no CPS service configured on purpose, there should have been an error thrown!");
+        } catch( Exception ex ) {
+            assertThat(ex)
+                .hasMessage("No Configuration Property Store Services have been found")
+                .isInstanceOf(FrameworkException.class)
+                ;
+        }
+        assertThat(frameworkInitUnderTest).isNull();
+    }
+
+    // @Test
+    // public void testLocateDynamicStatusStoreCanBeCalledAgain() throws Exception {
+
+    //     // Given...
+
+    //     // As all the logic is inside a constructor ! (bad)
+    //     // we can't call any methods on the class until we have constructed it
+    //     // using a good passing test...
+    //     FrameworkInitialisation frameworkInit = createFrameworkInit();
+
+    //     Log logger = new MockLog();
+    //     MockFileSystem fs = new MockFileSystem();
+    //     MockEnvironment mockEnv = new MockEnvironment();
+
+    //     // When...
+    //     URI uri = frameworkInit.locateDynamicStatusStore(
+    //         logger, mockEnv, null, fs);
+
+    //     // Then...
+    //     assertThat(uri).isNotNull();
+    //     assertThat(uri.getPath()).isEqualTo("/myuser/home/dss.properties" );
+
+    // }
+
+
+}

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestFrameworkInitialisation.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestFrameworkInitialisation.java
@@ -450,37 +450,7 @@ public class TestFrameworkInitialisation {
         assertThat(fs.exists(Path.of("/myoverriddenhome/cps.properties"))).isTrue();
     }
 
-    @Test
-    public void testLocateBootstrapUsesGALASA_HOMEsystemProInPreferenceToGALASA_HOMEenvVar() throws Exception {
-
-        // As all the logic is inside a constructor ! (bad)
-        // we can't call any methods on the class until we have constructed it
-        // using a good passing test...
-        FrameworkInitialisation frameworkInit = createFrameworkInit();
-
-        Log logger = new MockLog();
-        
-        // A fresh file system...
-        MockFileSystem fs = new MockFileSystem();
-        MockEnvironment mockEnv = new MockEnvironment();
-        // The user home... which should be ignored if GALASA_HOME is set.
-        mockEnv.setProperty("user.home","/myuser2/home");
-
-        // GALASA_HOME is set... we expect it to be used.
-        mockEnv.setProperty("GALASA_HOME","/myoverriddenhome");
-
-        // Set the system env... we don't expect this one to over-ride the 
-        // system property.
-        mockEnv.setenv("GALASA_HOME","/myoverriddenhome2");
-
-        Properties bootstrapProperties = new Properties();
-
-        URI bootstrapUri = frameworkInit.locateConfigurationPropertyStore(logger,mockEnv,bootstrapProperties,fs);
-
-        assertThat(bootstrapUri.getPath().toString()).isEqualTo("/myoverriddenhome/cps.properties");
-        assertThat(fs.exists(Path.of("/myoverriddenhome/cps.properties"))).isTrue();
-    }
-
+   
     @Test
     public void testLocateBootstrapUsesGALASA_HOMEenvVar() throws Exception {
 
@@ -503,6 +473,40 @@ public class TestFrameworkInitialisation {
         // Set the system env... we still expect this one to over-ride the 
         // user home.
         mockEnv.setenv("GALASA_HOME","/myoverriddenhome");
+
+        Properties bootstrapProperties = new Properties();
+
+        URI bootstrapUri = frameworkInit.locateConfigurationPropertyStore(logger,mockEnv,bootstrapProperties,fs);
+
+        assertThat(bootstrapUri.getPath().toString()).isEqualTo("/myoverriddenhome/cps.properties");
+        assertThat(fs.exists(Path.of("/myoverriddenhome/cps.properties"))).isTrue();
+    }
+
+
+    @Test
+    public void testLocateBootstrapStripsQuotesOffGALASA_HOMEsystemProp() throws Exception {
+
+        // As all the logic is inside a constructor ! (bad)
+        // we can't call any methods on the class until we have constructed it
+        // using a good passing test...
+        FrameworkInitialisation frameworkInit = createFrameworkInit();
+
+        Log logger = new MockLog();
+        
+        // A fresh file system...
+        MockFileSystem fs = new MockFileSystem();
+        MockEnvironment mockEnv = new MockEnvironment();
+        // The user home... which should be ignored if GALASA_HOME is set.
+        mockEnv.setProperty("user.home","/myuser2/home");
+
+        // GALASA_HOME is set... we expect it to be used.
+        // Note: The system property value is quoted. So that a 
+        // string can contain spaces.
+        mockEnv.setProperty("GALASA_HOME","\"/myoverriddenhome\"");
+
+        // Set the system env... we don't expect this one to over-ride the 
+        // system property.
+        mockEnv.setenv("GALASA_HOME","/myoverriddenhome2");
 
         Properties bootstrapProperties = new Properties();
 

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestFrameworkInitialisation.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestFrameworkInitialisation.java
@@ -55,10 +55,7 @@ public class TestFrameworkInitialisation {
 
         Bundle bundle = null;
 
-        // We want a framework service
-        MockFramework mockFramework = new MockFramework();
-        MockServiceReference<IFramework> mockFrameworkRef = new MockServiceReference<IFramework>(mockFramework, bundle );
-        services.put(IFramework.class.getName(),mockFrameworkRef);
+        MockFramework mockFramework = addMockFrameworkToMockServiceRegistry(services,bundle);
 
         // We want a CPS service...
         Map<String,String> cpsProperties = new HashMap<String,String>();
@@ -68,44 +65,18 @@ public class TestFrameworkInitialisation {
         // framework.run.name sets the run-name explicitly.
         // cpsProperties.put("framework.run.name","myRunName");
 
-        MockCPSStore mockCPSStore = new MockCPSStore(cpsProperties);
-        MockCPSRegistration mockCPSRegistration = new MockCPSRegistration(mockCPSStore);
-        MockServiceReference<IConfigurationPropertyStoreRegistration> mockCPSRef = new MockServiceReference<IConfigurationPropertyStoreRegistration>(mockCPSRegistration, bundle );
-        services.put(IConfigurationPropertyStoreRegistration.class.getName(),mockCPSRef);
+        addMockCPSToMockServiceRegistery(services,cpsProperties, bundle);
 
-        // We want a DSS service...
-        Map<String,String> dssProps = new HashMap<String,String>();
-
-        MockDSSStore mockDSSStore = new MockDSSStore(dssProps);
-        MockDSSRegistration mockDSSRegistration = new MockDSSRegistration(mockDSSStore);
-        MockServiceReference<IDynamicStatusStoreRegistration> mockDSSRef = new MockServiceReference<IDynamicStatusStoreRegistration>(mockDSSRegistration, bundle );
-        services.put(IDynamicStatusStoreRegistration.class.getName(),mockDSSRef);
+        MockDSSStore mockDSSStore = addMockDSSToMockServiceRegistry(services, bundle);
 
         MockBundleContext bundleContext = new MockBundleContext(services);
 
         MockFileSystem mockFileSystem = new MockFileSystem();
 
-        // We need a RAS store service also...
-        Map<String,String> rasProps = new HashMap<String,String>();
-        MockRASStoreService mockRASStoreService = new MockRASStoreService(rasProps);
-        MockRASRegistration mockRASRegistration = new MockRASRegistration(mockRASStoreService);
-        MockServiceReference<IResultArchiveStoreRegistration> mockRASRef = new MockServiceReference<IResultArchiveStoreRegistration>(mockRASRegistration, bundle );
-        services.put(IResultArchiveStoreRegistration.class.getName(),mockRASRef);
+        MockRASStoreService mockRASStoreService = addMockRASToMockServiceRegistry(services, bundle);
+        MockCredentialsStore mockCredentialsStore = addMockCredentialsStoreToMockServiceRegistry(services, bundle);
+        MockConfidentialTextStore mockConfidentialTextStore = addMockConfidentialTextServiceToMockServiceRegistry(services, bundle);
 
-        // We need a credentials service also...
-        Map<String,ICredentials> credsProps = new HashMap<String,ICredentials>();
-        MockCredentialsStore mockCredentialsStore = new MockCredentialsStore(credsProps);
-        MockCredentialsStoreRegistration mockCredentialsStoreRegistration = new MockCredentialsStoreRegistration(mockCredentialsStore);
-        MockServiceReference<ICredentialsStoreRegistration> mockCredsRegRef = new MockServiceReference<ICredentialsStoreRegistration>(mockCredentialsStoreRegistration, bundle );
-        services.put(ICredentialsStoreRegistration.class.getName(),mockCredsRegRef);
-
-        // We need a confidential text service also...
-        Map<String,String> confidentialTextProps = new HashMap<String,String>();
-        MockConfidentialTextStore mockConfidentialTextStore = new MockConfidentialTextStore(confidentialTextProps);
-        MockConfidentialTextStoreRegistration mockConfidentialTextStoreRegistration = new MockConfidentialTextStoreRegistration(mockConfidentialTextStore);
-        MockServiceReference<IConfidentialTextServiceRegistration> mockConfidentialTextServiceRegRef = new MockServiceReference<IConfidentialTextServiceRegistration>(mockConfidentialTextStoreRegistration, bundle );
-        services.put(IConfidentialTextServiceRegistration.class.getName(),mockConfidentialTextServiceRegRef);
-        
         // When...
         FrameworkInitialisation frameworkInitUnderTest = new FrameworkInitialisation( 
             bootstrapProperties,  
@@ -139,6 +110,60 @@ public class TestFrameworkInitialisation {
         return frameworkInitUnderTest;
     }
 
+
+    private MockFramework addMockFrameworkToMockServiceRegistry(Map<String,MockServiceReference<?>> services, Bundle bundle) {
+        MockFramework mockFramework = new MockFramework();
+        MockServiceReference<IFramework> mockFrameworkRef = new MockServiceReference<IFramework>(mockFramework, bundle );
+        services.put(IFramework.class.getName(),mockFrameworkRef);
+        return mockFramework;
+    }
+
+    private void addMockCPSToMockServiceRegistery(Map<String,MockServiceReference<?>> services, Map<String,String> cpsProperties, Bundle bundle) {
+        MockCPSStore mockCPSStore = new MockCPSStore(cpsProperties);
+        MockCPSRegistration mockCPSRegistration = new MockCPSRegistration(mockCPSStore);
+        MockServiceReference<IConfigurationPropertyStoreRegistration> mockCPSRef = new MockServiceReference<IConfigurationPropertyStoreRegistration>(mockCPSRegistration, bundle );
+        services.put(IConfigurationPropertyStoreRegistration.class.getName(),mockCPSRef);
+    }
+
+    private MockDSSStore addMockDSSToMockServiceRegistry(Map<String,MockServiceReference<?>> services, Bundle bundle) {
+        Map<String,String> dssProps = new HashMap<String,String>();
+        MockDSSStore mockDSSStore = new MockDSSStore(dssProps);
+        MockDSSRegistration mockDSSRegistration = new MockDSSRegistration(mockDSSStore);
+        MockServiceReference<IDynamicStatusStoreRegistration> mockDSSRef = 
+            new MockServiceReference<IDynamicStatusStoreRegistration>(mockDSSRegistration, bundle );
+        services.put(IDynamicStatusStoreRegistration.class.getName(),mockDSSRef);
+        return mockDSSStore;
+    }
+
+    private MockRASStoreService addMockRASToMockServiceRegistry(Map<String,MockServiceReference<?>> services, Bundle bundle) {
+        Map<String,String> rasProps = new HashMap<String,String>();
+        MockRASStoreService mockRASStoreService = new MockRASStoreService(rasProps);
+        MockRASRegistration mockRASRegistration = new MockRASRegistration(mockRASStoreService);
+        MockServiceReference<IResultArchiveStoreRegistration> mockRASRef = 
+            new MockServiceReference<IResultArchiveStoreRegistration>(mockRASRegistration, bundle );
+        services.put(IResultArchiveStoreRegistration.class.getName(),mockRASRef);
+        return mockRASStoreService;
+    }
+
+    private MockCredentialsStore addMockCredentialsStoreToMockServiceRegistry(Map<String,MockServiceReference<?>> services, Bundle bundle) {
+        Map<String,ICredentials> credsProps = new HashMap<String,ICredentials>();
+        MockCredentialsStore mockCredentialsStore = new MockCredentialsStore(credsProps);
+        MockCredentialsStoreRegistration mockCredentialsStoreRegistration = new MockCredentialsStoreRegistration(mockCredentialsStore);
+        MockServiceReference<ICredentialsStoreRegistration> mockCredsRegRef = 
+            new MockServiceReference<ICredentialsStoreRegistration>(mockCredentialsStoreRegistration, bundle );
+        services.put(ICredentialsStoreRegistration.class.getName(),mockCredsRegRef);
+        return mockCredentialsStore;
+    }
+
+    private MockConfidentialTextStore addMockConfidentialTextServiceToMockServiceRegistry(Map<String,MockServiceReference<?>> services, Bundle bundle) {
+        Map<String,String> confidentialTextProps = new HashMap<String,String>();
+        MockConfidentialTextStore mockConfidentialTextStore = new MockConfidentialTextStore(confidentialTextProps);
+        MockConfidentialTextStoreRegistration mockConfidentialTextStoreRegistration = new MockConfidentialTextStoreRegistration(mockConfidentialTextStore);
+        MockServiceReference<IConfidentialTextServiceRegistration> mockConfidentialTextServiceRegRef = 
+            new MockServiceReference<IConfidentialTextServiceRegistration>(mockConfidentialTextStoreRegistration, bundle );
+        services.put(IConfidentialTextServiceRegistration.class.getName(),mockConfidentialTextServiceRegRef);
+        return mockConfidentialTextStore;
+    }
 
     // When no framework service has been found... should be an error.
     @Test

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockBundleContext.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockBundleContext.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright contributors to the Galasa project
+ */
+package dev.galasa.framework.mocks;
+
+import java.io.File;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.Dictionary;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleException;
+import org.osgi.framework.BundleListener;
+import org.osgi.framework.Filter;
+import org.osgi.framework.FrameworkListener;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceFactory;
+import org.osgi.framework.ServiceListener;
+import org.osgi.framework.ServiceObjects;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.ServiceRegistration;
+import org.apache.commons.logging.*;
+
+public class MockBundleContext implements BundleContext{
+
+    private Map<String,MockServiceReference<?>> services ;
+    private final static Log logger = LogFactory.getLog(MockBundleContext.class);
+
+
+    /**
+     * @param services A map. The key is the interface/class name. 
+     */
+    public MockBundleContext(Map<String,MockServiceReference<?>> services) {
+        this.services = services;
+    }
+
+    @Override
+    public String getProperty(String key) {
+        throw new UnsupportedOperationException("Unimplemented method 'getProperty'");
+    }
+
+    @Override
+    public Bundle getBundle() {
+        throw new UnsupportedOperationException("Unimplemented method 'getBundle'");
+    }
+
+    @Override
+    public Bundle installBundle(String location, InputStream input) throws BundleException {
+        throw new UnsupportedOperationException("Unimplemented method 'installBundle'");
+    }
+
+    @Override
+    public Bundle installBundle(String location) throws BundleException {
+        throw new UnsupportedOperationException("Unimplemented method 'installBundle'");
+    }
+
+    @Override
+    public Bundle getBundle(long id) {
+        throw new UnsupportedOperationException("Unimplemented method 'getBundle'");
+    }
+
+    @Override
+    public Bundle[] getBundles() {
+        throw new UnsupportedOperationException("Unimplemented method 'getBundles'");
+    }
+
+    @Override
+    public void addServiceListener(ServiceListener listener, String filter) throws InvalidSyntaxException {
+        throw new UnsupportedOperationException("Unimplemented method 'addServiceListener'");
+    }
+
+    @Override
+    public void addServiceListener(ServiceListener listener) {
+        throw new UnsupportedOperationException("Unimplemented method 'addServiceListener'");
+    }
+
+    @Override
+    public void removeServiceListener(ServiceListener listener) {
+        throw new UnsupportedOperationException("Unimplemented method 'removeServiceListener'");
+    }
+
+    @Override
+    public void addBundleListener(BundleListener listener) {
+        throw new UnsupportedOperationException("Unimplemented method 'addBundleListener'");
+    }
+
+    @Override
+    public void removeBundleListener(BundleListener listener) {
+        throw new UnsupportedOperationException("Unimplemented method 'removeBundleListener'");
+    }
+
+    @Override
+    public void addFrameworkListener(FrameworkListener listener) {
+        throw new UnsupportedOperationException("Unimplemented method 'addFrameworkListener'");
+    }
+
+    @Override
+    public void removeFrameworkListener(FrameworkListener listener) {
+        throw new UnsupportedOperationException("Unimplemented method 'removeFrameworkListener'");
+    }
+
+    @Override
+    public ServiceRegistration<?> registerService(String[] clazzes, Object service, Dictionary<String, ?> properties) {
+        throw new UnsupportedOperationException("Unimplemented method 'registerService'");
+    }
+
+    @Override
+    public ServiceRegistration<?> registerService(String clazz, Object service, Dictionary<String, ?> properties) {
+        throw new UnsupportedOperationException("Unimplemented method 'registerService'");
+    }
+
+    @Override
+    public <S> ServiceRegistration<S> registerService(Class<S> clazz, S service, Dictionary<String, ?> properties) {
+        throw new UnsupportedOperationException("Unimplemented method 'registerService'");
+    }
+
+    @Override
+    public <S> ServiceRegistration<S> registerService(Class<S> clazz, ServiceFactory<S> factory,
+            Dictionary<String, ?> properties) {
+        throw new UnsupportedOperationException("Unimplemented method 'registerService'");
+    }
+
+    @Override
+    public ServiceReference<?>[] getServiceReferences(String clazz, String filter) throws InvalidSyntaxException {
+        throw new UnsupportedOperationException("Unimplemented method 'getServiceReferences'");
+    }
+
+    @Override
+    public ServiceReference<?>[] getAllServiceReferences(String clazz, String filter) throws InvalidSyntaxException {
+        int count = 0;
+        for( Entry<String,MockServiceReference<?>> entry : this.services.entrySet() ) {
+            if(entry.getKey().equals(clazz)) {
+                count++;
+            }
+        }
+
+        ServiceReference<?>[] allServiceReferences = new ServiceReference<?>[count];
+
+        int i=0;
+        for( Entry<String,MockServiceReference<?>> entry : this.services.entrySet() ) {
+            if(entry.getKey().equals(clazz)) {
+                allServiceReferences[i] = entry.getValue();
+                i++;
+            }
+        }
+
+        return allServiceReferences;
+    }
+
+    @Override
+    public ServiceReference<?> getServiceReference(String clazz) {
+        logger.info("getServiceReference(String clazz="+clazz+")");
+        ServiceReference<?> ref = this.services.get(clazz);
+        return ref;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <S> ServiceReference<S> getServiceReference(Class<S> clazz) {
+        logger.info("getServiceReference(Class<S> clazz="+clazz.getName()+")");
+        String className = clazz.getName();
+        ServiceReference<S> result ;
+        
+        ServiceReference<?> rawRef = getServiceReference(className);
+
+        result = (ServiceReference<S>)rawRef;
+        return result;
+    }
+
+    @Override
+    public <S> Collection<ServiceReference<S>> getServiceReferences(Class<S> clazz, String filter)
+            throws InvalidSyntaxException {
+        throw new UnsupportedOperationException("Unimplemented method 'getServiceReferences'");
+    }
+
+    @Override
+    public <S> S getService(ServiceReference<S> reference) {
+        logger.info("getService(ServiceReference<S> reference="+reference.getClass().getName()+")");
+
+        S result = ((MockServiceReference<S>)reference).getService();
+        return result;
+    }
+
+    @Override
+    public boolean ungetService(ServiceReference<?> reference) {
+        throw new UnsupportedOperationException("Unimplemented method 'ungetService'");
+    }
+
+    @Override
+    public <S> ServiceObjects<S> getServiceObjects(ServiceReference<S> reference) {
+        throw new UnsupportedOperationException("Unimplemented method 'getServiceObjects'");
+    }
+
+    @Override
+    public File getDataFile(String filename) {
+        throw new UnsupportedOperationException("Unimplemented method 'getDataFile'");
+    }
+
+    @Override
+    public Filter createFilter(String filter) throws InvalidSyntaxException {
+        throw new UnsupportedOperationException("Unimplemented method 'createFilter'");
+    }
+
+    @Override
+    public Bundle getBundle(String location) {
+        throw new UnsupportedOperationException("Unimplemented method 'getBundle'");
+    }
+    
+}

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockBundleContext.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockBundleContext.java
@@ -22,13 +22,10 @@ import org.osgi.framework.ServiceListener;
 import org.osgi.framework.ServiceObjects;
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
-import org.apache.commons.logging.*;
 
 public class MockBundleContext implements BundleContext{
 
     private Map<String,MockServiceReference<?>> services ;
-    private final static Log logger = LogFactory.getLog(MockBundleContext.class);
-
 
     /**
      * @param services A map. The key is the interface/class name. 
@@ -152,7 +149,7 @@ public class MockBundleContext implements BundleContext{
 
     @Override
     public ServiceReference<?> getServiceReference(String clazz) {
-        logger.info("getServiceReference(String clazz="+clazz+")");
+        // logger.info("getServiceReference(String clazz="+clazz+")");
         ServiceReference<?> ref = this.services.get(clazz);
         return ref;
     }
@@ -160,7 +157,7 @@ public class MockBundleContext implements BundleContext{
     @SuppressWarnings("unchecked")
     @Override
     public <S> ServiceReference<S> getServiceReference(Class<S> clazz) {
-        logger.info("getServiceReference(Class<S> clazz="+clazz.getName()+")");
+        // logger.info("getServiceReference(Class<S> clazz="+clazz.getName()+")");
         String className = clazz.getName();
         ServiceReference<S> result ;
         
@@ -178,7 +175,7 @@ public class MockBundleContext implements BundleContext{
 
     @Override
     public <S> S getService(ServiceReference<S> reference) {
-        logger.info("getService(ServiceReference<S> reference="+reference.getClass().getName()+")");
+        // logger.info("getService(ServiceReference<S> reference="+reference.getClass().getName()+")");
 
         S result = ((MockServiceReference<S>)reference).getService();
         return result;

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockCPSRegistration.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockCPSRegistration.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright contributors to the Galasa project
+ */
+package dev.galasa.framework.mocks;
+
+import javax.validation.constraints.NotNull;
+import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
+import dev.galasa.framework.spi.IConfigurationPropertyStore;
+import dev.galasa.framework.spi.IConfigurationPropertyStoreRegistration;
+import dev.galasa.framework.spi.IFrameworkInitialisation;
+
+public class MockCPSRegistration implements IConfigurationPropertyStoreRegistration {
+
+    private IConfigurationPropertyStore store ;
+
+    public MockCPSRegistration(IConfigurationPropertyStore store) {
+        this.store = store ;
+    }
+
+    @Override
+    public void initialise(@NotNull IFrameworkInitialisation frameworkInitialisation)
+            throws ConfigurationPropertyStoreException {
+
+        frameworkInitialisation.registerConfigurationPropertyStore(store);
+    }
+
+}

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockCPSStore.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockCPSStore.java
@@ -3,6 +3,7 @@
  */
 package dev.galasa.framework.mocks;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -11,12 +12,13 @@ import javax.validation.constraints.Null;
 
 import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
 import dev.galasa.framework.spi.IConfigurationPropertyStore;
+import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
 
-public class MockCPSStore implements IConfigurationPropertyStore {
+public class MockCPSStore implements IConfigurationPropertyStore, IConfigurationPropertyStoreService {
 
     Map<String,String> properties ;
 
-    public MockCPSStore( Map<String,String> properties ) {
+    public MockCPSStore(@NotNull Map<String,String> properties ) {
         this.properties = properties ;
     }
 
@@ -28,38 +30,82 @@ public class MockCPSStore implements IConfigurationPropertyStore {
     @Override
     public @NotNull Map<String, String> getPrefixedProperties(@NotNull String prefix)
             throws ConfigurationPropertyStoreException {
-        // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'getPrefixedProperties'");
     }
 
     @Override
     public void setProperty(@NotNull String key, @NotNull String value) throws ConfigurationPropertyStoreException {
-        // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'setProperty'");
     }
 
     @Override
     public void deleteProperty(@NotNull String key) throws ConfigurationPropertyStoreException {
-        // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'deleteProperty'");
     }
 
     @Override
     public Map<String, String> getPropertiesFromNamespace(String namespace) {
-        // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'getPropertiesFromNamespace'");
     }
 
     @Override
     public List<String> getNamespaces() {
-        // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'getNamespaces'");
     }
 
     @Override
     public void shutdown() throws ConfigurationPropertyStoreException {
-        // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'shutdown'");
+    }
+
+    @Override
+    public @Null String getProperty(@NotNull String prefix, @NotNull String suffix, String... infixes)
+            throws ConfigurationPropertyStoreException {
+
+        String result = null ;
+
+        List<String> infixList = new ArrayList<>();
+        for (String infix : infixes ) {
+            infixList.add(infix);
+        }
+
+        infixList.add("");
+
+        for (String infix : infixList ) {
+            String key ;
+            if (infix.trim().isEmpty()) {
+                key = prefix + "." + suffix;
+            } else {
+                key = prefix + "." + infix + "." + suffix;
+            }
+            String prop = this.properties.get(key);
+            if (prop != null) {
+                result = prop;
+                break;
+            }
+        }
+
+        return result;
+    }
+
+    @Override
+    public Map<String, String> getAllProperties() {
+        throw new UnsupportedOperationException("Unimplemented method 'getAllProperties'");
+    }
+
+    @Override
+    public String[] reportPropertyVariants(@NotNull String prefix, @NotNull String suffix, String... infixes) {
+        throw new UnsupportedOperationException("Unimplemented method 'reportPropertyVariants'");
+    }
+
+    @Override
+    public String reportPropertyVariantsString(@NotNull String prefix, @NotNull String suffix, String... infixes) {
+        throw new UnsupportedOperationException("Unimplemented method 'reportPropertyVariantsString'");
+    }
+
+    @Override
+    public List<String> getCPSNamespaces() {
+        throw new UnsupportedOperationException("Unimplemented method 'getCPSNamespaces'");
     }
 
 }

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockCPSStore.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockCPSStore.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright contributors to the Galasa project
+ */
+package dev.galasa.framework.mocks;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Null;
+
+import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
+import dev.galasa.framework.spi.IConfigurationPropertyStore;
+
+public class MockCPSStore implements IConfigurationPropertyStore {
+
+    Map<String,String> properties ;
+
+    public MockCPSStore( Map<String,String> properties ) {
+        this.properties = properties ;
+    }
+
+    @Override
+    public @Null String getProperty(@NotNull String key) throws ConfigurationPropertyStoreException {
+        return this.properties.get(key);
+    }
+
+    @Override
+    public @NotNull Map<String, String> getPrefixedProperties(@NotNull String prefix)
+            throws ConfigurationPropertyStoreException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'getPrefixedProperties'");
+    }
+
+    @Override
+    public void setProperty(@NotNull String key, @NotNull String value) throws ConfigurationPropertyStoreException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'setProperty'");
+    }
+
+    @Override
+    public void deleteProperty(@NotNull String key) throws ConfigurationPropertyStoreException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'deleteProperty'");
+    }
+
+    @Override
+    public Map<String, String> getPropertiesFromNamespace(String namespace) {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'getPropertiesFromNamespace'");
+    }
+
+    @Override
+    public List<String> getNamespaces() {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'getNamespaces'");
+    }
+
+    @Override
+    public void shutdown() throws ConfigurationPropertyStoreException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'shutdown'");
+    }
+
+}

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockConfidentialTextStore.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockConfidentialTextStore.java
@@ -17,19 +17,16 @@ public class MockConfidentialTextStore implements IConfidentialTextService {
 
     @Override
     public void registerText(String confidentialString, String comment) {
-        // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'registerText'");
     }
 
     @Override
     public String removeConfidentialText(String text) {
-        // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'removeConfidentialText'");
     }
 
     @Override
     public void shutdown() {
-        // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'shutdown'");
     }
 

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockConfidentialTextStore.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockConfidentialTextStore.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright contributors to the Galasa project
+ */
+package dev.galasa.framework.mocks;
+
+import java.util.Map;
+
+import dev.galasa.framework.spi.IConfidentialTextService;
+
+public class MockConfidentialTextStore implements IConfidentialTextService {
+
+    // private Map<String, String> confidentialTextProps;
+
+    public MockConfidentialTextStore(Map<String, String> confidentialTextProps) {
+        // this.confidentialTextProps = confidentialTextProps;
+    }
+
+    @Override
+    public void registerText(String confidentialString, String comment) {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'registerText'");
+    }
+
+    @Override
+    public String removeConfidentialText(String text) {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'removeConfidentialText'");
+    }
+
+    @Override
+    public void shutdown() {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'shutdown'");
+    }
+
+}

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockConfidentialTextStoreRegistration.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockConfidentialTextStoreRegistration.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright contributors to the Galasa project
+ */
+package dev.galasa.framework.mocks;
+
+import javax.validation.constraints.NotNull;
+
+import dev.galasa.framework.spi.ConfidentialTextException;
+import dev.galasa.framework.spi.IConfidentialTextService;
+import dev.galasa.framework.spi.IConfidentialTextServiceRegistration;
+import dev.galasa.framework.spi.IFrameworkInitialisation;
+
+public class MockConfidentialTextStoreRegistration implements IConfidentialTextServiceRegistration {
+
+    private IConfidentialTextService service ;
+
+    public MockConfidentialTextStoreRegistration(IConfidentialTextService service) {
+        this.service = service ;
+    }
+
+    @Override
+    public void initialise(@NotNull IFrameworkInitialisation frameworkInitialisation) throws ConfidentialTextException {
+        frameworkInitialisation.registerConfidentialTextService(service);
+    }
+
+}

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockCredentials.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockCredentials.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright contributors to the Galasa project
+ */
+package dev.galasa.framework.mocks;
+
+import dev.galasa.ICredentials;
+
+class MockCredentials implements ICredentials {
+};

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockCredentialsStore.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockCredentialsStore.java
@@ -27,7 +27,6 @@ public class MockCredentialsStore implements ICredentialsStore {
 
     @Override
     public void shutdown() throws CredentialsException {
-        // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'shutdown'");
     }
 

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockCredentialsStore.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockCredentialsStore.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright contributors to the Galasa project
+ */
+package dev.galasa.framework.mocks;
+
+import java.util.*;
+
+import javax.validation.constraints.NotNull;
+
+import dev.galasa.ICredentials;
+import dev.galasa.framework.spi.creds.CredentialsException;
+import dev.galasa.framework.spi.creds.ICredentialsStore;
+
+public class MockCredentialsStore implements ICredentialsStore {
+
+
+    Map<String,ICredentials> creds ;
+
+    public MockCredentialsStore(Map<String,ICredentials> creds) {
+        this.creds = creds ;
+    }
+
+    @Override
+    public ICredentials getCredentials(@NotNull String credentialsId) throws CredentialsException {
+        return this.creds.get(credentialsId);
+    }
+
+    @Override
+    public void shutdown() throws CredentialsException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'shutdown'");
+    }
+
+}

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockCredentialsStoreRegistration.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockCredentialsStoreRegistration.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright contributors to the Galasa project
+ */
+package dev.galasa.framework.mocks;
+
+import javax.validation.constraints.NotNull;
+
+
+import dev.galasa.framework.spi.IFrameworkInitialisation;
+import dev.galasa.framework.spi.creds.CredentialsException;
+import dev.galasa.framework.spi.creds.ICredentialsStore;
+import dev.galasa.framework.spi.creds.ICredentialsStoreRegistration;
+
+public class MockCredentialsStoreRegistration implements ICredentialsStoreRegistration {
+
+    private ICredentialsStore store ;
+
+    public MockCredentialsStoreRegistration(ICredentialsStore store ){
+        this.store = store ;
+    }
+
+    @Override
+    public void initialise(@NotNull IFrameworkInitialisation frameworkInitialisation) throws CredentialsException {
+        frameworkInitialisation.registerCredentialsStore(store);
+    }
+
+}

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockDSSRegistration.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockDSSRegistration.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright contributors to the Galasa project
+ */
+package dev.galasa.framework.mocks;
+
+import javax.validation.constraints.NotNull;
+import dev.galasa.framework.spi.DynamicStatusStoreException;
+import dev.galasa.framework.spi.IDynamicStatusStore;
+import dev.galasa.framework.spi.IDynamicStatusStoreRegistration;
+import dev.galasa.framework.spi.IFrameworkInitialisation;
+
+public class MockDSSRegistration implements IDynamicStatusStoreRegistration {
+
+    private IDynamicStatusStore store ;
+
+    public MockDSSRegistration(IDynamicStatusStore store) {
+        this.store = store ;
+    }
+
+    @Override
+    public void initialise(
+        @NotNull IFrameworkInitialisation frameworkInitialisation
+    ) throws DynamicStatusStoreException {
+
+        frameworkInitialisation.registerDynamicStatusStore(store);
+    }
+
+}

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockDSSStore.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockDSSStore.java
@@ -30,13 +30,11 @@ public class MockDSSStore implements IDynamicStatusStore {
 
     @Override
     public void put(@NotNull String key, @NotNull String value) throws DynamicStatusStoreException {
-        // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'put'");
     }
 
     @Override
     public void put(@NotNull Map<String, String> keyValues) throws DynamicStatusStoreException {
-        // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'put'");
     }
 
@@ -77,50 +75,42 @@ public class MockDSSStore implements IDynamicStatusStore {
 
     @Override
     public void delete(@NotNull String key) throws DynamicStatusStoreException {
-        // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'delete'");
     }
 
     @Override
     public void delete(@NotNull Set<String> keys) throws DynamicStatusStoreException {
-        // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'delete'");
     }
 
     @Override
     public void deletePrefix(@NotNull String keyPrefix) throws DynamicStatusStoreException {
-        // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'deletePrefix'");
     }
 
     @Override
     public void performActions(IDssAction... actions)
             throws DynamicStatusStoreException, DynamicStatusStoreMatchException {
-        // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'performActions'");
     }
 
     @Override
     public UUID watch(IDynamicStatusStoreWatcher watcher, String key) throws DynamicStatusStoreException {
-        // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'watch'");
     }
 
     @Override
     public UUID watchPrefix(IDynamicStatusStoreWatcher watcher, String keyPrefix) throws DynamicStatusStoreException {
-        // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'watchPrefix'");
     }
 
     @Override
     public void unwatch(UUID watchId) throws DynamicStatusStoreException {
-        // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'unwatch'");
     }
 
     @Override
     public void shutdown() throws DynamicStatusStoreException {
-        // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'shutdown'");
     }
     

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockDSSStore.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockDSSStore.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright contributors to the Galasa project
+ */
+package dev.galasa.framework.mocks;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Null;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import dev.galasa.framework.spi.DynamicStatusStoreException;
+import dev.galasa.framework.spi.DynamicStatusStoreMatchException;
+import dev.galasa.framework.spi.IDssAction;
+import dev.galasa.framework.spi.IDynamicStatusStore;
+import dev.galasa.framework.spi.IDynamicStatusStoreWatcher;
+
+public class MockDSSStore implements IDynamicStatusStore {
+
+    private Map<String,String> valueMap ;
+    private Log logger = LogFactory.getLog(MockDSSStore.class.getName());
+    public MockDSSStore(Map<String,String> valueMap) {
+        this.valueMap = valueMap;
+    }
+
+    @Override
+    public void put(@NotNull String key, @NotNull String value) throws DynamicStatusStoreException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'put'");
+    }
+
+    @Override
+    public void put(@NotNull Map<String, String> keyValues) throws DynamicStatusStoreException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'put'");
+    }
+
+    @Override
+    public boolean putSwap(@NotNull String key, String oldValue, @NotNull String newValue)
+            throws DynamicStatusStoreException {
+        logger.debug("DSS putswap of property "+key+" oldValue:"+oldValue+" newValue:"+newValue);
+        valueMap.put(key,newValue);
+        return true;
+    }
+
+    @Override
+    public boolean putSwap(@NotNull String key, String oldValue, @NotNull String newValue,
+            @NotNull Map<String, String> others) throws DynamicStatusStoreException {
+        logger.debug("DSS putswap of property "+key+" oldValue:"+oldValue+" newValue:"+newValue);
+        valueMap.put(key,newValue);
+        return true;
+    }
+
+    @Override
+    public @Null String get(@NotNull String key) throws DynamicStatusStoreException {
+        String value = valueMap.get(key);
+        logger.debug("DSS get of property "+key+" returning "+value);
+        return value;
+    }
+
+    @Override
+    public @NotNull Map<String, String> getPrefix(@NotNull String keyPrefix) throws DynamicStatusStoreException {
+        Map<String, String> results = new HashMap<String,String>();
+        for (String key : valueMap.keySet()){
+            if (key.startsWith(keyPrefix+".")){
+                results.put(key,valueMap.get(key));
+            }
+        }
+        logger.debug("DSS getPrefix of property "+keyPrefix+" returning "+results.toString());
+        return results;
+    }
+
+    @Override
+    public void delete(@NotNull String key) throws DynamicStatusStoreException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'delete'");
+    }
+
+    @Override
+    public void delete(@NotNull Set<String> keys) throws DynamicStatusStoreException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'delete'");
+    }
+
+    @Override
+    public void deletePrefix(@NotNull String keyPrefix) throws DynamicStatusStoreException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'deletePrefix'");
+    }
+
+    @Override
+    public void performActions(IDssAction... actions)
+            throws DynamicStatusStoreException, DynamicStatusStoreMatchException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'performActions'");
+    }
+
+    @Override
+    public UUID watch(IDynamicStatusStoreWatcher watcher, String key) throws DynamicStatusStoreException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'watch'");
+    }
+
+    @Override
+    public UUID watchPrefix(IDynamicStatusStoreWatcher watcher, String keyPrefix) throws DynamicStatusStoreException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'watchPrefix'");
+    }
+
+    @Override
+    public void unwatch(UUID watchId) throws DynamicStatusStoreException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'unwatch'");
+    }
+
+    @Override
+    public void shutdown() throws DynamicStatusStoreException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'shutdown'");
+    }
+    
+}

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockEnvironment.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockEnvironment.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright contributors to the Galasa project 
+ */
+package dev.galasa.framework.mocks;
+
+import java.util.*;
+
+import dev.galasa.framework.Environment;
+
+/**
+ * An implementation of the Environment interface which allows code to get
+ * environment variables and system properties from the real system.
+ */
+public class MockEnvironment implements Environment {
+
+    Map<String,String> envProps ;
+    Map<String,String> sysProps ;
+
+    public MockEnvironment(Map<String,String> envProps,Map<String,String> sysProps) {
+        this.envProps = envProps;
+        this.sysProps = sysProps;
+    }
+
+    public MockEnvironment() {
+        this.envProps = new HashMap<String,String>();
+        this.sysProps = new HashMap<String,String>();
+    }
+
+    public void setenv(String propertyName, String value ) {
+        this.envProps.put(propertyName, value);
+    }
+
+    public void setProperty(String propertyName, String value) {
+        this.sysProps.put(propertyName,value);
+    }
+
+    @Override
+    public String getenv(String propertyName) {
+        return this.envProps.get(propertyName);
+    }
+
+    @Override
+    public String getProperty(String propertyName) {
+        return this.sysProps.get(propertyName);
+    }
+
+
+    
+}

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockFileSystem.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockFileSystem.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright contributors to the Galasa project
+ */
+package dev.galasa.framework.mocks;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import dev.galasa.framework.IFileSystem;
+
+public class MockFileSystem implements IFileSystem {
+
+    private static class Node {
+        // Path path;
+        boolean isFolder ;
+        byte[] contents ;
+    }
+
+    private Map<String,Node> files = new HashMap<>();
+
+    public boolean isFolder(Path folderPath) {
+        boolean isFolder = false ;
+        Node node = files.get(folderPath.toString());
+        if (node != null) {
+            isFolder = node.isFolder;
+        }
+        return isFolder;
+    }
+
+    public byte[] getContentsAsBytes(Path filePath) {
+        Node node = files.get(filePath.toString());
+        byte[] results = null; 
+        if (node != null) {
+            results = node.contents;
+        }
+        return results;
+    }
+
+    public String getContentsAsString(Path filePath) {
+        byte[] bytes = getContentsAsBytes(filePath);
+        String results = null;
+        if (bytes != null ) {
+            results = new String(bytes);
+        }
+        return results;
+    }
+
+    @Override
+    public void createDirectories(Path folderPath) throws IOException {
+        if (folderPath!=null) {
+            if(!exists(folderPath)) {
+                // Recursively make sure the parent folder exists.
+                Path parent = folderPath.getParent();
+                createDirectories(parent);
+                // Now create this folder.
+                createNode(folderPath, false);
+            }
+        }
+    }
+
+    @Override
+    public void createFile(Path path) throws IOException {
+        if (exists(path)) {
+            throw new IOException("File "+path.toString()+" already exists!");
+        }
+        createNode(path, false);
+    }
+
+    private void createNode(Path path, boolean isFolder) {
+        Node node = new Node();
+        node.isFolder = isFolder ;
+        node.contents = new byte[0];
+        // node.path = path ;
+        files.put(path.toString(),node);
+    }
+
+    @Override
+    public boolean exists(Path pathToFolderOrFile) {
+        boolean isExists ;
+        Node node = this.files.get(pathToFolderOrFile.toString());
+        if (node == null) {
+            isExists = false ;
+        } else {
+            isExists = true ;
+        }
+        return isExists;
+    }
+
+}

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockFramework.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockFramework.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright contributors to the Galasa project
+ */
+package dev.galasa.framework.mocks;
+
+import dev.galasa.framework.Framework;
+
+public class MockFramework extends Framework {
+
+   
+}

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockLog.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockLog.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright contributors to the Galasa project 
+ */
+package dev.galasa.framework.mocks;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+
+public class MockLog implements Log {
+
+    public static final Throwable NO_THROWABLE = null;
+
+    private boolean isDebugEnabled = true ;
+    private boolean isErrorEnabled = true ;
+    private boolean isFatalEnabled = true ;
+    private boolean isInfoEnabled  = true ;
+    private boolean isWarnEnabled  = true ;
+    private boolean isTraceEnabled = true ;
+
+    List<MockLogRecord> lines = new LinkedList<MockLogRecord>();
+
+    public MockLog() {
+        this(true,true,true,true,true,true);
+    }
+
+    public MockLog(
+        boolean isDebugEnabled, 
+        boolean isErrorEnabled, 
+        boolean isFatalEnabled, 
+        boolean isInfoEnabled, 
+        boolean isWarnEnabled,
+        boolean isTraceEnabled) {
+        this.isDebugEnabled = isDebugEnabled;
+        this.isErrorEnabled = isErrorEnabled;
+        this.isFatalEnabled = isFatalEnabled;
+        this.isInfoEnabled = isInfoEnabled;
+        this.isWarnEnabled = isWarnEnabled ;
+        this.isTraceEnabled = isTraceEnabled;
+    }
+
+    @Override
+    public void debug(Object message) {
+        this.debug(message,null);
+    }
+
+    @Override
+    public void debug(Object message, Throwable t) {
+        MockLogRecord record = new MockLogRecord(MockLogRecordType.DEBUG , message, t);
+        lines.add(record);
+    }
+
+    @Override
+    public void error(Object message) {
+        MockLogRecord record = new MockLogRecord(MockLogRecordType.ERROR , message, NO_THROWABLE);
+        lines.add(record);
+    }
+
+    @Override
+    public void error(Object message, Throwable t) {
+        MockLogRecord record = new MockLogRecord(MockLogRecordType.ERROR , message, t);
+        lines.add(record);
+    }
+
+    @Override
+    public void fatal(Object message) {
+        MockLogRecord record = new MockLogRecord(MockLogRecordType.FATAL , message, NO_THROWABLE);
+        lines.add(record);
+    }
+
+    @Override
+    public void fatal(Object message, Throwable t) {
+        MockLogRecord record = new MockLogRecord(MockLogRecordType.FATAL , message, t);
+        lines.add(record);
+    }
+
+    @Override
+    public void info(Object message) {
+        MockLogRecord record = new MockLogRecord(MockLogRecordType.INFO , message, NO_THROWABLE);
+        lines.add(record);
+    }
+
+    @Override
+    public void info(Object message, Throwable t) {
+        MockLogRecord record = new MockLogRecord(MockLogRecordType.FATAL , message, t);
+        lines.add(record);
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        return this.isDebugEnabled;
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        return this.isErrorEnabled;
+    }
+
+    @Override
+    public boolean isFatalEnabled() {
+        return this.isFatalEnabled;
+    }
+
+    @Override
+    public boolean isInfoEnabled() {
+        return this.isInfoEnabled;
+    }
+
+    @Override
+    public boolean isTraceEnabled() {
+        return this.isTraceEnabled;
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return this.isWarnEnabled;
+    }
+
+    @Override
+    public void trace(Object message) {
+        MockLogRecord record = new MockLogRecord(MockLogRecordType.TRACE , message, NO_THROWABLE);
+        lines.add(record);
+    }
+
+    @Override
+    public void trace(Object message, Throwable t) {
+        MockLogRecord record = new MockLogRecord(MockLogRecordType.TRACE , message, t);
+        lines.add(record);
+    }
+
+    @Override
+    public void warn(Object message) {
+        MockLogRecord record = new MockLogRecord(MockLogRecordType.WARN , message, NO_THROWABLE);
+        lines.add(record);
+    }
+
+    @Override
+    public void warn(Object message, Throwable t) {
+        MockLogRecord record = new MockLogRecord(MockLogRecordType.WARN , message, t);
+        lines.add(record);
+    }
+
+    public void setDebugEnabled(boolean isDebugEnabled) {
+        this.isDebugEnabled = isDebugEnabled;
+    }
+
+    public void setErrorEnabled(boolean isErrorEnabled) {
+        this.isErrorEnabled = isErrorEnabled;
+    }
+
+    public void setFatalEnabled(boolean isFatalEnabled) {
+        this.isFatalEnabled = isFatalEnabled;
+    }
+
+    public void setInfoEnabled(boolean isInfoEnabled) {
+        this.isInfoEnabled = isInfoEnabled;
+    }
+
+    public void setWarnEnabled(boolean isWarnEnabled) {
+        this.isWarnEnabled = isWarnEnabled;
+    }
+
+    public void setTraceEnabled(boolean isTraceEnabled) {
+        this.isTraceEnabled = isTraceEnabled;
+    }
+
+    public boolean contains(String containsSubString) {
+        boolean contains = false ;
+        for (MockLogRecord record : lines) {
+            contains = record.getContent().contains(containsSubString);
+            if (contains) {
+                break;
+            }
+        }
+        return contains;
+    }
+    
+}

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockLogRecord.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockLogRecord.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright contributors to the Galasa project 
+ */
+package dev.galasa.framework.mocks;
+
+/** A record collected from the log interface, by the MockLog class. */
+public class MockLogRecord {
+
+
+
+    private String content ;
+    private MockLogRecordType type ;
+    private Throwable t ;
+
+    public MockLogRecord( MockLogRecordType type, Object content , Throwable t) {
+        this.type = type ;
+
+        String messageText = "";
+        if (content != null) {
+            messageText = content.toString();
+        }
+        this.content = messageText ;
+        this.t = t ;
+    }
+
+    public String getContent() {
+        return this.content;
+    }
+
+    public MockLogRecordType getType() {
+        return this.type;
+    }
+
+    public Throwable getThrowable() {
+        return this.t;
+    }
+}

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockLogRecordType.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockLogRecordType.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright contributors to the Galasa project 
+ */
+package dev.galasa.framework.mocks;
+
+public enum MockLogRecordType {
+    DEBUG, ERROR, FATAL, INFO, WARN, TRACE
+}

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockRASRegistration.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockRASRegistration.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright contributors to the Galasa project
+ */
+package dev.galasa.framework.mocks;
+
+import javax.validation.constraints.NotNull;
+import dev.galasa.framework.spi.IFrameworkInitialisation;
+import dev.galasa.framework.spi.IResultArchiveStoreRegistration;
+import dev.galasa.framework.spi.IResultArchiveStoreService;
+import dev.galasa.framework.spi.ResultArchiveStoreException;
+
+public class MockRASRegistration implements IResultArchiveStoreRegistration {
+
+    private @NotNull IResultArchiveStoreService storeService ;
+
+    public MockRASRegistration(IResultArchiveStoreService storeService) {
+        this.storeService = storeService ;
+    }
+
+    @Override
+    public void initialise(@NotNull IFrameworkInitialisation frameworkInitialisation)
+            throws ResultArchiveStoreException {
+
+        frameworkInitialisation.registerResultArchiveStoreService(storeService);
+    }
+
+}

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockRASStoreService.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockRASStoreService.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright contributors to the Galasa project
+ */
+package dev.galasa.framework.mocks;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import javax.validation.constraints.NotNull;
+import dev.galasa.framework.spi.IResultArchiveStoreDirectoryService;
+import dev.galasa.framework.spi.IResultArchiveStoreService;
+import dev.galasa.framework.spi.ResultArchiveStoreException;
+import dev.galasa.framework.spi.teststructure.TestStructure;
+
+public class MockRASStoreService implements IResultArchiveStoreService{
+
+    Map<String,String> properties ;
+
+    public MockRASStoreService( Map<String,String> properties ) {
+        this.properties = properties ;
+    }
+
+    @Override
+    public void writeLog(@NotNull String message) throws ResultArchiveStoreException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'writeLog'");
+    }
+
+    @Override
+    public void writeLog(@NotNull List<String> messages) throws ResultArchiveStoreException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'writeLog'");
+    }
+
+    @Override
+    public void updateTestStructure(@NotNull TestStructure testStructure) throws ResultArchiveStoreException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'updateTestStructure'");
+    }
+
+    @Override
+    public Path getStoredArtifactsRoot() {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'getStoredArtifactsRoot'");
+    }
+
+    @Override
+    public void flush() {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'flush'");
+    }
+
+    @Override
+    public void shutdown() {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'shutdown'");
+    }
+
+    @Override
+    public @NotNull List<IResultArchiveStoreDirectoryService> getDirectoryServices() {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'getDirectoryServices'");
+    }
+
+    @Override
+    public String calculateRasRunId() {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'calculateRasRunId'");
+    }
+
+    
+}

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockRASStoreService.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockRASStoreService.java
@@ -23,49 +23,41 @@ public class MockRASStoreService implements IResultArchiveStoreService{
 
     @Override
     public void writeLog(@NotNull String message) throws ResultArchiveStoreException {
-        // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'writeLog'");
     }
 
     @Override
     public void writeLog(@NotNull List<String> messages) throws ResultArchiveStoreException {
-        // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'writeLog'");
     }
 
     @Override
     public void updateTestStructure(@NotNull TestStructure testStructure) throws ResultArchiveStoreException {
-        // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'updateTestStructure'");
     }
 
     @Override
     public Path getStoredArtifactsRoot() {
-        // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'getStoredArtifactsRoot'");
     }
 
     @Override
     public void flush() {
-        // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'flush'");
     }
 
     @Override
     public void shutdown() {
-        // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'shutdown'");
     }
 
     @Override
     public @NotNull List<IResultArchiveStoreDirectoryService> getDirectoryServices() {
-        // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'getDirectoryServices'");
     }
 
     @Override
     public String calculateRasRunId() {
-        // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'calculateRasRunId'");
     }
 

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockServiceReference.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockServiceReference.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright contributors to the Galasa project 
+ */
+package dev.galasa.framework.mocks;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.ServiceReference;
+
+public class MockServiceReference<T> implements ServiceReference<T> {
+
+    private T service;
+    private Bundle bundle ;
+
+    public MockServiceReference(T service, Bundle bundle) {
+        this.bundle = bundle;
+        this.service = service;
+    }
+
+    public T getService() {
+        return this.service;
+    }
+
+    @Override
+    public Object getProperty(String key) {
+        throw new UnsupportedOperationException("Unimplemented method 'getProperty'");
+    }
+
+    @Override
+    public String[] getPropertyKeys() {
+        throw new UnsupportedOperationException("Unimplemented method 'getPropertyKeys'");
+    }
+
+    @Override
+    public Bundle getBundle() {
+        return this.bundle;
+    }
+
+    @Override
+    public Bundle[] getUsingBundles() {
+        throw new UnsupportedOperationException("Unimplemented method 'getUsingBundles'");
+    }
+
+    @Override
+    public boolean isAssignableTo(Bundle bundle, String className) {
+        throw new UnsupportedOperationException("Unimplemented method 'isAssignableTo'");
+    }
+
+    @Override
+    public int compareTo(Object reference) {
+        throw new UnsupportedOperationException("Unimplemented method 'compareTo'");
+    }
+    
+}


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

This PR relates to https://github.com/galasa-dev/projectmanagement/issues/1397 

- [x] Set of mock objects capable of mocking the underside of the framework init code.
- [x] Broke the massive constructor (200+ lines) into smaller functions which can be unit tested in isolation. 
- [x] Less reliance on this.xxx in all methods, which made things very interlocked.
- [x] Added `IFileSystem` to isolate the code from access to `nio.filesystem`. So file and folder create operations can be mocked-out.
- [x] Added `IEnvironment` to isolate the code from `System.getenv()` and `System.getProperty()` calls.