### PR TITLE
Add constructor with logger param

### DIFF
--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkInitialisation.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkInitialisation.java
@@ -55,6 +55,17 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
     }
 
 
+    public FrameworkInitialisation(
+        Properties bootstrapProperties, 
+        Properties overrideProperties,
+        boolean testrun,
+        Log initLogger
+    ) throws URISyntaxException, InvalidSyntaxException, FrameworkException {
+        this(bootstrapProperties, overrideProperties, testrun, initLogger, 
+        new SystemEnvironment(), getBundleContext(), new FileSystem());
+    }
+
+
     private static BundleContext getBundleContext() {
         return FrameworkUtil.getBundle(FrameworkInitialisation.class).getBundleContext();
     }


### PR DESCRIPTION
The Framework Initialisation constructor was changed recently but was being used by the Eclipse plugin (see https://github.com/galasa-dev/eclipse/blob/main/galasa-eclipse-parent/dev.galasa.eclipse/src/dev/galasa/eclipse/framework/management/InitialiseFrameworkJob.java#L67-L68). This change will fix compilation errors when building the Eclipse plugin.