### PR TITLE
minimum changes to stop CLI-launched tests from blowing up

### DIFF
--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkInitialisation.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkInitialisation.java
@@ -443,6 +443,17 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
         return runName;
     }
 
+    private void processRASlocationProperty(String rasProperty , List<URI> uriResultArchiveStores) throws URISyntaxException {
+        if((rasProperty != null) && !rasProperty.isEmpty()){
+            final String[] rasPaths = rasProperty.split(",");
+            for (final String rasPath : rasPaths) {
+                if (!rasPath.trim().isEmpty()) {
+                    logger.debug("Adding Result Archive Store location " + uriDynamicStatusStore.toString());
+                    uriResultArchiveStores.add(new URI(rasPath));
+                }
+            }
+        }
+    }
 
     /**
      * Creates a list of URIs which refer to Result Archive Stores.
@@ -462,29 +473,18 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
         URI localRasUri = localRasPath.toUri();
         try {
 
+            // Are we using a RAS store indicated by the overrides ?
             String rasProperty = overrideProperties.getProperty("framework.resultarchive.store");
-            if((rasProperty != null) && !rasProperty.isEmpty()){
-                final String[] rasPaths = rasProperty.split(",");
-                for (final String rasPath : rasPaths) {
-                    if (!rasPath.trim().isEmpty()) {
-                        logger.debug("Adding Result Archive Store location " + uriDynamicStatusStore.toString());
-                        uriResultArchiveStores.add(new URI(rasPath));
-                    }
-                }
+            processRASlocationProperty(rasProperty,uriResultArchiveStores);
+
+            
+            if (uriResultArchiveStores.isEmpty()) {
+                // We've not got a RAS store yet, so use the one configured in the CPS...
+                rasProperty = cpsFramework.getProperty("resultarchive", "store");
+                processRASlocationProperty(rasProperty,uriResultArchiveStores);
             }
 
-            rasProperty = cpsFramework.getProperty("resultarchive", "store");
-            if((rasProperty != null) && !rasProperty.isEmpty()){
-                final String[] rasPaths = rasProperty.split(",");
-                for (final String rasPath : rasPaths) {
-                    if (!rasPath.trim().isEmpty()) {
-                        logger.debug("Adding Result Archive Store location " + uriDynamicStatusStore.toString());
-                        uriResultArchiveStores.add(new URI(rasPath));
-                    }
-                }
-            }
-
-            if(uriResultArchiveStores.size() == 0) {
+            if(uriResultArchiveStores.isEmpty()) {
                 // Neither environment nor cps have set the RAS location.
                 // Default to a local RAS within galasaHome
                 uriResultArchiveStores.add(localRasUri);
@@ -623,11 +623,18 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
         for (final ServiceReference<?> rasReference : rasServiceReference) {
             final IResultArchiveStoreRegistration rasRegistration = (IResultArchiveStoreRegistration) bundleContext
                     .getService(rasReference);
-            logger.trace("Found RAS Provider " + rasRegistration.getClass().getName());
-            // Magic here: The ras Registration calls back to this.registerResultArchiveStoreService()
-            // which in turn sets the value into the framework, so that 
-            // ramework.getResultArchiveStoreService() returns non-null.
-            rasRegistration.initialise(this);
+            if (rasRegistration == null) {
+                // Something went wrong. Can't find a RAS service to use.
+                FrameworkException ex = new FrameworkException( new Exception("Unable to find RAS provider."));
+                logger.error("Unable to find RAS provider.", ex);
+                throw ex ;
+            } else {
+                logger.trace("Found RAS Provider " + rasRegistration.getClass().getName());
+                // Magic here: The ras Registration calls back to this.registerResultArchiveStoreService()
+                // which in turn sets the value into the framework, so that 
+                // ramework.getResultArchiveStoreService() returns non-null.
+                rasRegistration.initialise(this);
+            }
         }
         if (this.framework.getResultArchiveStoreService() == null) {
             throw new FrameworkException("Failed to initialise a Result Archive Store, unable to continue");

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestFrameworkInitialisation.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestFrameworkInitialisation.java
@@ -387,7 +387,7 @@ public class TestFrameworkInitialisation {
     }
 
     @Test
-    public void testCreatingRASUriListUsesCPS() throws Exception {
+    public void testCreatingRASUriListUsesCPSNoOverrides() throws Exception {
 
         // As all the logic is inside a constructor ! (bad)
         // we can't call any methods on the class until we have constructed it
@@ -395,12 +395,33 @@ public class TestFrameworkInitialisation {
         FrameworkInitialisation frameworkInit = createFrameworkInit();
 
         Map<String,String> cpsProps = new HashMap<String,String>();
-        cpsProps.put("resultarchive.store","file:///myoverriddenhome/ras");
+        cpsProps.put("resultarchive.store","file:///myoverriddenhome/rasFromCPS");
         MockCPSStore mockCPS = new MockCPSStore(cpsProps);
 
         // When...
         List<URI> uriList = frameworkInit.createUriResultArchiveStores(new Properties(), mockCPS);
-        assertThat(uriList).contains(URI.create("file:///myoverriddenhome/ras"));
+        assertThat(uriList).contains(URI.create("file:///myoverriddenhome/rasFromCPS"));
+    }
+
+    @Test
+    public void testCreatingRASUriListUsesOverridesNotCPS() throws Exception {
+
+        // As all the logic is inside a constructor ! (bad)
+        // we can't call any methods on the class until we have constructed it
+        // using a good passing test...
+        FrameworkInitialisation frameworkInit = createFrameworkInit();
+
+        Map<String,String> cpsProps = new HashMap<String,String>();
+        cpsProps.put("resultarchive.store","file:///myoverriddenhome/rasFromCPS");
+        MockCPSStore mockCPS = new MockCPSStore(cpsProps);
+
+        Properties overrides = new Properties();
+        overrides.setProperty("framework.resultarchive.store", "file:///myoverriddenhome/rasFromOverrides");
+
+        // When...
+        List<URI> uriList = frameworkInit.createUriResultArchiveStores(overrides, mockCPS);
+        assertThat(uriList).contains(URI.create("file:///myoverriddenhome/rasFromOverrides"));
+        assertThat(uriList).doesNotContain(URI.create("file:///myoverriddenhome/rasFromCPS"));
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

If the overrides refer to the RAS to use, use that.
If the overrides don't refer to a RAS, see if the CPS does, and use the CPS value.
If neither overrides nor CPS provide a RAS, use the file RAS by default.


The same fix may be required for the other services, but that can come later.

I can verify that we don't get a null pointer exception if this change goes in when we run a CLI test.
