### PR TITLE
Add artifacts.json to root artifacts and fix artifacts.properties

### DIFF
--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/commons/ArtifactsJson.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/commons/ArtifactsJson.java
@@ -6,33 +6,36 @@ package dev.galasa.framework.api.ras.internal.commons;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
+import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 
 import dev.galasa.framework.api.ras.internal.routes.RunsRoute;
 import dev.galasa.framework.spi.IRunResult;
 import dev.galasa.framework.spi.ResultArchiveStoreException;
+import dev.galasa.framework.spi.utils.GalasaGsonBuilder;
 
-public class ArtifactPropertiesArtifact implements IRunRootArtifact {
+public class ArtifactsJson implements IRunRootArtifact {
 
     private RunsRoute runsRoute;
+    static final Gson gson = GalasaGsonBuilder.build();
 
-    public ArtifactPropertiesArtifact(RunsRoute runsRoute) {
+    public ArtifactsJson(RunsRoute runsRoute) {
         this.runsRoute = runsRoute;
     }
 
     @Override
     public byte[] getContent(IRunResult run) throws ResultArchiveStoreException, IOException {
-        JsonArray artifactProperties = runsRoute.getArtifacts(run);
-        return artifactProperties.toString().getBytes(StandardCharsets.UTF_8);
+        JsonArray artifactsJson = runsRoute.getArtifacts(run);
+        return gson.toJson(artifactsJson).getBytes(StandardCharsets.UTF_8);
     }
 
     @Override
     public String getContentType() {
-        return "text/plain";
+        return "application/json";
     }
 
     @Override
     public String getPathName() {
-        return "/artifacts.properties";
+        return "/artifacts.json";
     }
 }

--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/commons/ArtifactsProperties.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/commons/ArtifactsProperties.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright contributors to the Galasa project
+ */
+package dev.galasa.framework.api.ras.internal.commons;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import dev.galasa.framework.api.ras.internal.routes.RunsRoute;
+import dev.galasa.framework.spi.IRunResult;
+import dev.galasa.framework.spi.ResultArchiveStoreException;
+
+public class ArtifactsProperties implements IRunRootArtifact {
+
+    private RunsRoute runsRoute;
+
+    public ArtifactsProperties(RunsRoute runsRoute) {
+        this.runsRoute = runsRoute;
+    }
+
+    @Override
+    public byte[] getContent(IRunResult run) throws ResultArchiveStoreException, IOException {
+        JsonArray artifactsJson = runsRoute.getArtifacts(run);
+
+        // Convert JSON array into a map of key-value pairs, where keys are paths and values are artifact content types,
+        // to match the generated artifacts.properties files.
+        Map<String, String> artifactsProperties = new HashMap<>();
+        for (JsonElement element : artifactsJson) {
+            JsonObject artifactObject = element.getAsJsonObject();
+            
+            artifactsProperties.put(artifactObject.get("path").getAsString(), artifactObject.get("contentType").getAsString());
+        }
+        
+        // Convert the map to a string, where keys and values are separated by =, and
+        // each entry is written on a separate line.
+        String artifactsPropertiesStr = artifactsProperties.entrySet().stream()
+            .map(entry -> entry.getKey() + "=" + entry.getValue())
+            .collect(Collectors.joining("\n"));
+        
+        return artifactsPropertiesStr.getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public String getContentType() {
+        return "text/plain";
+    }
+
+    @Override
+    public String getPathName() {
+        return "/artifacts.properties";
+    }
+}

--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/commons/RunLogArtifact.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/commons/RunLogArtifact.java
@@ -17,7 +17,7 @@ public class RunLogArtifact implements IRunRootArtifact {
         if (runLog != null) {
             return runLog.getBytes(StandardCharsets.UTF_8);
         }
-        return null;
+        return "".getBytes(StandardCharsets.UTF_8);
     }
 
     @Override

--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunArtifactsListRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunArtifactsListRoute.java
@@ -17,7 +17,8 @@ import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 
 import dev.galasa.framework.IFileSystem;
-import dev.galasa.framework.api.ras.internal.commons.ArtifactPropertiesArtifact;
+import dev.galasa.framework.api.ras.internal.commons.ArtifactsJson;
+import dev.galasa.framework.api.ras.internal.commons.ArtifactsProperties;
 import dev.galasa.framework.api.ras.internal.commons.IRunRootArtifact;
 import dev.galasa.framework.api.ras.internal.commons.InternalServletException;
 import dev.galasa.framework.api.ras.internal.commons.QueryParameters;
@@ -45,7 +46,12 @@ public class RunArtifactsListRoute extends RunsRoute {
     public RunArtifactsListRoute(IFileSystem fileSystem, IFramework framework) {
         //  Regex to match endpoint: /ras/runs/{runId}/artifacts
         super("\\/runs\\/([A-z0-9.\\-=]+)\\/artifacts\\/?", fileSystem, framework);
-        rootArtifacts = Arrays.asList(new RunLogArtifact(), new StructureJsonArtifact(), new ArtifactPropertiesArtifact(this));
+        rootArtifacts = Arrays.asList(
+            new RunLogArtifact(),
+            new StructureJsonArtifact(),
+            new ArtifactsProperties(this),
+            new ArtifactsJson(this)
+        );
     }
 
     @Override

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/BaseServletTest.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/BaseServletTest.java
@@ -46,7 +46,7 @@ public class BaseServletTest {
 		}
 	}
 
-	protected void checkJsonArrayStructure(String jsonString, Map<String, String> jsonFields) throws Exception {
+	protected void checkJsonArrayStructure(String jsonString, Map<String, String> jsonFieldsToCheck) throws Exception {
 
 		JsonElement jsonElement = JsonParser.parseString(jsonString);
 		assertThat(jsonElement).isNotNull().as("Failed to parse the body to a json object.");
@@ -54,7 +54,9 @@ public class BaseServletTest {
 		JsonArray jsonArray = jsonElement.getAsJsonArray();
 		assertThat(jsonArray).isNotNull().as("Json parsed is not a json array.");
 
-        for (Entry<String, String> entry : jsonFields.entrySet()) {
+        // Go through the map of provided fields and check if any of the objects in the JSON array
+        // contain a matching key-value entry.
+        for (Entry<String, String> entry : jsonFieldsToCheck.entrySet()) {
             boolean fieldMatches = false;
 
             for (JsonElement element : jsonArray) {

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/BaseServletTest.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/BaseServletTest.java
@@ -7,7 +7,6 @@ import com.google.gson.*;
 
 import dev.galasa.framework.spi.IRunResult;
 import dev.galasa.framework.spi.teststructure.TestStructure;
-import dev.galasa.framework.spi.utils.GalasaGsonBuilder;
 import dev.galasa.framework.api.ras.internal.mocks.MockRunResult;
 import dev.galasa.framework.mocks.MockFileSystem;
 import dev.galasa.framework.mocks.MockPath;
@@ -24,8 +23,6 @@ import java.util.Map.Entry;
 public class BaseServletTest {
 
 	protected MockFileSystem mockFileSystem;
-
-    protected static final Gson gson = GalasaGsonBuilder.build();
 
 	protected void checkErrorStructure(String jsonString , int expectedErrorCode , String... expectedErrorMessageParts ) throws Exception {
 
@@ -68,7 +65,7 @@ public class BaseServletTest {
             }
             assertThat(fieldMatches).isTrue();
         }
-	}
+    }
 
 	protected List<IRunResult> generateTestData(String runId, String runName, String runLog) {
 		List<IRunResult> mockInputRunResults = new ArrayList<IRunResult>();

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/BaseServletTest.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/BaseServletTest.java
@@ -7,6 +7,7 @@ import com.google.gson.*;
 
 import dev.galasa.framework.spi.IRunResult;
 import dev.galasa.framework.spi.teststructure.TestStructure;
+import dev.galasa.framework.spi.utils.GalasaGsonBuilder;
 import dev.galasa.framework.api.ras.internal.mocks.MockRunResult;
 import dev.galasa.framework.mocks.MockFileSystem;
 import dev.galasa.framework.mocks.MockPath;
@@ -16,11 +17,15 @@ import static org.assertj.core.api.Assertions.*;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 
 
 public class BaseServletTest {
 
 	protected MockFileSystem mockFileSystem;
+
+    protected static final Gson gson = GalasaGsonBuilder.build();
 
 	protected void checkErrorStructure(String jsonString , int expectedErrorCode , String... expectedErrorMessageParts ) throws Exception {
 
@@ -42,6 +47,27 @@ public class BaseServletTest {
 		for ( String expectedMessagePart : expectedErrorMessageParts ) {
 			assertThat(msg).contains(expectedMessagePart);
 		}
+	}
+
+	protected void checkJsonArrayStructure(String jsonString, Map<String, String> jsonFields) throws Exception {
+
+		JsonElement jsonElement = JsonParser.parseString(jsonString);
+		assertThat(jsonElement).isNotNull().as("Failed to parse the body to a json object.");
+
+		JsonArray jsonArray = jsonElement.getAsJsonArray();
+		assertThat(jsonArray).isNotNull().as("Json parsed is not a json array.");
+
+        for (Entry<String, String> entry : jsonFields.entrySet()) {
+            boolean fieldMatches = false;
+
+            for (JsonElement element : jsonArray) {
+                JsonObject jsonObject = element.getAsJsonObject();
+                if (jsonObject.get(entry.getKey()).toString().equals(entry.getValue())) {
+                    fieldMatches = true;
+                }
+            }
+            assertThat(fieldMatches).isTrue();
+        }
 	}
 
 	protected List<IRunResult> generateTestData(String runId, String runName, String runLog) {

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/TestRunArtifactsDownloadServlet.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/TestRunArtifactsDownloadServlet.java
@@ -31,7 +31,41 @@ public class TestRunArtifactsDownloadServlet extends BaseServletTest {
 		mockFileSystem = new MockFileSystem();
 	}
 
-	@Test
+    @Test
+	public void testBadArtifactPathInRequestGivesNotFoundError() throws Exception {
+		//Given..
+		String runId = "xx12345xx";
+        String runName = "U123";
+        String artifactPath = "bad/artifact/path";
+		List<IRunResult> mockInputRunResults = generateTestData(runId, runName, null);
+
+		Map<String, String[]> parameterMap = new HashMap<String,String[]>();
+		MockHttpServletRequest mockRequest = new MockHttpServletRequest(parameterMap, "/runs/" + runId + "/files/" + artifactPath);
+		MockBaseServletEnvironment mockServletEnvironment = new MockBaseServletEnvironment(mockInputRunResults, mockRequest, mockFileSystem);
+		
+		BaseServlet servlet = mockServletEnvironment.getServlet();
+		HttpServletRequest req = mockServletEnvironment.getRequest();
+		HttpServletResponse resp = mockServletEnvironment.getResponse();
+		ServletOutputStream outStream = resp.getOutputStream();
+		
+		//When...
+		servlet.init();
+		servlet.doGet(req,resp);
+
+		// Then...
+		// Expecting this json:
+		// {
+		//   "error_code" : 5008,
+		//   "error_message" : "GAL5008E: Error locating artifact '/bad/artifact/path' for run with identifier 'U123'."
+		// }
+		assertThat(resp.getStatus()).isEqualTo(500);
+		checkErrorStructure(outStream.toString(), 5008, "GAL5008E", artifactPath, runName);
+	
+		assertThat( resp.getContentType()).isEqualTo("Application/json");
+		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
+	}
+
+    @Test
 	public void testGoodRunIdAndBadArtifactPathGivesNotFoundError() throws Exception {
 		//Given..
 		String runId = "xx12345xx";
@@ -55,11 +89,11 @@ public class TestRunArtifactsDownloadServlet extends BaseServletTest {
 		// Then...
 		// Expecting this json:
 		// {
-		//   "error_code" : 5008,
-		//   "error_message" : "GAL5008E: Error locating artifact '/bad/artifact/path' for run with identifier 'U123'."
+		//   "error_code" : 5009,
+		//   "error_message" : "GAL5009E: Error retrieving artifact '/bad/artifact/path' for run with identifier 'U123'."
 		// }
 		assertThat(resp.getStatus()).isEqualTo(500);
-		checkErrorStructure(outStream.toString(), 5008, "GAL5008E", artifactPath, runName);
+		checkErrorStructure(outStream.toString(), 5009, "GAL5009E", artifactPath, runName);
 	
 		assertThat( resp.getContentType()).isEqualTo("Application/json");
 		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
@@ -89,11 +123,11 @@ public class TestRunArtifactsDownloadServlet extends BaseServletTest {
 		// Then...
 		// Expecting this json:
 		// {
-		//   "error_code" : 5008,
-		//   "error_message" : "GAL5008E: Error locating artifact '/bad/artifact/path' for run with identifier 'U123'."
+		//   "error_code" : 5009,
+		//   "error_message" : "GAL5009E: Error retrieving artifact '/bad/artifact/path' for run with identifier 'U123'."
 		// }
 		assertThat(resp.getStatus()).isEqualTo(500);
-		checkErrorStructure(outStream.toString(), 5008, "GAL5008E", artifactPath, runName);
+		checkErrorStructure(outStream.toString(), 5009, "GAL5009E", artifactPath, runName);
 	
 		assertThat( resp.getContentType()).isEqualTo("Application/json");
 		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
@@ -187,7 +221,7 @@ public class TestRunArtifactsDownloadServlet extends BaseServletTest {
 		// Then...
 		// Expecting:
 		assertThat(resp.getStatus()).isEqualTo(500);
-		checkErrorStructure(outStream.toString(), 5008, "GAL5008E", artifactPath, runName);
+		checkErrorStructure(outStream.toString(), 5009, "GAL5009E", artifactPath, runName);
 	
 		assertThat( resp.getContentType()).isEqualTo("Application/json");
 		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
@@ -222,6 +256,68 @@ public class TestRunArtifactsDownloadServlet extends BaseServletTest {
 		assertThat(resp.getStatus()).isEqualTo(200);
         assertThat(outStream.toString()).isEqualTo(fileContent);
 		assertThat(resp.getContentType()).isEqualTo("application/x-gzip");
+		assertThat(resp.getHeader("Content-Disposition")).isEqualTo("attachment");
+	}
+
+    @Test
+    public void testGoodRunIdAndArtifactsPropertiesReturnsOKAndFile() throws Exception {
+		//Given..
+		String runId = "12345";
+		String runName = "testA";
+        String artifactPath = "/artifacts.properties";
+        MockPath existingPath = new MockPath("/testA/term002.gz", mockFileSystem);
+		String fileContent = "dummy content";
+        List<IRunResult> mockInputRunResults = generateTestData(runId, runName, null);
+		mockFileSystem.createFile(existingPath);
+		mockFileSystem.setFileContents(existingPath, fileContent);
+
+		Map<String, String[]> parameterMap = new HashMap<String,String[]>();
+		MockHttpServletRequest mockRequest = new MockHttpServletRequest(parameterMap, "/runs/" + runId + "/files" + artifactPath);
+		MockBaseServletEnvironment mockServletEnvironment = new MockBaseServletEnvironment(mockInputRunResults, mockRequest, mockFileSystem);
+		
+		BaseServlet servlet = mockServletEnvironment.getServlet();
+		HttpServletRequest req = mockServletEnvironment.getRequest();
+		HttpServletResponse resp = mockServletEnvironment.getResponse();
+		ServletOutputStream outStream = resp.getOutputStream();
+		
+		//When...
+		servlet.init();
+		servlet.doGet(req,resp);
+
+		// Then...
+		// Expecting:
+		assertThat(resp.getStatus()).isEqualTo(200);
+        assertThat(outStream.toString()).isEqualTo("/artifacts" + existingPath + "=" + "application/x-gzip");
+		assertThat(resp.getContentType()).isEqualTo("text/plain");
+		assertThat(resp.getHeader("Content-Disposition")).isEqualTo("attachment");
+	}
+
+    @Test
+    public void testGoodRunIdAndEmptyRunLogReturnsOKEmptyFile() throws Exception {
+		//Given..
+		String runId = "12345";
+		String runName = "testA";
+        String artifactPath = "/run.log";
+        List<IRunResult> mockInputRunResults = generateTestData(runId, runName, null);
+
+		Map<String, String[]> parameterMap = new HashMap<String,String[]>();
+		MockHttpServletRequest mockRequest = new MockHttpServletRequest(parameterMap, "/runs/" + runId + "/files" + artifactPath);
+		MockBaseServletEnvironment mockServletEnvironment = new MockBaseServletEnvironment(mockInputRunResults, mockRequest, mockFileSystem);
+		
+		BaseServlet servlet = mockServletEnvironment.getServlet();
+		HttpServletRequest req = mockServletEnvironment.getRequest();
+		HttpServletResponse resp = mockServletEnvironment.getResponse();
+		ServletOutputStream outStream = resp.getOutputStream();
+		
+		//When...
+		servlet.init();
+		servlet.doGet(req,resp);
+
+		// Then...
+		// Expecting:
+		assertThat(resp.getStatus()).isEqualTo(200);
+        assertThat(outStream.toString()).isEmpty();
+		assertThat(resp.getContentType()).isEqualTo("text/plain");
 		assertThat(resp.getHeader("Content-Disposition")).isEqualTo("attachment");
 	}
 }

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/TestRunArtifactsListServlet.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/TestRunArtifactsListServlet.java
@@ -52,7 +52,7 @@ public class TestRunArtifactsListServlet extends BaseServletTest {
         }
 	}
 
-	public String generateExpectedJson(List<MockJsonObject> artifacts, String runLog, int artifactsSize) {
+	private String generateExpectedJsonArtifacts(List<MockJsonObject> artifacts) {
 		String jsonResult = "[\n";
 		int numOfArtifacts = artifacts.size();
 		if (numOfArtifacts > 0) {
@@ -62,38 +62,44 @@ public class TestRunArtifactsListServlet extends BaseServletTest {
 				if (0 < i && i < numOfArtifacts) {
 					runData = ",\n";
 				}
-				runData += "  {\n"+
-					   "    \"path\": \""+artifacts.get(i).path.toString()+"\",\n"+
-					   "    \"contentType\": \""+artifacts.get(i).contentType+"\",\n"+
-					   "    \"size\": "+artifacts.get(i).size+"\n"+
-					   "  }";
+                MockJsonObject artifact = artifacts.get(i);
+                runData += getArtifactAsJsonString(artifact.path.toString(), artifact.contentType, artifact.size);
                 if (i == numOfArtifacts - 1) {
                     runData += ",\n";
                 }
 				jsonResult += runData;
 			}
 		}
-        String runLogData= "  {\n"+
-                   "    \"path\": \"/run.log\",\n"+
-                   "    \"contentType\": \"text/plain\",\n"+
-                   "    \"size\": "+runLog.length()+"\n"+
-                   "  }";
-        jsonResult += runLogData;
-        String structureData= ",\n  {\n"+
-                   "    \"path\": \"/structure.json\",\n"+
-                   "    \"contentType\": \"application/json\",\n"+
-                   "    \"size\": 71\n"+
-                   "  }";
-        jsonResult += structureData;
-        String artifactsData= ",\n  {\n"+
-                   "    \"path\": \"/artifacts.properties\",\n"+
-                   "    \"contentType\": \"text/plain\",\n"+
-                   "    \"size\": "+artifactsSize+"\n"+
-                   "  }";
-        jsonResult += artifactsData;
-		jsonResult += "\n]";
 		return jsonResult;
 	}
+
+    private String getArtifactAsJsonString(String path, String contentType, int size) {
+        String artifactJson = "  {\n"+
+            "    \"path\": \""+path+"\",\n"+
+            "    \"contentType\": \""+contentType+"\",\n"+
+            "    \"size\": "+size+"\n"+
+            "  }";
+        return artifactJson;
+    }
+
+    private Map<String, String> getArtifactFields(String path, String contentType, String size) {
+        Map<String, String> artifactFields = Map.of(
+            "path", '"'+path+'"',
+            "contentType", '"'+contentType+'"'
+        );
+
+        if (size != null) {
+            artifactFields.put("size", '"'+size+'"');
+        }
+        return artifactFields;
+    }
+
+    private void checkRootArtifactsJson(String jsonString) throws Exception {
+        checkJsonArrayStructure(jsonString, getArtifactFields("/run.log", "text/plain", null));
+        checkJsonArrayStructure(jsonString, getArtifactFields("/structure.json", "application/json", null));
+        checkJsonArrayStructure(jsonString, getArtifactFields("/artifacts.properties", "text/plain", null));
+        checkJsonArrayStructure(jsonString, getArtifactFields("/artifacts.json", "application/json", null));
+    }
 
 	@Before
 	public void setUp() {
@@ -177,6 +183,11 @@ public class TestRunArtifactsListServlet extends BaseServletTest {
         //       "contentType": "text/plain",
         //       "size": 240
         //     }
+        //     {
+        //       "path": "/artifacts.json",
+        //       "contentType": "application/json",
+        //       "size": 313
+        //     }
         // ]
 		assertThat(resp.getStatus()).isEqualTo(200);
 
@@ -185,7 +196,7 @@ public class TestRunArtifactsListServlet extends BaseServletTest {
 		assertThat(jsonElement).isNotNull().as("Failed to parse the body to a json object.");
 
 		JsonArray jsonArray = jsonElement.getAsJsonArray();
-		assertThat(jsonArray.size()).isEqualTo(6);
+		assertThat(jsonArray.size()).isEqualTo(7);
 
         List<Path> expectedArtifactPaths = dummyArtifactPaths.stream()
             .map(path -> new MockPath("/artifacts" + path.toString(), mockFileSystem))
@@ -197,8 +208,10 @@ public class TestRunArtifactsListServlet extends BaseServletTest {
                 new MockJsonObject(expectedArtifactPaths.get(i), mockArtifacts.get(i).getContentType(), mockArtifacts.get(i).getSize()
             ));
         }
-		String expectedJson = generateExpectedJson(expectedArtifacts, runLog, 240);
-		assertThat(outStream.toString()).isEqualTo(expectedJson);
+
+        checkRootArtifactsJson(jsonString);
+		String expectedJson = generateExpectedJsonArtifacts(expectedArtifacts);
+		assertThat(jsonString).contains(expectedJson);
 	
 		assertThat(resp.getContentType()).isEqualTo("Application/json");
 		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
@@ -254,23 +267,30 @@ public class TestRunArtifactsListServlet extends BaseServletTest {
 		//     "contentType": "text/plain",
 		//     "size": "240",
 		//   }
+		//	 {
+		//     "path": "/artifacts.json",
+		//     "contentType": "application/json",
+		//     "size": "240",
+		//   }
 		// ]
-		// assertThat(resp.getStatus()).isEqualTo(200);
+		assertThat(resp.getStatus()).isEqualTo(200);
 
 		String jsonString = outStream.toString();
 		JsonElement jsonElement = JsonParser.parseString(jsonString);
 		assertThat(jsonElement).isNotNull().as("Failed to parse the body to a json object.");
 
 		JsonArray jsonArray = jsonElement.getAsJsonArray();
-		assertThat(jsonArray.size()).isEqualTo(4);
+		assertThat(jsonArray.size()).isEqualTo(5);
 
         MockPath expectedArtifactPath = new MockPath("/artifacts" + dummyArtifactPath.toString(), mockFileSystem);
         MockJsonObject expectedArtifact = new MockJsonObject(expectedArtifactPath, mockArtifact.getContentType(), mockArtifact.getSize());
-		String expectedJson = generateExpectedJson(Arrays.asList(expectedArtifact), runLog, 82);
-		assertThat(outStream.toString()).isEqualTo(expectedJson);
+
+		String expectedJson = generateExpectedJsonArtifacts(Arrays.asList(expectedArtifact));
+		assertThat(jsonString).contains(expectedJson);
+        checkRootArtifactsJson(jsonString);
 	
-		assertThat( resp.getContentType()).isEqualTo("Application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
+		assertThat(resp.getContentType()).isEqualTo("Application/json");
+		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 
@@ -317,6 +337,11 @@ public class TestRunArtifactsListServlet extends BaseServletTest {
 		//     "contentType": "text/plain",
 		//     "size": 240,
 		//   }
+		//	 {
+		//     "path": "/artifacts.json",
+		//     "contentType": "application/json",
+		//     "size": 240,
+		//   }
 		// ]
 		assertThat(resp.getStatus()).isEqualTo(200);
 
@@ -325,10 +350,11 @@ public class TestRunArtifactsListServlet extends BaseServletTest {
 		assertThat(jsonElement).isNotNull().as("Failed to parse the body to a json object.");
 
 		JsonArray jsonArray = jsonElement.getAsJsonArray();
-		assertThat(jsonArray.size()).isEqualTo(3);
+		assertThat(jsonArray.size()).isEqualTo(4);
 
-        String expectedJson = generateExpectedJson(new ArrayList<>(), runLog, 2);
-		assertThat(outStream.toString()).isEqualTo(expectedJson);
+        checkRootArtifactsJson(jsonString);
+        String expectedJson = generateExpectedJsonArtifacts(new ArrayList<>());
+		assertThat(jsonString).contains(expectedJson);
 	
 		assertThat(resp.getContentType()).isEqualTo("Application/json");
 		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");


### PR DESCRIPTION
Changes:
- An `artifacts.json` file is now available to download with the `/files` endpoint and is listed in the `/artifacts` endpoint's response.
- Downloading `artifacts.properties` no longer creates JSON inside the text file. Instead, it correctly creates key-value pairs of artifact paths and content types just like files that are created during local runs.
- Removed unnecessary try-catch in the `downloadStoredArtifact` method, as the method is called within a try-catch already.
- Added unit tests