### PR TITLE
framework.manifest maven artifacts created so OBR can download dependencies via maven.

### DIFF
--- a/galasa-parent/build.gradle
+++ b/galasa-parent/build.gradle
@@ -164,13 +164,13 @@ task buildReleaseYamlSubprojects() {
         ext {
             // the property that should be overridden in suproject's build.gradle
             // Each sub-project will set the values...
-            project_name = '' // The name of the bundle.
-            include_in_obr = '' // Is the bundle included in the uber-obr ?
-            include_in_mvp = '' 
-            include_in_bom = '' 
-            include_in_javadoc = '' // Is the component displayed to users on the public javadoc site ?
-            include_in_isolated = '' // Is the component included in the bundles shipped as part of the isolated build ?
-            include_in_codecoverage = ''
+            projectName = '' // The name of the bundle.
+            includeInOBR = '' // Is the bundle included in the uber-obr ?
+            includeInMVP = '' 
+            includeInBOM = '' 
+            includeInJavadoc = '' // Is the component displayed to users on the public javadoc site ?
+            includeInIsolated = '' // Is the component included in the bundles shipped as part of the isolated build ?
+            includeInCodeCoverage = ''
         }
 
         afterEvaluate {
@@ -180,36 +180,36 @@ task buildReleaseYamlSubprojects() {
 
                     // Decide which manifest file we want to append to based on subcomponent.
                     def manifestFilePath
-                    if ( project_name.startsWith('dev.galasa.framework.api') ) {
+                    if ( projectName.startsWith('dev.galasa.framework.api') ) {
                         manifestFilePath = apiManifestFilePath
                     } else {
                         manifestFilePath = frameworkManifestFilePath
                     }
 
-                    if (project_name == '') {
+                    if (projectName == '') {
                         throw new Exception("Project has no name.")
                     }
 
                     def f = new File(manifestFilePath)
-                    f.append("\n\n  - artifact: $project_name")
+                    f.append("\n\n  - artifact: $projectName")
                     f.append("\n    version: $version")
-                    if (include_in_obr != '') {
-                        f.append("\n    obr:          $include_in_obr")
+                    if (includeInOBR != '') {
+                        f.append("\n    obr:          $includeInOBR")
                     }
-                    if (include_in_mvp != '') {
-                        f.append("\n    mvp:          $include_in_mvp")
+                    if (includeInMVP != '') {
+                        f.append("\n    mvp:          $includeInMVP")
                     }
-                    if (include_in_bom != '') {
-                        f.append("\n    bom:          $include_in_bom")
+                    if (includeInBOM != '') {
+                        f.append("\n    bom:          $includeInBOM")
                     }
-                    if (include_in_javadoc != '') {
-                        f.append("\n    javadoc:      $include_in_javadoc")
+                    if (includeInJavadoc != '') {
+                        f.append("\n    javadoc:      $includeInJavadoc")
                     }
-                    if (include_in_isolated != '') {
-                        f.append("\n    isolated:     $include_in_isolated")
+                    if (includeInIsolated != '') {
+                        f.append("\n    isolated:     $includeInIsolated")
                     }
-                    if (include_in_codecoverage != '') {
-                        f.append("\n    codecoverage: $include_in_codecoverage")
+                    if (includeInCodeCoverage != '') {
+                        f.append("\n    codecoverage: $includeInCodeCoverage")
                     }
 
                 }

--- a/galasa-parent/build.gradle
+++ b/galasa-parent/build.gradle
@@ -6,6 +6,10 @@ plugins {
     id 'maven-publish'
 }
 
+// Note: The following line is changed by the set-version.sh script.
+// It is also read by other build scrips as required.
+version = "0.30.0"
+
 repositories {
     gradlePluginPortal()
     mavenCentral()
@@ -56,7 +60,24 @@ allprojects {
    }
 }
 
-
+//---------------------------------------------------------------
+// We need to gather the release and packaging metadata from each
+// sub-project, to generate a release.yaml document which can act
+// as a manifest for this component.
+//
+// The OSGi bundles in this project are all in one of two groups:
+// - The 'framework'
+// or 
+// - The 'api'
+//
+// Each module is examined, and contributes it's metadata to one
+// of two manifest files. Both manifest files are then combined
+// into an overall manifest file ready to be published to a 
+// maven repository.
+//
+// At a later time, the OBR project will draw-down the manifest
+// and use it to build the uber-obr.
+//---------------------------------------------------------------
 configurations {
     release_metadata
 }
@@ -96,6 +117,11 @@ api:
   bundles:
 """
 
+
+//----------------------------------------------------------
+// Flushes any existing content on the specified path, and 
+// creates a new file, containing the header text.
+//----------------------------------------------------------
 def prepareGeneratedFile(path , header) {
     // Make sure the manifest file is clean, and exists.
     def overallManifestFile = new File(path)
@@ -109,6 +135,10 @@ def prepareGeneratedFile(path , header) {
     overallManifestFile.append(header)
 }
 
+//----------------------------------------------------------
+// Prepare the overall manifest, and a manifest for each of 
+// the 'framework' and 'api' collections of bundles.
+//----------------------------------------------------------
 task buildReleaseYamlPrepare() {
     // During execution phase, make sure the file exists.
     doFirst{
@@ -123,6 +153,10 @@ task buildReleaseYamlPrepare() {
     }
 }
 
+//----------------------------------------------------------
+// Allow each subproject to contribute to one of the manifest 
+// collectons.
+//----------------------------------------------------------
 task buildReleaseYamlSubprojects() {
     dependsOn buildReleaseYamlPrepare
 
@@ -184,6 +218,11 @@ task buildReleaseYamlSubprojects() {
     }
 }
 
+//----------------------------------------------------------
+// Once we've collected all the metadata into either the 
+// 'framework' or 'api' collections of bundle information, 
+// Combine them into the 'overall' manifest file.
+//----------------------------------------------------------
 task buildReleaseYamlFinalise() {
     dependsOn buildReleaseYamlSubprojects
     // At the end of days, add the framework and api sections to the overall manifest file.
@@ -200,6 +239,7 @@ task buildReleaseYaml() {
     dependsOn buildReleaseYamlFinalise
 }
 
+// Declare that the uber-manifest release.yaml file exists, and how to build it.
 def myReleaseYaml = artifacts.add('release_metadata', file(overallManifestFilePath)) {
     builtBy 'buildReleaseYaml'
 }
@@ -209,8 +249,9 @@ def myReleaseYaml = artifacts.add('release_metadata', file(overallManifestFilePa
 publishing {
     publications {
         maven(MavenPublication) {
+            // Publish the component manifest/release.yaml
             artifact myReleaseYaml
-            artifactId "dev.galasa.framework"
+            artifactId "dev.galasa.framework.manifest"
             groupId 'dev.galasa'
             version version
         }

--- a/galasa-parent/build.gradle
+++ b/galasa-parent/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'biz.aQute.bnd.builder' version '5.3.0' apply false
     id 'dev.galasa.githash' version '0.15.0' apply false
     id 'jacoco'
+    id 'maven-publish'
 }
 
 repositories {
@@ -53,4 +54,177 @@ allprojects {
    tasks.withType(Javadoc) {
       options.addStringOption('Xdoclint:none', '-quiet')
    }
+}
+
+
+configurations {
+    release_metadata
+}
+
+def overallManifestFilePath = "$buildDir/release.yaml"
+def frameworkManifestFilePath = "$buildDir/framework-release.yaml"
+def apiManifestFilePath = "$buildDir/api-release.yaml"
+
+def overallHeader = """#
+# Copyright contributors to the Galasa project 
+#
+
+# -----------------------------------------------------------
+#
+#                         WARNING
+#
+# This file is periodically re-generated from the contents of 
+# the repository, so don't make changes here manually please.
+# -----------------------------------------------------------
+
+
+apiVersion: galasa.dev/v1alpha
+kind: Release
+metadata:
+  name: galasa-release
+"""
+
+def frameworkHeader = """
+
+framework:
+  bundles:
+"""
+
+def apiHeader = """
+
+api:
+  bundles:
+"""
+
+def prepareGeneratedFile(path , header) {
+    // Make sure the manifest file is clean, and exists.
+    def overallManifestFile = new File(path)
+    if (overallManifestFile.exists()){
+        // File exists, delete it and create a new one.
+        overallManifestFile.delete()
+    }
+    overallManifestFile.createNewFile()
+
+    // Add the header to the manifest file
+    overallManifestFile.append(header)
+}
+
+task buildReleaseYamlPrepare() {
+    // During execution phase, make sure the file exists.
+    doFirst{
+        // Make sure the build directory exists.
+        if ( !buildDir.exists() ) {
+            buildDir.mkdirs()
+        }
+        
+        prepareGeneratedFile(overallManifestFilePath,overallHeader)
+        prepareGeneratedFile(frameworkManifestFilePath,frameworkHeader)
+        prepareGeneratedFile(apiManifestFilePath,apiHeader)
+    }
+}
+
+task buildReleaseYamlSubprojects() {
+    dependsOn buildReleaseYamlPrepare
+
+    subprojects {
+        ext {
+            // the property that should be overridden in suproject's build.gradle
+            // Each sub-project will set the values...
+            project_name = '' // The name of the bundle.
+            include_in_obr = '' // Is the bundle included in the uber-obr ?
+            include_in_mvp = '' 
+            include_in_bom = '' 
+            include_in_javadoc = '' // Is the component displayed to users on the public javadoc site ?
+            include_in_isolated = '' // Is the component included in the bundles shipped as part of the isolated build ?
+            include_in_codecoverage = ''
+        }
+
+        afterEvaluate {
+            doLast {
+                // Some projects don't have a version property... as they are parent projects mostly.
+                if (version != 'unspecified') {
+
+                    // Decide which manifest file we want to append to based on subcomponent.
+                    def manifestFilePath
+                    if ( project_name.startsWith('dev.galasa.framework.api') ) {
+                        manifestFilePath = apiManifestFilePath
+                    } else {
+                        manifestFilePath = frameworkManifestFilePath
+                    }
+
+                    if (project_name == '') {
+                        throw new Exception("Project has no name.")
+                    }
+
+                    def f = new File(manifestFilePath)
+                    f.append("\n\n  - artifact: $project_name")
+                    f.append("\n    version: $version")
+                    if (include_in_obr != '') {
+                        f.append("\n    obr:          $include_in_obr")
+                    }
+                    if (include_in_mvp != '') {
+                        f.append("\n    mvp:          $include_in_mvp")
+                    }
+                    if (include_in_bom != '') {
+                        f.append("\n    bom:          $include_in_bom")
+                    }
+                    if (include_in_javadoc != '') {
+                        f.append("\n    javadoc:      $include_in_javadoc")
+                    }
+                    if (include_in_isolated != '') {
+                        f.append("\n    isolated:     $include_in_isolated")
+                    }
+                    if (include_in_codecoverage != '') {
+                        f.append("\n    codecoverage: $include_in_codecoverage")
+                    }
+
+                }
+            }
+        }
+    }
+}
+
+task buildReleaseYamlFinalise() {
+    dependsOn buildReleaseYamlSubprojects
+    // At the end of days, add the framework and api sections to the overall manifest file.
+    doLast{
+        def toConcatenate = files(frameworkManifestFilePath, apiManifestFilePath)
+        def overallManifestFile = new File(overallManifestFilePath)
+        toConcatenate.each { f -> overallManifestFile.append(f.text)}
+    }
+}
+
+// Build the release.yaml file
+task buildReleaseYaml() {
+    println 'Building the release.yaml file...'
+    dependsOn buildReleaseYamlFinalise
+}
+
+def myReleaseYaml = artifacts.add('release_metadata', file(overallManifestFilePath)) {
+    builtBy 'buildReleaseYaml'
+}
+
+// Publish the release.yaml as a maven artifact.
+// Note: The maven co-ordinates are versioned using the version for this bundle.
+publishing {
+    publications {
+        maven(MavenPublication) {
+            artifact myReleaseYaml
+            artifactId "dev.galasa.framework"
+            groupId 'dev.galasa'
+            version version
+        }
+    }
+    repositories {
+        maven {
+            url  = "$targetMaven"
+        
+            if ("$targetMaven".startsWith('http')) {
+                credentials {
+                    username System.getenv('MAVENUSERNAME')
+                    password System.getenv('MAVENPASSWORD')
+                }
+            }
+        }
+    }
 }

--- a/galasa-parent/dev.galasa.framework.api.authentication/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api.authentication/build.gradle
@@ -12,3 +12,17 @@ dependencies {
     
     implementation 'com.auth0:java-jwt:3.19.1'
 }
+
+// Note: These values are consumed by the parent build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
+ext.project_name=project.name
+ext.include_in_obr          = true
+ext.include_in_mvp          = false
+ext.include_in_isolated     = true
+ext.include_in_bom          = false
+ext.include_in_codecoverage = true
+ext.include_in_javadoc      = false
+

--- a/galasa-parent/dev.galasa.framework.api.authentication/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api.authentication/build.gradle
@@ -18,11 +18,11 @@ dependencies {
 // or referenced from.
 // The settings here are gathered together by the build process to create a release.yaml file 
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
-ext.project_name=project.name
-ext.include_in_obr          = true
-ext.include_in_mvp          = false
-ext.include_in_isolated     = true
-ext.include_in_bom          = false
-ext.include_in_codecoverage = true
-ext.include_in_javadoc      = false
+ext.projectName=project.name
+ext.includeInOBR          = true
+ext.includeInMVP          = false
+ext.includeInIsolated     = true
+ext.includeInBOM          = false
+ext.includeInCodeCoverage = true
+ext.includeInJavadoc      = false
 

--- a/galasa-parent/dev.galasa.framework.api.bootstrap/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api.bootstrap/build.gradle
@@ -16,11 +16,11 @@ dependencies {
 // or referenced from.
 // The settings here are gathered together by the build process to create a release.yaml file 
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
-ext.project_name=project.name
-ext.include_in_obr          = true
-ext.include_in_mvp          = false
-ext.include_in_isolated     = true
-ext.include_in_bom          = false
-ext.include_in_codecoverage = true
-ext.include_in_javadoc      = false
+ext.projectName=project.name
+ext.includeInOBR          = true
+ext.includeInMVP          = false
+ext.includeInIsolated     = true
+ext.includeInBOM          = false
+ext.includeInCodeCoverage = true
+ext.includeInJavadoc      = false
 

--- a/galasa-parent/dev.galasa.framework.api.bootstrap/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api.bootstrap/build.gradle
@@ -10,3 +10,17 @@ version = '0.27.0'
 dependencies {
     implementation project(':dev.galasa.framework')
 }
+
+// Note: These values are consumed by the parent build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
+ext.project_name=project.name
+ext.include_in_obr          = true
+ext.include_in_mvp          = false
+ext.include_in_isolated     = true
+ext.include_in_bom          = false
+ext.include_in_codecoverage = true
+ext.include_in_javadoc      = false
+

--- a/galasa-parent/dev.galasa.framework.api.cps/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api.cps/build.gradle
@@ -32,11 +32,11 @@ openApiGenerate {
 // or referenced from.
 // The settings here are gathered together by the build process to create a release.yaml file 
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
-ext.project_name=project.name
-ext.include_in_obr          = true
-ext.include_in_mvp          = false
-ext.include_in_isolated     = true
-ext.include_in_bom          = false
-ext.include_in_codecoverage = true
-ext.include_in_javadoc      = false
+ext.projectName=project.name
+ext.includeInOBR          = true
+ext.includeInMVP          = false
+ext.includeInIsolated     = true
+ext.includeInBOM          = false
+ext.includeInCodeCoverage = true
+ext.includeInJavadoc      = false
 

--- a/galasa-parent/dev.galasa.framework.api.cps/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api.cps/build.gradle
@@ -26,3 +26,17 @@ openApiGenerate {
         modelPropertyNaming: "original"
     ]
 }
+
+// Note: These values are consumed by the parent build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
+ext.project_name=project.name
+ext.include_in_obr          = true
+ext.include_in_mvp          = false
+ext.include_in_isolated     = true
+ext.include_in_bom          = false
+ext.include_in_codecoverage = true
+ext.include_in_javadoc      = false
+

--- a/galasa-parent/dev.galasa.framework.api.health/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api.health/build.gradle
@@ -10,3 +10,18 @@ version = '0.25.0'
 dependencies {
     implementation project(':dev.galasa.framework')
 }
+
+
+// Note: These values are consumed by the parent build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
+ext.project_name=project.name
+ext.include_in_obr          = true
+ext.include_in_mvp          = false
+ext.include_in_isolated     = true
+ext.include_in_bom          = false
+ext.include_in_codecoverage = true
+ext.include_in_javadoc      = false
+

--- a/galasa-parent/dev.galasa.framework.api.health/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api.health/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 // or referenced from.
 // The settings here are gathered together by the build process to create a release.yaml file 
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
-ext.project_name=project.name
-ext.include_in_obr          = true
-ext.include_in_mvp          = false
-ext.include_in_isolated     = true
-ext.include_in_bom          = false
-ext.include_in_codecoverage = true
-ext.include_in_javadoc      = false
+ext.projectName=project.name
+ext.includeInOBR          = true
+ext.includeInMVP          = false
+ext.includeInIsolated     = true
+ext.includeInBOM          = false
+ext.includeInCodeCoverage = true
+ext.includeInJavadoc      = false
 

--- a/galasa-parent/dev.galasa.framework.api.launcher/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api.launcher/build.gradle
@@ -10,3 +10,17 @@ version = '0.21.0'
 dependencies {
     implementation project(':dev.galasa.framework')
 }
+
+// Note: These values are consumed by the parent build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
+ext.project_name=project.name
+ext.include_in_obr          = false
+ext.include_in_mvp          = false
+ext.include_in_isolated     = false
+ext.include_in_bom          = false
+ext.include_in_codecoverage = false
+ext.include_in_javadoc      = false
+

--- a/galasa-parent/dev.galasa.framework.api.launcher/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api.launcher/build.gradle
@@ -16,11 +16,11 @@ dependencies {
 // or referenced from.
 // The settings here are gathered together by the build process to create a release.yaml file 
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
-ext.project_name=project.name
-ext.include_in_obr          = false
-ext.include_in_mvp          = false
-ext.include_in_isolated     = false
-ext.include_in_bom          = false
-ext.include_in_codecoverage = false
-ext.include_in_javadoc      = false
+ext.projectName=project.name
+ext.includeInOBR          = false
+ext.includeInMVP          = false
+ext.includeInIsolated     = false
+ext.includeInBOM          = false
+ext.includeInCodeCoverage = false
+ext.includeInJavadoc      = false
 

--- a/galasa-parent/dev.galasa.framework.api.ras/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api.ras/build.gradle
@@ -39,11 +39,11 @@ openApiGenerate {
 // or referenced from.
 // The settings here are gathered together by the build process to create a release.yaml file 
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
-ext.project_name=project.name
-ext.include_in_obr          = true
-ext.include_in_mvp          = false
-ext.include_in_isolated     = true
-ext.include_in_bom          = false
-ext.include_in_codecoverage = true
-ext.include_in_javadoc      = false
+ext.projectName=project.name
+ext.includeInOBR          = true
+ext.includeInMVP          = false
+ext.includeInIsolated     = true
+ext.includeInBOM          = false
+ext.includeInCodeCoverage = true
+ext.includeInJavadoc      = false
 

--- a/galasa-parent/dev.galasa.framework.api.ras/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api.ras/build.gradle
@@ -32,3 +32,18 @@ openApiGenerate {
         supportsES6: "false"
     ]
 }
+
+
+// Note: These values are consumed by the parent build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
+ext.project_name=project.name
+ext.include_in_obr          = true
+ext.include_in_mvp          = false
+ext.include_in_isolated     = true
+ext.include_in_bom          = false
+ext.include_in_codecoverage = true
+ext.include_in_javadoc      = false
+

--- a/galasa-parent/dev.galasa.framework.api.runs/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api.runs/build.gradle
@@ -25,3 +25,17 @@ openApiGenerate {
         modelPropertyNaming: "original"
     ]
 }
+
+// Note: These values are consumed by the parent build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
+ext.project_name=project.name
+ext.include_in_obr          = true
+ext.include_in_mvp          = false
+ext.include_in_isolated     = true
+ext.include_in_bom          = false
+ext.include_in_codecoverage = true
+ext.include_in_javadoc      = false
+

--- a/galasa-parent/dev.galasa.framework.api.runs/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api.runs/build.gradle
@@ -31,11 +31,11 @@ openApiGenerate {
 // or referenced from.
 // The settings here are gathered together by the build process to create a release.yaml file 
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
-ext.project_name=project.name
-ext.include_in_obr          = true
-ext.include_in_mvp          = false
-ext.include_in_isolated     = true
-ext.include_in_bom          = false
-ext.include_in_codecoverage = true
-ext.include_in_javadoc      = false
+ext.projectName=project.name
+ext.includeInOBR          = true
+ext.includeInMVP          = false
+ext.includeInIsolated     = true
+ext.includeInBOM          = false
+ext.includeInCodeCoverage = true
+ext.includeInJavadoc      = false
 

--- a/galasa-parent/dev.galasa.framework.api.testcatalog/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api.testcatalog/build.gradle
@@ -19,11 +19,11 @@ dependencies {
 // or referenced from.
 // The settings here are gathered together by the build process to create a release.yaml file 
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
-ext.project_name=project.name
-ext.include_in_obr          = true
-ext.include_in_mvp          = false
-ext.include_in_isolated     = true
-ext.include_in_bom          = false
-ext.include_in_codecoverage = true
-ext.include_in_javadoc      = false
+ext.projectName=project.name
+ext.includeInOBR          = true
+ext.includeInMVP          = false
+ext.includeInIsolated     = true
+ext.includeInBOM          = false
+ext.includeInCodeCoverage = true
+ext.includeInJavadoc      = false
 

--- a/galasa-parent/dev.galasa.framework.api.testcatalog/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api.testcatalog/build.gradle
@@ -12,3 +12,18 @@ dependencies {
     
     implementation 'commons-io:commons-io:2.9.0'
 }
+
+
+// Note: These values are consumed by the parent build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
+ext.project_name=project.name
+ext.include_in_obr          = true
+ext.include_in_mvp          = false
+ext.include_in_isolated     = true
+ext.include_in_bom          = false
+ext.include_in_codecoverage = true
+ext.include_in_javadoc      = false
+

--- a/galasa-parent/dev.galasa.framework.api.webui/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api.webui/build.gradle
@@ -31,11 +31,11 @@ openApiGenerate {
 // or referenced from.
 // The settings here are gathered together by the build process to create a release.yaml file 
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
-ext.project_name=project.name
-ext.include_in_obr          = true
-ext.include_in_mvp          = false
-ext.include_in_isolated     = true
-ext.include_in_bom          = false
-ext.include_in_codecoverage = true
-ext.include_in_javadoc      = false
+ext.projectName=project.name
+ext.includeInOBR          = true
+ext.includeInMVP          = false
+ext.includeInIsolated     = true
+ext.includeInBOM          = false
+ext.includeInCodeCoverage = true
+ext.includeInJavadoc      = false
 

--- a/galasa-parent/dev.galasa.framework.api.webui/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api.webui/build.gradle
@@ -25,3 +25,17 @@ openApiGenerate {
         supportsES6: "false"
     ]
 }
+
+// Note: These values are consumed by the parent build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
+ext.project_name=project.name
+ext.include_in_obr          = true
+ext.include_in_mvp          = false
+ext.include_in_isolated     = true
+ext.include_in_bom          = false
+ext.include_in_codecoverage = true
+ext.include_in_javadoc      = false
+

--- a/galasa-parent/dev.galasa.framework.api/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api/build.gradle
@@ -15,3 +15,17 @@ dependencies {
     implementation 'org.apache.felix:org.apache.felix.bundlerepository:2.0.2'
 
 }
+
+// Note: These values are consumed by the parent build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
+ext.project_name=project.name
+ext.include_in_obr          = true
+ext.include_in_mvp          = false
+ext.include_in_isolated     = true
+ext.include_in_bom          = false
+ext.include_in_codecoverage = true
+ext.include_in_javadoc      = false
+

--- a/galasa-parent/dev.galasa.framework.api/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api/build.gradle
@@ -21,11 +21,11 @@ dependencies {
 // or referenced from.
 // The settings here are gathered together by the build process to create a release.yaml file 
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
-ext.project_name=project.name
-ext.include_in_obr          = true
-ext.include_in_mvp          = false
-ext.include_in_isolated     = true
-ext.include_in_bom          = false
-ext.include_in_codecoverage = true
-ext.include_in_javadoc      = false
+ext.projectName=project.name
+ext.includeInOBR          = true
+ext.includeInMVP          = false
+ext.includeInIsolated     = true
+ext.includeInBOM          = false
+ext.includeInCodeCoverage = true
+ext.includeInJavadoc      = false
 

--- a/galasa-parent/dev.galasa.framework.docker.controller/build.gradle
+++ b/galasa-parent/dev.galasa.framework.docker.controller/build.gradle
@@ -36,3 +36,18 @@ dependencies {
     }
 
 }
+
+// Note: These values are consumed by the parent build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
+ext.project_name=project.name
+ext.include_in_obr          = true
+ext.include_in_mvp          = false
+ext.include_in_isolated     = true
+ext.include_in_bom          = false
+ext.include_in_codecoverage = true
+ext.include_in_javadoc      = false
+
+

--- a/galasa-parent/dev.galasa.framework.docker.controller/build.gradle
+++ b/galasa-parent/dev.galasa.framework.docker.controller/build.gradle
@@ -42,12 +42,12 @@ dependencies {
 // or referenced from.
 // The settings here are gathered together by the build process to create a release.yaml file 
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
-ext.project_name=project.name
-ext.include_in_obr          = true
-ext.include_in_mvp          = false
-ext.include_in_isolated     = true
-ext.include_in_bom          = false
-ext.include_in_codecoverage = true
-ext.include_in_javadoc      = false
+ext.projectName=project.name
+ext.includeInOBR          = true
+ext.includeInMVP          = false
+ext.includeInIsolated     = true
+ext.includeInBOM          = false
+ext.includeInCodeCoverage = true
+ext.includeInJavadoc      = false
 
 

--- a/galasa-parent/dev.galasa.framework.k8s.controller/build.gradle
+++ b/galasa-parent/dev.galasa.framework.k8s.controller/build.gradle
@@ -31,3 +31,17 @@ dependencies {
     }
 
 }
+
+// Note: These values are consumed by the parent build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
+ext.project_name=project.name
+ext.include_in_obr          = true
+ext.include_in_mvp          = false
+ext.include_in_isolated     = true
+ext.include_in_bom          = false
+ext.include_in_codecoverage = true
+ext.include_in_javadoc      = false
+

--- a/galasa-parent/dev.galasa.framework.k8s.controller/build.gradle
+++ b/galasa-parent/dev.galasa.framework.k8s.controller/build.gradle
@@ -37,11 +37,11 @@ dependencies {
 // or referenced from.
 // The settings here are gathered together by the build process to create a release.yaml file 
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
-ext.project_name=project.name
-ext.include_in_obr          = true
-ext.include_in_mvp          = false
-ext.include_in_isolated     = true
-ext.include_in_bom          = false
-ext.include_in_codecoverage = true
-ext.include_in_javadoc      = false
+ext.projectName=project.name
+ext.includeInOBR          = true
+ext.includeInMVP          = false
+ext.includeInIsolated     = true
+ext.includeInBOM          = false
+ext.includeInCodeCoverage = true
+ext.includeInJavadoc      = false
 

--- a/galasa-parent/dev.galasa.framework.log4j2.bridge/build.gradle
+++ b/galasa-parent/dev.galasa.framework.log4j2.bridge/build.gradle
@@ -12,3 +12,17 @@ dependencies {
     implementation 'org.apache.logging.log4j:log4j-core:2.17.1'
     implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.1'
 }
+
+// Note: These values are consumed by the parent build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
+ext.project_name=project.name
+ext.include_in_obr          = false
+ext.include_in_mvp          = false
+ext.include_in_isolated     = false
+ext.include_in_bom          = false
+ext.include_in_codecoverage = false
+ext.include_in_javadoc      = false
+

--- a/galasa-parent/dev.galasa.framework.log4j2.bridge/build.gradle
+++ b/galasa-parent/dev.galasa.framework.log4j2.bridge/build.gradle
@@ -18,11 +18,11 @@ dependencies {
 // or referenced from.
 // The settings here are gathered together by the build process to create a release.yaml file 
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
-ext.project_name=project.name
-ext.include_in_obr          = false
-ext.include_in_mvp          = false
-ext.include_in_isolated     = false
-ext.include_in_bom          = false
-ext.include_in_codecoverage = false
-ext.include_in_javadoc      = false
+ext.projectName=project.name
+ext.includeInOBR          = false
+ext.includeInMVP          = false
+ext.includeInIsolated     = false
+ext.includeInBOM          = false
+ext.includeInCodeCoverage = false
+ext.includeInJavadoc      = false
 

--- a/galasa-parent/dev.galasa.framework.maven.repository.spi/build.gradle
+++ b/galasa-parent/dev.galasa.framework.maven.repository.spi/build.gradle
@@ -6,3 +6,17 @@ plugins {
 version = '0.21.0'
 
 description = 'Galasa Maven Repository SPI'
+
+// Note: These values are consumed by the parent build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
+ext.project_name=project.name
+ext.include_in_obr          = true
+ext.include_in_mvp          = true
+ext.include_in_isolated     = true
+ext.include_in_bom          = false
+ext.include_in_codecoverage = true
+ext.include_in_javadoc      = false
+

--- a/galasa-parent/dev.galasa.framework.maven.repository.spi/build.gradle
+++ b/galasa-parent/dev.galasa.framework.maven.repository.spi/build.gradle
@@ -12,11 +12,11 @@ description = 'Galasa Maven Repository SPI'
 // or referenced from.
 // The settings here are gathered together by the build process to create a release.yaml file 
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
-ext.project_name=project.name
-ext.include_in_obr          = true
-ext.include_in_mvp          = true
-ext.include_in_isolated     = true
-ext.include_in_bom          = false
-ext.include_in_codecoverage = true
-ext.include_in_javadoc      = false
+ext.projectName=project.name
+ext.includeInOBR          = true
+ext.includeInMVP          = true
+ext.includeInIsolated     = true
+ext.includeInBOM          = false
+ext.includeInCodeCoverage = true
+ext.includeInJavadoc      = false
 

--- a/galasa-parent/dev.galasa.framework.maven.repository/build.gradle
+++ b/galasa-parent/dev.galasa.framework.maven.repository/build.gradle
@@ -13,3 +13,17 @@ dependencies {
     implementation 'org.apache.maven:maven-repository-metadata:3.3.9'
     implementation 'org.codehaus.plexus:plexus-utils:3.0.24'
 }
+
+// Note: These values are consumed by the parent build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
+ext.project_name=project.name
+ext.include_in_obr          = true
+ext.include_in_mvp          = true
+ext.include_in_isolated     = true
+ext.include_in_bom          = false
+ext.include_in_codecoverage = true
+ext.include_in_javadoc      = false
+

--- a/galasa-parent/dev.galasa.framework.maven.repository/build.gradle
+++ b/galasa-parent/dev.galasa.framework.maven.repository/build.gradle
@@ -19,11 +19,11 @@ dependencies {
 // or referenced from.
 // The settings here are gathered together by the build process to create a release.yaml file 
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
-ext.project_name=project.name
-ext.include_in_obr          = true
-ext.include_in_mvp          = true
-ext.include_in_isolated     = true
-ext.include_in_bom          = false
-ext.include_in_codecoverage = true
-ext.include_in_javadoc      = false
+ext.projectName=project.name
+ext.includeInOBR          = true
+ext.includeInMVP          = true
+ext.includeInIsolated     = true
+ext.includeInBOM          = false
+ext.includeInCodeCoverage = true
+ext.includeInJavadoc      = false
 

--- a/galasa-parent/dev.galasa.framework.metrics/build.gradle
+++ b/galasa-parent/dev.galasa.framework.metrics/build.gradle
@@ -21,11 +21,11 @@ dependencies {
 // or referenced from.
 // The settings here are gathered together by the build process to create a release.yaml file 
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
-ext.project_name=project.name
-ext.include_in_obr          = true
-ext.include_in_mvp          = false
-ext.include_in_isolated     = true
-ext.include_in_bom          = false
-ext.include_in_codecoverage = true
-ext.include_in_javadoc      = false
+ext.projectName=project.name
+ext.includeInOBR          = true
+ext.includeInMVP          = false
+ext.includeInIsolated     = true
+ext.includeInBOM          = false
+ext.includeInCodeCoverage = true
+ext.includeInJavadoc      = false
 

--- a/galasa-parent/dev.galasa.framework.metrics/build.gradle
+++ b/galasa-parent/dev.galasa.framework.metrics/build.gradle
@@ -15,3 +15,17 @@ dependencies {
     implementation 'io.prometheus:simpleclient_hotspot:0.6.0'
 
 }
+
+// Note: These values are consumed by the parent build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
+ext.project_name=project.name
+ext.include_in_obr          = true
+ext.include_in_mvp          = false
+ext.include_in_isolated     = true
+ext.include_in_bom          = false
+ext.include_in_codecoverage = true
+ext.include_in_javadoc      = false
+

--- a/galasa-parent/dev.galasa.framework.resource.management/build.gradle
+++ b/galasa-parent/dev.galasa.framework.resource.management/build.gradle
@@ -22,11 +22,11 @@ dependencies {
 // or referenced from.
 // The settings here are gathered together by the build process to create a release.yaml file 
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
-ext.project_name=project.name
-ext.include_in_obr          = true
-ext.include_in_mvp          = false
-ext.include_in_isolated     = true
-ext.include_in_bom          = false
-ext.include_in_codecoverage = true
-ext.include_in_javadoc      = false
+ext.projectName=project.name
+ext.includeInOBR          = true
+ext.includeInMVP          = false
+ext.includeInIsolated     = true
+ext.includeInBOM          = false
+ext.includeInCodeCoverage = true
+ext.includeInJavadoc      = false
 

--- a/galasa-parent/dev.galasa.framework.resource.management/build.gradle
+++ b/galasa-parent/dev.galasa.framework.resource.management/build.gradle
@@ -15,3 +15,18 @@ dependencies {
     implementation 'io.prometheus:simpleclient_hotspot:0.6.0'
 
 }
+
+
+// Note: These values are consumed by the parent build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
+ext.project_name=project.name
+ext.include_in_obr          = true
+ext.include_in_mvp          = false
+ext.include_in_isolated     = true
+ext.include_in_bom          = false
+ext.include_in_codecoverage = true
+ext.include_in_javadoc      = false
+

--- a/galasa-parent/dev.galasa.framework/build.gradle
+++ b/galasa-parent/dev.galasa.framework/build.gradle
@@ -27,3 +27,17 @@ dependencies {
     testImplementation project (':dev.galasa')
 
 }
+
+// Note: These values are consumed by the parent build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
+ext.project_name=project.name
+ext.include_in_obr          = true
+ext.include_in_mvp          = true
+ext.include_in_isolated     = false
+ext.include_in_bom          = true
+ext.include_in_codecoverage = true
+ext.include_in_javadoc      = false
+

--- a/galasa-parent/dev.galasa.framework/build.gradle
+++ b/galasa-parent/dev.galasa.framework/build.gradle
@@ -33,11 +33,11 @@ dependencies {
 // or referenced from.
 // The settings here are gathered together by the build process to create a release.yaml file 
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
-ext.project_name=project.name
-ext.include_in_obr          = true
-ext.include_in_mvp          = true
-ext.include_in_isolated     = false
-ext.include_in_bom          = true
-ext.include_in_codecoverage = true
-ext.include_in_javadoc      = false
+ext.projectName=project.name
+ext.includeInOBR          = true
+ext.includeInMVP          = true
+ext.includeInIsolated     = false
+ext.includeInBOM          = true
+ext.includeInCodeCoverage = true
+ext.includeInJavadoc      = false
 

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkInitialisation.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkInitialisation.java
@@ -389,6 +389,7 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
 
         URI uriDynamicStatusStore = null;
         try {
+
             String dssProperty = overrideProperties.getProperty("framework.dynamicstatus.store");
             if((dssProperty != null) && !dssProperty.isEmpty()){
                 uriDynamicStatusStore = new URI(dssProperty);
@@ -453,11 +454,7 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
         URI localRasUri = localRasPath.toUri();
         try {
 
-<<<<<<< HEAD
             String rasProperty = overrideProperties.getProperty("framework.resultarchive.store");
-=======
-            String rasProperty = bootstrapProperties.getProperty("framework.resultarchive.store");
->>>>>>> 9b352623 (updates to initialisation)
             if((rasProperty != null) && !rasProperty.isEmpty()){
                 final String[] rasPaths = rasProperty.split(",");
                 for (final String rasPath : rasPaths) {
@@ -527,11 +524,7 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
         URI uriCredentialsStore ;
         // *** Work out the creds uri
         try {
-<<<<<<< HEAD
             String credsProperty = overrideProperties.getProperty("framework.credentials.store");
-=======
-            String credsProperty = bootstrapProperties.getProperty("framework.credentials.store");
->>>>>>> 9b352623 (updates to initialisation)
             if((credsProperty != null) && !credsProperty.isEmpty()){
                 uriCredentialsStore = new URI(credsProperty);
                 logger.debug("Credentials Store is " + uriCredentialsStore.toString());

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkInitialisation.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkInitialisation.java
@@ -388,19 +388,29 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
 
         URI uriDynamicStatusStore = null;
         try {
-            String dssProperty = cpsFramework.getProperty("dynamicstatus", "store");
-            if ((dssProperty == null) || dssProperty.isEmpty()) {
-                uriDynamicStatusStore = Paths.get(this.galasaHome, "dss.properties").toUri();
-                createIfMissing(uriDynamicStatusStore,fileSystem);
-            } else {
+            String dssProperty = bootstrapProperties.getProperty("framework.dynamicstatus.store");
+            if((dssProperty != null) && !dssProperty.isEmpty()){
                 uriDynamicStatusStore = new URI(dssProperty);
+                logger.debug("Dynamic Status Store is " + uriDynamicStatusStore.toString());
                 createIfMissing(uriDynamicStatusStore, fileSystem);
+                return uriDynamicStatusStore;
             }
+
+            dssProperty = cpsFramework.getProperty("dynamicstatus", "store");
+            if((dssProperty != null) && !dssProperty.isEmpty()){
+                uriDynamicStatusStore = new URI(dssProperty);
+                logger.debug("Dynamic Status Store is " + uriDynamicStatusStore.toString());
+                createIfMissing(uriDynamicStatusStore, fileSystem);
+                return uriDynamicStatusStore;
+            }
+
+            uriDynamicStatusStore = Paths.get(this.galasaHome, "dss.properties").toUri();
+            logger.debug("Dynamic Status Store is " + uriDynamicStatusStore.toString());
+            createIfMissing(uriDynamicStatusStore,fileSystem);
+            return uriDynamicStatusStore;
         } catch (final Exception e) {
             throw new FrameworkException("Unable to resolve the Dynamic Status Store URI", e);
         }
-        logger.debug("Dynamic Status Store is " + uriDynamicStatusStore.toString());
-        return uriDynamicStatusStore;
     }
 
     // Find the run name of the test run, if it's not a set property 
@@ -435,32 +445,42 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
         IConfigurationPropertyStoreService cpsFramework
     ) throws FrameworkException {
 
-        ArrayList<URI> uriResultArchiveStores ;
+        ArrayList<URI> uriResultArchiveStores = new ArrayList<>(1);
 
         Path localRasPath = Paths.get(this.galasaHome, "ras");
         URI localRasUri = localRasPath.toUri();
         try {
-            String rasProperty = cpsFramework.getProperty("resultarchive", "store");
 
-            // Create the empty list.
-            uriResultArchiveStores = new ArrayList<>(1);
-
-            if ((rasProperty == null) || rasProperty.isEmpty()) {
-                // Neither environment nor cps have set the RAS location.
-                // Default to a local RAS within galasaHome
-                uriResultArchiveStores.add(localRasUri);
-            } else {
-
-                // Allow for comma-separated list of RAS paths.
+            String rasProperty = bootstrapProperties.getProperty("framework.resultarchive.store");
+            if((rasProperty != null) && !rasProperty.isEmpty()){
                 final String[] rasPaths = rasProperty.split(",");
                 for (final String rasPath : rasPaths) {
                     if (!rasPath.trim().isEmpty()) {
+                        logger.debug("Adding Result Archive Store location " + uriDynamicStatusStore.toString());
                         uriResultArchiveStores.add(new URI(rasPath));
                     }
                 }
-                if (uriResultArchiveStores.isEmpty()) {
-                    throw new FrameworkException("No Result Archive Store URIs were provided");
+            }
+
+            rasProperty = cpsFramework.getProperty("resultarchive", "store");
+            if((rasProperty != null) && !rasProperty.isEmpty()){
+                final String[] rasPaths = rasProperty.split(",");
+                for (final String rasPath : rasPaths) {
+                    if (!rasPath.trim().isEmpty()) {
+                        logger.debug("Adding Result Archive Store location " + uriDynamicStatusStore.toString());
+                        uriResultArchiveStores.add(new URI(rasPath));
+                    }
                 }
+            }
+
+            if(uriResultArchiveStores.size() == 0) {
+                // Neither environment nor cps have set the RAS location.
+                // Default to a local RAS within galasaHome
+                uriResultArchiveStores.add(localRasUri);
+            }
+
+            if(uriResultArchiveStores.isEmpty()){
+                throw new FrameworkException("No Result Archive Store URIs were provided");
             }
         } catch (final FrameworkException e) {
             throw e;
@@ -496,20 +516,28 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
         IConfigurationPropertyStoreService cpsFramework,
         IFileSystem fileSystem
     ) throws FrameworkException {
+        
         URI uriCredentialsStore ;
         // *** Work out the creds uri
         try {
-            String credsProperty = cpsFramework.getProperty("credentials", "store");
-
-            if ((credsProperty == null) || credsProperty.isEmpty()) {
-                uriCredentialsStore = Paths.get(
-                    this.galasaHome, "credentials.properties")
-                        .toUri();
-                createIfMissing(uriCredentialsStore,fileSystem);
-            } else {
+            String credsProperty = bootstrapProperties.getProperty("framework.credentials.store");
+            if((credsProperty != null) && !credsProperty.isEmpty()){
                 uriCredentialsStore = new URI(credsProperty);
-                createIfMissing(uriCredentialsStore,fileSystem);
+                logger.debug("Credentials Store is " + uriCredentialsStore.toString());
+                createIfMissing(uriCredentialsStore, fileSystem);
+                return uriCredentialsStore;
             }
+
+            credsProperty = cpsFramework.getProperty("credentials", "store");
+            if((credsProperty != null) && !credsProperty.isEmpty()){
+                uriCredentialsStore = new URI(credsProperty);
+                logger.debug("Credentials Store is " + uriCredentialsStore.toString());
+                createIfMissing(uriCredentialsStore, fileSystem);
+                return uriCredentialsStore;
+            }
+            uriCredentialsStore = Paths.get(this.galasaHome, "credentials.properties").toUri();
+            createIfMissing(uriCredentialsStore,fileSystem);
+            
         } catch (final Exception e) {
             throw new FrameworkException("Unable to resolve the Credentials Store URI", e);
         }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkInitialisation.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkInitialisation.java
@@ -111,11 +111,11 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
         }
 
         this.uriConfigurationPropertyStore = locateConfigurationPropertyStore(
-            this.logger, this.bootstrapProperties, this.fileSystem);
+            this.logger, overrideProperties, this.fileSystem);
         this.cpsFramework = initialiseConfigurationPropertyStore(logger,bundleContext);
 
         this.uriDynamicStatusStore = locateDynamicStatusStore(
-            this.logger, this.cpsFramework, this.fileSystem);
+            this.logger, overrideProperties, this.cpsFramework, this.fileSystem);
         this.dssFramework = initialiseDynamicStatusStore(logger,bundleContext);
 
         if (testrun) {
@@ -127,12 +127,12 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
             this.framework.setTestRunName(runName);
         }
 
-        this.uriResultArchiveStores = createUriResultArchiveStores(this.cpsFramework);
+        this.uriResultArchiveStores = createUriResultArchiveStores(overrideProperties, this.cpsFramework);
         logger.debug("Result Archive Stores are " + this.uriResultArchiveStores.toString());
         initialiseResultsArchiveStore(logger,bundleContext);
 
         this.uriCredentialsStore = locateCredentialsStore(
-            this.logger,this.cpsFramework,this.fileSystem);
+            this.logger,overrideProperties,this.cpsFramework,this.fileSystem);
         initialiseCredentialsStore(logger,bundleContext);
 
         initialiseConfidentialTextService(logger,bundleContext);
@@ -355,12 +355,12 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
      */
     URI locateConfigurationPropertyStore(
         Log logger ,
-        Properties bootstrapProperties,
+        Properties overrideProperties,
         IFileSystem fileSystem
     ) throws URISyntaxException {
 
         URI storeUri ;
-        String propUri = bootstrapProperties.getProperty("framework.config.store");
+        String propUri = overrideProperties.getProperty("framework.config.store");
         if ((propUri != null) && (!propUri.isEmpty())) {
             logger.debug("bootstrap property framework.config.store used to determine CPS location.");
         }
@@ -382,13 +382,14 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
     // Note: Not private so we can easily unit test it.
     URI locateDynamicStatusStore(
         Log logger,
+        Properties overrideProperties,
         IConfigurationPropertyStoreService cpsFramework,
         IFileSystem fileSystem
     ) throws FrameworkException {
 
         URI uriDynamicStatusStore = null;
         try {
-            String dssProperty = bootstrapProperties.getProperty("framework.dynamicstatus.store");
+            String dssProperty = overrideProperties.getProperty("framework.dynamicstatus.store");
             if((dssProperty != null) && !dssProperty.isEmpty()){
                 uriDynamicStatusStore = new URI(dssProperty);
                 logger.debug("Dynamic Status Store is " + uriDynamicStatusStore.toString());
@@ -442,6 +443,7 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
      * @throws FrameworkException
      */
     List<URI> createUriResultArchiveStores(
+        Properties overrideProperties,
         IConfigurationPropertyStoreService cpsFramework
     ) throws FrameworkException {
 
@@ -451,7 +453,7 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
         URI localRasUri = localRasPath.toUri();
         try {
 
-            String rasProperty = bootstrapProperties.getProperty("framework.resultarchive.store");
+            String rasProperty = overrideProperties.getProperty("framework.resultarchive.store");
             if((rasProperty != null) && !rasProperty.isEmpty()){
                 final String[] rasPaths = rasProperty.split(",");
                 for (final String rasPath : rasPaths) {
@@ -513,6 +515,7 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
      */
     URI locateCredentialsStore(
         Log logger,
+        Properties overrideProperties,
         IConfigurationPropertyStoreService cpsFramework,
         IFileSystem fileSystem
     ) throws FrameworkException {
@@ -520,7 +523,7 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
         URI uriCredentialsStore ;
         // *** Work out the creds uri
         try {
-            String credsProperty = bootstrapProperties.getProperty("framework.credentials.store");
+            String credsProperty = overrideProperties.getProperty("framework.credentials.store");
             if((credsProperty != null) && !credsProperty.isEmpty()){
                 uriCredentialsStore = new URI(credsProperty);
                 logger.debug("Credentials Store is " + uriCredentialsStore.toString());
@@ -680,4 +683,4 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
                 + this.framework.getConfidentialTextService().getClass().getName());
 
     }
-}
+}   

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkInitialisation.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkInitialisation.java
@@ -389,7 +389,6 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
 
         URI uriDynamicStatusStore = null;
         try {
-
             String dssProperty = overrideProperties.getProperty("framework.dynamicstatus.store");
             if((dssProperty != null) && !dssProperty.isEmpty()){
                 uriDynamicStatusStore = new URI(dssProperty);

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkInitialisation.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkInitialisation.java
@@ -453,7 +453,11 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
         URI localRasUri = localRasPath.toUri();
         try {
 
+<<<<<<< HEAD
             String rasProperty = overrideProperties.getProperty("framework.resultarchive.store");
+=======
+            String rasProperty = bootstrapProperties.getProperty("framework.resultarchive.store");
+>>>>>>> 9b352623 (updates to initialisation)
             if((rasProperty != null) && !rasProperty.isEmpty()){
                 final String[] rasPaths = rasProperty.split(",");
                 for (final String rasPath : rasPaths) {
@@ -523,7 +527,11 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
         URI uriCredentialsStore ;
         // *** Work out the creds uri
         try {
+<<<<<<< HEAD
             String credsProperty = overrideProperties.getProperty("framework.credentials.store");
+=======
+            String credsProperty = bootstrapProperties.getProperty("framework.credentials.store");
+>>>>>>> 9b352623 (updates to initialisation)
             if((credsProperty != null) && !credsProperty.isEmpty()){
                 uriCredentialsStore = new URI(credsProperty);
                 logger.debug("Credentials Store is " + uriCredentialsStore.toString());

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestFrameworkInitialisation.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestFrameworkInitialisation.java
@@ -274,7 +274,7 @@ public class TestFrameworkInitialisation {
 
         // When...
         URI uri = frameworkInit.locateDynamicStatusStore(
-            logger, mockCPS, fs);
+            logger, bootstrap, mockCPS, fs);
 
         // Then...
         assertThat(uri).isNotNull();
@@ -307,7 +307,7 @@ public class TestFrameworkInitialisation {
 
         // When...
         URI uri = frameworkInit.locateDynamicStatusStore(
-            logger, frameworkInit.getFramework().getConfigurationPropertyService("framework"), fs);
+            logger, new Properties(), frameworkInit.getFramework().getConfigurationPropertyService("framework"), fs);
 
         // Then...
         assertThat(uri).isNotNull();
@@ -342,7 +342,7 @@ public class TestFrameworkInitialisation {
 
         // When...
         URI uri = frameworkInit.locateCredentialsStore(
-            logger, mockCPS, fs);
+            logger, new Properties(), mockCPS, fs);
 
         // Then...
         assertThat(uri).isNotNull();
@@ -375,7 +375,7 @@ public class TestFrameworkInitialisation {
 
         // When...
         URI uri = frameworkInit.locateCredentialsStore(
-            logger, frameworkInit.getFramework().getConfigurationPropertyService("framework"), fs);
+            logger, new Properties(), frameworkInit.getFramework().getConfigurationPropertyService("framework"), fs);
 
         // Then...
         assertThat(uri).isNotNull();
@@ -399,7 +399,7 @@ public class TestFrameworkInitialisation {
         MockCPSStore mockCPS = new MockCPSStore(cpsProps);
 
         // When...
-        List<URI> uriList = frameworkInit.createUriResultArchiveStores(mockCPS);
+        List<URI> uriList = frameworkInit.createUriResultArchiveStores(new Properties(), mockCPS);
         assertThat(uriList).contains(URI.create("file:///myoverriddenhome/ras"));
     }
 
@@ -421,7 +421,7 @@ public class TestFrameworkInitialisation {
         MockCPSStore mockCPS = new MockCPSStore(cpsProps);
 
         // When...
-        List<URI> uriList = frameworkInit.createUriResultArchiveStores(mockCPS);
+        List<URI> uriList = frameworkInit.createUriResultArchiveStores(new Properties(),mockCPS);
         assertThat(uriList).contains(URI.create("file:///myuser/home/ras"));
     }
 

--- a/galasa-parent/dev.galasa/build.gradle
+++ b/galasa-parent/dev.galasa/build.gradle
@@ -6,3 +6,17 @@ plugins {
 version = '0.21.0'
 
 description = 'Galasa Testers Programmer Interface (TPI)'
+
+// Note: These values are consumed by the parent build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
+ext.project_name=project.name
+ext.include_in_obr          = true
+ext.include_in_mvp          = true
+ext.include_in_isolated     = false
+ext.include_in_bom          = true
+ext.include_in_codecoverage = true
+ext.include_in_javadoc      = true
+

--- a/galasa-parent/dev.galasa/build.gradle
+++ b/galasa-parent/dev.galasa/build.gradle
@@ -12,11 +12,11 @@ description = 'Galasa Testers Programmer Interface (TPI)'
 // or referenced from.
 // The settings here are gathered together by the build process to create a release.yaml file 
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
-ext.project_name=project.name
-ext.include_in_obr          = true
-ext.include_in_mvp          = true
-ext.include_in_isolated     = false
-ext.include_in_bom          = true
-ext.include_in_codecoverage = true
-ext.include_in_javadoc      = true
+ext.projectName=project.name
+ext.includeInOBR          = true
+ext.includeInMVP          = true
+ext.includeInIsolated     = false
+ext.includeInBOM          = true
+ext.includeInCodeCoverage = true
+ext.includeInJavadoc      = true
 

--- a/galasa-parent/galasa-boot/build.gradle
+++ b/galasa-parent/galasa-boot/build.gradle
@@ -59,3 +59,17 @@ dependencies {
     bundleDependency project (':dev.galasa.framework.maven.repository.spi')
     
 }
+
+// Note: These values are consumed by the parent build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
+ext.project_name=project.name
+ext.include_in_obr          = false
+ext.include_in_mvp          = true
+ext.include_in_isolated     = false
+ext.include_in_bom          = false
+ext.include_in_codecoverage = true
+ext.include_in_javadoc      = false
+

--- a/galasa-parent/galasa-boot/build.gradle
+++ b/galasa-parent/galasa-boot/build.gradle
@@ -65,11 +65,11 @@ dependencies {
 // or referenced from.
 // The settings here are gathered together by the build process to create a release.yaml file 
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
-ext.project_name=project.name
-ext.include_in_obr          = false
-ext.include_in_mvp          = true
-ext.include_in_isolated     = false
-ext.include_in_bom          = false
-ext.include_in_codecoverage = true
-ext.include_in_javadoc      = false
+ext.projectName=project.name
+ext.includeInOBR          = false
+ext.includeInMVP          = true
+ext.includeInIsolated     = false
+ext.includeInBOM          = false
+ext.includeInCodeCoverage = true
+ext.includeInJavadoc      = false
 

--- a/galasa-parent/galasa-testharness/build.gradle
+++ b/galasa-parent/galasa-testharness/build.gradle
@@ -12,3 +12,16 @@ dependencies {
     implementation project(':dev.galasa.framework')
 
 }
+// Note: These values are consumed by the parent build process
+// They indicate which packages of functionality this OSGi bundle should be delivered inside,
+// or referenced from.
+// The settings here are gathered together by the build process to create a release.yaml file 
+// which gathers-up all the packaging metadata about all the OSGi bundles in this component.
+ext.project_name=project.name
+ext.include_in_obr          = false
+ext.include_in_mvp          = false
+ext.include_in_isolated     = false
+ext.include_in_bom          = false
+ext.include_in_codecoverage = false
+ext.include_in_javadoc      = false
+

--- a/galasa-parent/galasa-testharness/build.gradle
+++ b/galasa-parent/galasa-testharness/build.gradle
@@ -17,11 +17,11 @@ dependencies {
 // or referenced from.
 // The settings here are gathered together by the build process to create a release.yaml file 
 // which gathers-up all the packaging metadata about all the OSGi bundles in this component.
-ext.project_name=project.name
-ext.include_in_obr          = false
-ext.include_in_mvp          = false
-ext.include_in_isolated     = false
-ext.include_in_bom          = false
-ext.include_in_codecoverage = false
-ext.include_in_javadoc      = false
+ext.projectName=project.name
+ext.includeInOBR          = false
+ext.includeInMVP          = false
+ext.includeInIsolated     = false
+ext.includeInBOM          = false
+ext.includeInCodeCoverage = false
+ext.includeInJavadoc      = false
 

--- a/set-version.sh
+++ b/set-version.sh
@@ -136,18 +136,25 @@ mkdir -p $temp_dir
 # of the framework component lives.
 # For example: version = "0.29.0"
 cat $BASEDIR/galasa-parent/dev.galasa.framework/build.gradle | sed "s/^[ ]*version[ ]*=.*/version = \"$component_version\"/1" > $temp_dir/framework-build.gradle
+cp $temp_dir/framework-build.gradle $BASEDIR/galasa-parent/dev.galasa.framework/build.gradle
+
 
 # The galasa-parent/dev.galasa.framework/settings.gradle file has a bundleVersion number which needs
 # to be bumped also...
 # eg: bundleVersion = 0.27.0
 cat $BASEDIR/galasa-parent/dev.galasa.framework/settings.gradle | sed "s/^[ ]*bundleVersion[ ]*=.*/bundleVersion = $component_version/1" > $temp_dir/framework-settings.gradle
+cp $temp_dir/framework-settings.gradle $BASEDIR/galasa-parent/dev.galasa.framework/settings.gradle
+
+
+# The parent project also needs to know the version, as it builds the release.yaml file
+# which must have that version also.
+cat $BASEDIR/galasa-parent/build.gradle | sed "s/^[ ]*version[ ]*=.*/version = \"$component_version\"/1" > $temp_dir/framework-parent-build.gradle
+cp $temp_dir/framework-parent-build.gradle $BASEDIR/galasa-parent/build.gradle
 
 
 update_release_yaml ${BASEDIR}/release.yaml $temp_dir/release.yaml
+cp $temp_dir/release.yaml ${BASEDIR}/release.yaml
 
 # Copy the temp files back to where they belong...
 
-cp $temp_dir/framework-build.gradle $BASEDIR/galasa-parent/dev.galasa.framework/build.gradle
-cp $temp_dir/framework-settings.gradle $BASEDIR/galasa-parent/dev.galasa.framework/settings.gradle
-cp $temp_dir/release.yaml ${BASEDIR}/release.yaml
 


### PR DESCRIPTION
- Metadata about each bundle now sits in the `build.gradle` file within that bundle's build process.
- The overall parent project causes that metadata to be rendered into a release.yaml file
- The `release.yaml` file has two 'groups' of bundles: `framework` and `api`
- That `release.yaml` file is published to maven as artifact `dev.galasa/dev.galasa.framework.manifest`
- The new bundle has the same version number as the framework bundle.
  - `set-version.sh` script updated to keep the two in step.

