### PR TITLE
Gradle needs to work in vscode.

### DIFF
--- a/galasa-parent/dev.galasa.framework.api.ras/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api.ras/build.gradle
@@ -2,6 +2,9 @@ plugins {
     id 'biz.aQute.bnd.builder'
     id 'org.openapi.generator' version "5.0.1"
     id 'galasa.api.server'
+
+    // testCompile requires Java plugin.
+    id 'java'
 }
 
 description = 'Galasa API - RAS'


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

I was finding that without this java dependency being declared, vscode stopped parsing all java files within the framework repo... stopping me working on that code.
