### PR TITLE
Update TestRunner.java

### DIFF
--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
@@ -569,7 +569,7 @@ public class TestRunner {
     }
 
     private void stopEnvironment(TestRunManagers managers) {
-        if (this.runType == RunType.SHARED_ENVIRONMENT_BUILD) {   
+        if (this.runType != RunType.SHARED_ENVIRONMENT_BUILD) {   
             logger.info("Starting Provision Stop phase");
             managers.provisionStop();
         }


### PR DESCRIPTION
Signed-off-by: Tom Slattery [tom.slattery@no-reply.com](mailto:tom.slattery@no-reply.com)

Currently, provision stop can only occur if the run type is not SHARED_ENVIRONMENT_BUILD. I think this is a mistake - Share Environment Builds are intended to keep the environment around after the test have been run.

In the case where you are running a regular non-shared environment test run, the test environment will not have the Provision Stop phase run against it, but will later have Provision Discard run.

I was finding for my test environments the Provision Discard phase was timing out as the resources were being held onto because they had not been stopped due to Provision Stop being skipped.

I have updated the test runner to be consistent in behaviour for both Provision Stop and Provision Discard, so that the environment is properly stopped and discarded for non shared environment runs.

Opening a new PR for DCO check