### PR TITLE
Allow environment variables to be picked up correctly

### DIFF
--- a/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/Launcher.java
+++ b/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/Launcher.java
@@ -649,7 +649,7 @@ public class Launcher {
         String RAS_ENV_VAR = "GALASA_RESULTARCHIVE_STORE";
         String CREDS_ENV_VAR = "GALASA_CREDENTIALS_STORE";
 
-        String cps = env.getProperty(CPS_ENV_VAR);
+        String cps = env.getenv(CPS_ENV_VAR);
 
         if( (cps != null) && (!cps.trim().isEmpty())){
             cps = cps.trim();
@@ -657,21 +657,21 @@ public class Launcher {
             bootstrap.setProperty("framework.config.store",cps);
         }
 
-        String dss = env.getProperty(DSS_ENV_VAR);
+        String dss = env.getenv(DSS_ENV_VAR);
         if( (dss != null) && (!dss.trim().isEmpty())){
             dss = dss.trim();
             logger.info(String.format("Environment variable: %s used to locate DSS location",DSS_ENV_VAR));
             bootstrap.setProperty("framework.dynamicstatus.store",dss);
         }
 
-        String ras = env.getProperty(RAS_ENV_VAR);
+        String ras = env.getenv(RAS_ENV_VAR);
         if( (ras != null) && (!ras.trim().isEmpty())){
             ras = ras.trim();
             logger.info(String.format("Environment variable: %s used to locate RAS location",RAS_ENV_VAR));
             bootstrap.setProperty("framework.resultarchive.store",ras);
         }
 
-        String creds = env.getProperty(CREDS_ENV_VAR);
+        String creds = env.getenv(CREDS_ENV_VAR);
         if( (creds != null) && (!creds.trim().isEmpty())){
             creds = creds.trim();
             logger.info(String.format("Environment variable: %s used to locate credentials store location",CREDS_ENV_VAR));

--- a/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/TestLauncher.java
+++ b/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/TestLauncher.java
@@ -34,16 +34,16 @@ public class TestLauncher {
         Properties bootstrap = new Properties();
 
         bootstrap.setProperty("framework.config.store","/this/should/be/ignored.properties");
-        me.setProperty("GALASA_CONFIG_STORE","/Users/hobbit/galasa_home/cps.properties");
+        me.setenv("GALASA_CONFIG_STORE","/Users/hobbit/galasa_home/cps.properties");
 
         bootstrap.setProperty("framework.dynamicstatus.store","/this/should/be/ignored.properties");
-        me.setProperty("GALASA_DYNAMICSTATUS_STORE","/Users/hobbit/galasa_home/dss.properties");
+        me.setenv("GALASA_DYNAMICSTATUS_STORE","/Users/hobbit/galasa_home/dss.properties");
 
         bootstrap.setProperty("framework.resultarchive.store","/this/should/be/ignored/ras");
-        me.setProperty("GALASA_RESULTARCHIVE_STORE","/Users/hobbit/galasa_home/ras");
+        me.setenv("GALASA_RESULTARCHIVE_STORE","/Users/hobbit/galasa_home/ras");
 
         bootstrap.setProperty("framework.credentials.store","/this/should/be/ignored.properties");
-        me.setProperty("GALASA_CREDENTIALS_STORE","/Users/hobbit/galasa_home/creds.properties");
+        me.setenv("GALASA_CREDENTIALS_STORE","/Users/hobbit/galasa_home/creds.properties");
 
         l.setStoresFromEnvironmentVariables(me,bootstrap);
 
@@ -59,13 +59,13 @@ public class TestLauncher {
         MockEnvironment me = new MockEnvironment();
         Properties bootstrap = new Properties();
 
-        me.setProperty("GALASA_CONFIG_STORE","/Users/hobbit/galasa_home/cps.properties");
+        me.setenv("GALASA_CONFIG_STORE","/Users/hobbit/galasa_home/cps.properties");
 
-        me.setProperty("GALASA_DYNAMICSTATUS_STORE","/Users/hobbit/galasa_home/dss.properties");
+        me.setenv("GALASA_DYNAMICSTATUS_STORE","/Users/hobbit/galasa_home/dss.properties");
 
-        me.setProperty("GALASA_RESULTARCHIVE_STORE","/Users/hobbit/galasa_home/ras");
+        me.setenv("GALASA_RESULTARCHIVE_STORE","/Users/hobbit/galasa_home/ras");
 
-        me.setProperty("GALASA_CREDENTIALS_STORE","/Users/hobbit/galasa_home/creds.properties");
+        me.setenv("GALASA_CREDENTIALS_STORE","/Users/hobbit/galasa_home/creds.properties");
 
         l.setStoresFromEnvironmentVariables(me,bootstrap);
 
@@ -104,16 +104,16 @@ public class TestLauncher {
         Properties bootstrap = new Properties();
 
         bootstrap.setProperty("framework.config.store","/this/should/be/ignored.properties");
-        me.setProperty("GALASA_CONFIG_STORE","/Users/hobbit/galasa_home/cps.properties  ");
+        me.setenv("GALASA_CONFIG_STORE","/Users/hobbit/galasa_home/cps.properties  ");
 
         bootstrap.setProperty("framework.dynamicstatus.store","/this/should/be/ignored.properties");
-        me.setProperty("GALASA_DYNAMICSTATUS_STORE","  /Users/hobbit/galasa_home/dss.properties");
+        me.setenv("GALASA_DYNAMICSTATUS_STORE","  /Users/hobbit/galasa_home/dss.properties");
 
         bootstrap.setProperty("framework.resultarchive.store","/this/should/be/ignored/ras");
-        me.setProperty("GALASA_RESULTARCHIVE_STORE"," /Users/hobbit/galasa_home/ras  ");
+        me.setenv("GALASA_RESULTARCHIVE_STORE"," /Users/hobbit/galasa_home/ras  ");
 
         bootstrap.setProperty("framework.credentials.store","/this/should/be/ignored.properties");
-        me.setProperty("GALASA_CREDENTIALS_STORE","/Users/hobbit/galasa_home/creds.properties");
+        me.setenv("GALASA_CREDENTIALS_STORE","/Users/hobbit/galasa_home/creds.properties");
 
         l.setStoresFromEnvironmentVariables(me,bootstrap);
 

--- a/test-api-locally.md
+++ b/test-api-locally.md
@@ -46,7 +46,7 @@ Please note that the version numbers in these commmands will need to be updated 
 
 ```shell
 export GALASA_OBR_VERSION=0.31.0
-export GALASA_BOOT_JAR_VERSION=0.30.0
+export GALASA_BOOT_JAR_VERSION=0.31.0
 alias galasaapi='java -jar ~/.m2/repository/dev/galasa/galasa-boot/${GALASA_BOOT_JAR_VERSION}/galasa-boot-${GALASA_BOOT_JAR_VERSION}.jar --api --localmaven file://${HOME}/.m2/repository/ --remotemaven https://development.galasa.dev/ --obr mvn:dev.galasa/dev.galasa.uber.obr/${GALASA_OBR_VERSION}/obr ;'
 
 alias galasatest='java -jar ~/.m2/repository/dev/galasa/galasa-boot/${GALASA_BOOT_JAR_VERSION}/galasa-boot-${GALASA_BOOT_JAR_VERSION}.jar --api --localmaven file://${HOME}/.m2/repository/ --remotemaven https://development.galasa.dev/  --obr mvn:dev.galasa/dev.galasa.uber.obr/${GALASA_OBR_VERSION}/obr  --obr mvn:dev.galasa.example.banking/dev.galasa.example.banking.obr/0.0.1-SNAPSHOT/obr --test dev.galasa.example.banking.account/dev.galasa.example.banking.account.TestAccount;'


### PR DESCRIPTION
For https://github.com/galasa-dev/projectmanagement/issues/1634

- Replaced the usage of `getProperty` with `getenv` when getting environment variables
- Fixed the unit tests to correctly use `setenv` instead of `setProperty` when setting environment variables
- Bumped galasa-boot to 0.31.0