### PR TITLE
Validate the openapi.yaml file is valid during every build

### DIFF
--- a/galasa-parent/dev.galasa.framework.api.openapi/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api.openapi/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'biz.aQute.bnd.builder'
     id 'maven-publish'
     id 'galasa.java'
+    id "org.openapi.generator" version "6.6.0"
 }
 
 description = 'Galasa Open API specification'
@@ -19,6 +20,15 @@ repositories {
 
 configurations {
     conf
+}
+
+// Validating a single specification
+openApiValidate {
+    inputSpec.set("$projectDir/src/main/resources/openapi.yaml")
+}
+
+tasks.named('build') { 
+    dependsOn('openApiValidate') 
 }
 
 // Publish the openapi.yaml on it's own as a special artifact.


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

- Validates that the openapi.yaml file is valid during every build.
- I tested it with a bad version of the openapi.yaml (since discarded) and got an error like this:
```

Building...
➜ Building goals buildReleaseYaml build check jacocoTestReport
➜ Using this command: gradle --build-cache --parallel     --console=plain     --warning-mode=all     -Dorg.gradle.java.home=/Users/mcobbett/.sdkman/candidates/java/current     -PsourceMaven=https://development.galasa.dev/main/maven-repo/obr/ -info     buildReleaseYaml build check jacocoTestReport     
Error parsing content
com.fasterxml.jackson.dataformat.yaml.snakeyaml.error.MarkedYAMLException: while parsing a flow mapping
 in 'reader', line 8, column 15:
    badOnPurpise: { # Unclosed bracket
                  ^
expected ',' or '}', but got :
 in 'reader', line 10, column 5:
    info:
        ^

 at [Source: (StringReader); line: 10, column: 5]
        at com.fasterxml.jackson.dataformat.yaml.snakeyaml.error.MarkedYAMLException.from(MarkedYAMLException.java:28)
        ... stack trace...
        at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: while parsing a flow mapping
 in 'reader', line 8, column 15:
    badOnPurpise: { # Unclosed bracket
                  ^
expected ',' or '}', but got :
 in 'reader', line 10, column 5:
    info:
        ^

        at org.yaml.snakeyaml.parser.ParserImpl$ParseFlowMappingKey.produce(ParserImpl.java:919)
        at org.yaml.snakeyaml.parser.ParserImpl.peekEvent(ParserImpl.java:185)
        at org.yaml.snakeyaml.parser.ParserImpl.getEvent(ParserImpl.java:195)
        at com.fasterxml.jackson.dataformat.yaml.YAMLParser.nextToken(YAMLParser.java:419)
        ... 144 more
failed to read resource listing
com.fasterxml.jackson.core.JsonParseException: Unexpected character ('#' (code 35)): expected a valid value (JSON String, Number, Array, Object or token 'null', 'true' or 'false')
 at [Source: (StringReader); line: 1, column: 2]
        at com.fasterxml.jackson.core.JsonParser._constructError(JsonParser.java:2418)
        at ... stack trace...

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':dev.galasa.framework.api.openapi:openApiValidate'.
> Validation failed.

```