### PR TITLE
openapi REST call still returns older structure, not the new one. Fixed regression.

### DIFF
--- a/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -642,6 +642,11 @@ paths:
       operationId: getCpsNamespaceCascadeProperty
       deprecated: true
       summary: Get cascade CPS property
+      description: |
+        Searches for a property using namespace, prefix suffix and infixes. 
+        Deprecated in v0.31.0.
+        Use the /cps/{namespace}/properties call instead, using the prefix, suffix and infix query parameters, instead of this call.
+        This call will be removed in a future version of this REST API.
       tags:
       - Configuration Property Store API
       parameters:
@@ -684,7 +689,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GalasaProperty'
+                $ref: '#/components/schemas/CpsProperty'
         '401':
           description: Unauthorized as valid authentication has not been provided
           content:


### PR DESCRIPTION
The `/cps/namespace/{namespace}/prefix/{prefix}/suffix/{suffix}` call was messed-up in the openapi.yaml file.

The call actually returns an CpsProperty, but the yaml file said it should return a GalasaProperty, so any client generated to use this REST interface would get confused with what the servlet layer would return.

