### PR TITLE
On windows, detect the user home, and base GALASA_HOME off that if not set explicitly.

### DIFF
--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkInitialisation.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkInitialisation.java
@@ -88,8 +88,23 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
         if( (home == null) || (home.trim().isEmpty())) {
             home = env.getenv(GALASA_HOME);
             if( (home == null) || (home.trim().isEmpty())) {
-                home = env.getProperty(USER_HOME)+"/.galasa";
-                logger.info("System property "+USER_HOME+" used to set value of home location.");
+                String userHome = env.getProperty(USER_HOME);
+                if ( userHome != null ) {
+                    logger.info("System property "+USER_HOME+" ("+userHome+") used to set value of home location.");
+                    home = userHome + "/.galasa";
+                } else {
+                    // On windows, the USERPROFILE environment variable will be set to C:/User/Name or similar.
+                    String userProfile = env.getenv("USERPROFILE");
+                    if (userProfile != null) {
+                        logger.info("System property USERPROFILE ("+userProfile+") used to set value of home location.");
+                        home = userProfile + "/.galasa";
+                    } else {
+                        // Just in case, fall back on a trusty default.
+                        logger.info("Defaulting home to ~/.galasa");
+                        home = "~/.galasa";
+                    }
+                }
+                
             } else {
                 logger.info("Environment variable GALASA_HOME used to set value of home location.");
             }

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockEnvironment.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockEnvironment.java
@@ -45,7 +45,5 @@ public class MockEnvironment implements Environment {
     public String getProperty(String propertyName) {
         return this.sysProps.get(propertyName);
     }
-
-
     
 }


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

Trying to default the galasa home folder to pick up the users' home directory. 
On windows, this 'should' be set into the USERPROFILE environment variable.
