### PR TITLE
Framework initialiser needs to set galasahome in an eclipse environment

### DIFF
--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/Environment.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/Environment.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.spi;
+
+/** 
+ * An interface through which we can get environment variable values. 
+ * Allows for easy mocking of the System class, which is notoriously hard to mock
+ * out for unit tests.
+ */
+public interface Environment {
+
+    /** Gets the value of a given environment variable. */
+    String getenv(String propertyName);
+
+    /** Gets a system property */
+    String getProperty(String propertyName);
+}

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/SystemEnvironment.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/SystemEnvironment.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.spi;
+
+/**
+ * An implementation of the Environment interface which allows code to get
+ * environment variables from the real system.
+ */
+public class SystemEnvironment implements Environment {
+
+    @Override
+    public String getenv(String propertyName) {
+        return System.getenv(propertyName);
+    }
+
+    @Override
+    public String getProperty(String propertyName) {
+        return System.getProperty(propertyName);
+    }
+    
+}

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestFrameworkInitialisation.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestFrameworkInitialisation.java
@@ -15,6 +15,7 @@ import dev.galasa.framework.mocks.MockCredentialsStore;
 import dev.galasa.framework.mocks.MockCredentialsStoreRegistration;
 import dev.galasa.framework.mocks.MockDSSRegistration;
 import dev.galasa.framework.mocks.MockDSSStore;
+import dev.galasa.framework.mocks.MockEnvironment;
 import dev.galasa.framework.mocks.MockFileSystem;
 import dev.galasa.framework.mocks.MockFramework;
 import dev.galasa.framework.mocks.MockLog;
@@ -80,6 +81,8 @@ public class TestFrameworkInitialisation {
         MockRASStoreService mockRASStoreService = addMockRASToMockServiceRegistry(services, bundle);
         MockCredentialsStore mockCredentialsStore = addMockCredentialsStoreToMockServiceRegistry(services, bundle);
         MockConfidentialTextStore mockConfidentialTextStore = addMockConfidentialTextServiceToMockServiceRegistry(services, bundle);
+        MockEnvironment mockEnv = new MockEnvironment();
+
 
         // When...
         FrameworkInitialisation frameworkInitUnderTest = new FrameworkInitialisation( 
@@ -88,7 +91,8 @@ public class TestFrameworkInitialisation {
             isTestrun,
             logger,
             bundleContext,
-            mockFileSystem);
+            mockFileSystem,
+            mockEnv);
 
         // Then...
         assertThat(mockFramework.getConfidentialTextService()).isEqualTo(mockConfidentialTextStore);
@@ -177,7 +181,7 @@ public class TestFrameworkInitialisation {
         Properties overrideProperties = new Properties();
         boolean isTestrun = true ;
         Log logger = new MockLog();
-//        MockEnvironment mockEnv = new MockEnvironment();
+        MockEnvironment mockEnv = new MockEnvironment();
 
         Map<String,MockServiceReference<?>> services = new HashMap<String,MockServiceReference<?>>();
         
@@ -194,9 +198,9 @@ public class TestFrameworkInitialisation {
                 overrideProperties, 
                 isTestrun,
                 logger, 
-//                mockEnv,
                 bundleContext,
-                mockFileSystem);
+                mockFileSystem,
+                mockEnv);
             fail("There is no CPS service configured on purpose, there should have been an error thrown!");
         } catch( Exception ex ) {
             assertThat(ex)
@@ -216,7 +220,8 @@ public class TestFrameworkInitialisation {
         Properties overrideProperties = new Properties();
         boolean isTestrun = true ;
         Log logger = new MockLog();
-//        MockEnvironment mockEnv = new MockEnvironment();
+        MockEnvironment mockEnv = new MockEnvironment();
+        mockEnv.setProperty("user.home","/home");
 
         Map<String,MockServiceReference<?>> services = new HashMap<String,MockServiceReference<?>>();
 
@@ -240,9 +245,9 @@ public class TestFrameworkInitialisation {
                 overrideProperties, 
                 isTestrun,
                 logger, 
-//                mockEnv,
                 bundleContext,
-                mockFileSystem);
+                mockFileSystem,
+                mockEnv);
             fail("There is no CPS service configured on purpose, there should have been an error thrown!");
         } catch( Exception ex ) {
             assertThat(ex)
@@ -301,11 +306,11 @@ public class TestFrameworkInitialisation {
         
         // A fresh file system...
         MockFileSystem fs = new MockFileSystem();
-//        MockEnvironment mockEnv = new MockEnvironment();
-//        // The user home... which should be ignored if GALASA_HOME is set.
-//        mockEnv.setProperty("user.home","/myuser2/home");
-//        // The value we expect to be used...
-//        mockEnv.setProperty("GALASA_HOME","/myoverriddenhome");
+    //    MockEnvironment mockEnv = new MockEnvironment();
+    //    // The user home... which should be ignored if GALASA_HOME is set.
+    //    mockEnv.setProperty("user.home","/myuser2/home");
+    //    // The value we expect to be used...
+    //    mockEnv.setProperty("GALASA_HOME","/myoverriddenhome");
 
         // When...
         URI uri = frameworkInit.locateDynamicStatusStore(

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockEnvironment.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockEnvironment.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.mocks;
+
+import java.util.*;
+
+import dev.galasa.framework.spi.Environment;
+
+/**
+ * An implementation of the Environment interface which allows code to get
+ * environment variables and system properties from the real system.
+ */
+public class MockEnvironment implements Environment {
+
+    Map<String,String> envProps ;
+    Map<String,String> sysProps ;
+
+    public MockEnvironment(Map<String,String> envProps,Map<String,String> sysProps) {
+        this.envProps = envProps;
+        this.sysProps = sysProps;
+    }
+
+    public MockEnvironment() {
+        this.envProps = new HashMap<String,String>();
+        this.sysProps = new HashMap<String,String>();
+    }
+
+    public void setenv(String propertyName, String value ) {
+        this.envProps.put(propertyName, value);
+    }
+
+    public void setProperty(String propertyName, String value) {
+        this.sysProps.put(propertyName,value);
+    }
+
+    @Override
+    public String getenv(String propertyName) {
+        return this.envProps.get(propertyName);
+    }
+
+    @Override
+    public String getProperty(String propertyName) {
+        return this.sysProps.get(propertyName);
+    }
+
+
+    
+}

--- a/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/felix/FelixFramework.java
+++ b/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/felix/FelixFramework.java
@@ -12,7 +12,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -57,9 +56,7 @@ public class FelixFramework {
     private Bundle obrBundle;
 
     private RepositoryAdmin repositoryAdmin;
-    
-    private final SecureRandom random = new SecureRandom();
-    
+        
     private File felixCache;
 
     /**

--- a/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/ITLauncher.java
+++ b/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/ITLauncher.java
@@ -10,8 +10,6 @@ import static org.junit.Assert.fail;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import dev.galasa.boot.Launcher;
-
 public class ITLauncher {
 
     /**

--- a/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/TestGalasaHome.java
+++ b/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/TestGalasaHome.java
@@ -7,7 +7,6 @@ package dev.galasa.boot;
 
 import static org.assertj.core.api.Assertions.*;
 
-import dev.galasa.boot.Launcher;
 import dev.galasa.boot.mocks.MockEnvironment;
 
 import org.junit.Test;
@@ -24,8 +23,5 @@ public class TestGalasaHome {
         String home = l.getGalasaHome(mockEnv);
 
         assertThat(home).isEqualTo("/Users/hobbit/galasa_home_dir/");
-        
-
-
     }
 }

--- a/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/TestLauncher.java
+++ b/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/TestLauncher.java
@@ -7,7 +7,6 @@ package dev.galasa.boot;
 
 import static org.assertj.core.api.Assertions.*;
 
-import dev.galasa.boot.Launcher;
 import dev.galasa.boot.mocks.MockEnvironment;
 
 import org.junit.Test;
@@ -25,8 +24,6 @@ public class TestLauncher {
         String home = l.getGalasaHome(mockEnv);
 
         assertThat(home).isEqualTo("/Users/hobbit/galasa_home_dir/");
-        
-
 
     }
 


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

To address [Eclipse Plugin: NullPointerException thrown when initialising Galasa#1613](https://github.com/galasa-dev/projectmanagement/issues/1613)

The pulling of information from the system properties and system environment variables was moved to bootstrap (where it is still needed).

Duplicating the code in the framework bundle where it originated from.
Im not happy about duplicating code, but the bootstrap needs it, and can't depend on externals jars for the functionality, where the framework can't include it from the bootstrap... as that would be a circular reference.

So I think this is one of those rare occasions where code has to be near-duplicated, but with different package names.
