### PR TITLE
set-version script should update the openapi.yaml doc also

### DIFF
--- a/set-version.sh
+++ b/set-version.sh
@@ -161,4 +161,7 @@ cp $temp_dir/framework-parent-build.gradle $BASEDIR/galasa-parent/build.gradle
 update_release_yaml ${BASEDIR}/release.yaml $temp_dir/release.yaml
 cp $temp_dir/release.yaml ${BASEDIR}/release.yaml
 
-# Copy the temp files back to where they belong...
+
+## Update the openapi file
+cat ${BASEDIR}/openapi.yaml | sed "s/^[ ]*version[ ]*:.*/  version : \"$component_version\"/1" > $temp_dir/openapi.yaml
+cp $temp_dir/openapi.yaml ${BASEDIR}/openapi.yaml


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

The release version should be updated in the openapi.yaml when the time comes.