### PR TITLE
Updates to Runs Reset/Cancel servlet and schema. 

### DIFF
--- a/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
@@ -21,13 +21,13 @@ public enum ServletErrorMessage {
     GAL5013_RESULT_NAME_NOT_RECOGNIZED                (5013,"E: Error parsing the query parameters. 'result' value ''{0}'' not recognised. Expected result name to match one of the following ''{1}''."),
     GAL5014_STATUS_NAME_NOT_RECOGNIZED                (5014,"E: Error parsing the query parameters. 'status' value ''{0}'' not recognised. Expected status name to match one of the following ''{1}''."),
 
-    // RunsReset/Delete...
+    // RunsReset/Cancel...
     GAL5045_INVALID_STATUS_UPDATE_REQUEST             (5045, "E: Error occured. The field ''status'' in the request body is invalid. The ''status'' value ''{0}'' supplied is not supported. Supported values are: ''queued'' and ''finished''."),
-    GAL5046_UNABLE_TO_DELETE_RUN_INVALID_RESULT       (5046, "E: Error occured when trying to delete the run ''{0}''. The ''result'' ''{1}' supplied is not supported. Supported values are: ''cancelled''."),
+    GAL5046_UNABLE_TO_CANCEL_RUN_INVALID_RESULT       (5046, "E: Error occured when trying to cancel the run ''{0}''. The ''result'' ''{1}''' supplied is not supported. Supported values are: ''cancelled''."),
     GAL5047_UNABLE_TO_RESET_RUN                       (5047, "E: Error occured when trying to reset the run ''{0}''. Report the problem to your Galasa Ecosystem owner."),
-    GAL5048_UNABLE_TO_DELETE_RUN                      (5048, "E: Error occured when trying to delete the run ''{0}''. Report the problem to your Galasa Ecosystem owner."),
+    GAL5048_UNABLE_TO_CANCEL_RUN                      (5048, "E: Error occured when trying to cancel the run ''{0}''. Report the problem to your Galasa Ecosystem owner."),
     GAL5049_UNABLE_TO_RESET_COMPLETED_RUN             (5049, "E: Error occured when trying to reset the run ''{0}''. The run has already completed."),
-    GAL5050_UNABLE_TO_DELETE_COMPLETED_RUN            (5050, "E: Error occured when trying to delete the run ''{0}''. The run has already completed."),
+    GAL5050_UNABLE_TO_CANCEL_COMPLETED_RUN            (5050, "E: Error occured when trying to cancel the run ''{0}''. The run has already completed."),
     
     // RunArtifactsList...
     GAL5007_ERROR_RETRIEVING_ARTIFACTS_LIST           (5007,"E: Error retrieving artifacts for run with identifier ''{0}''."),

--- a/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -1367,7 +1367,7 @@ paths:
                   value: Successfully reset run U123
                   summary: Reset run action success
                 deleteRun:
-                  value: Successfuly deleted run U123
+                  value: Successfully deleted run U123
                   summary: Delete run action success
         '400':
           description: Bad request
@@ -2008,7 +2008,7 @@ components:
         status:
           type: string
           enum: ["queued","finished"]
-        results:
+        result:
           type: string
           enum: ["","cancelled"]
     Requestors:

--- a/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -1335,7 +1335,7 @@ paths:
 
   #--------------------------------------
   # Update the status of an active test 
-  # run to reset or delete it.
+  # run to reset or cancel it.
   #--------------------------------------
     put:
       summary: Update the status of a test run
@@ -1366,9 +1366,9 @@ paths:
                 resetRun:
                   value: Successfully reset run U123
                   summary: Reset run action success
-                deleteRun:
-                  value: Successfully deleted run U123
-                  summary: Delete run action success
+                cancelRun:
+                  value: Successfully cancelled run U123
+                  summary: Cancel run action success
         '400':
           description: Bad request
           content:
@@ -1379,7 +1379,7 @@ paths:
                 invalidStatusUpdateRequest:
                   value:
                     error_code: 5045
-                    error_message: "GAL5045E: Error occured. The field 'status' in the request body is invalid. The 'status' value 'create' supplied is not supported. Supported values are: 'delete' and 'reset'"
+                    error_message: "GAL5045E: Error occured. The field 'status' in the request body is invalid. The 'status' value 'create' supplied is not supported. Supported values are: 'cancel' and 'reset'"
                   summary: An error occured because the status field does not contain an expected action
                 runNameDoesNotMatch:
                   value:
@@ -1391,11 +1391,11 @@ paths:
                     error_code: 5049
                     error_message: "GAL5049E: Error occured when trying to reset the run ''{0}''. The run has already completed."
                   summary: The run in the request has already completed and can not be reset
-                deleteRunHasAlreadyCompleted:
+                cancelRunHasAlreadyCompleted:
                   value:
                     error_code: 5050
-                    error_message: "GAL5050E: Error occured when trying to delete the run 'U123'. The run has already completed."
-                  summary: The run in the request has already completed and can not be deleted        
+                    error_message: "GAL5050E: Error occured when trying to cancel the run 'U123'. The run has already completed."
+                  summary: The run in the request has already completed and can not be cancelled        
         '401':
           description: Unauthorized as valid authentication has not been provided
           content:
@@ -1425,11 +1425,11 @@ paths:
                    error_code: 5047
                    error_message: "GAL5047E: Error occured when trying to reset the run 'U123'. Report the problem to your Galasa Ecosystem owner."
                   summary: An error occured when trying to action the run reset
-                unableToDelete:
+                unableToCancel:
                   value:
                     error_code: 5048
-                    error_message: "GAL5048E: Error occured when trying to delete the run 'U123'. Report the problem to your Galasa Ecosystem owner."
-                  summary: An error occured when trying to action the run delete
+                    error_message: "GAL5048E: Error occured when trying to cancel the run 'U123'. Report the problem to your Galasa Ecosystem owner."
+                  summary: An error occured when trying to action the run cancel
   #--------------------------------------
   # Retrieve Run Log.
   #--------------------------------------

--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunDetailsRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunDetailsRoute.java
@@ -91,7 +91,7 @@ public class RunDetailsRoute extends RunsRoute {
       } else if (status == RunActionStatus.FINISHED) {
          cancelRun(runName, result);
          logger.info("Run cancelled by external source.");
-         responseBody = String.format("Successfully deleted run %s", runName);
+         responseBody = String.format("Successfully cancelled run %s", runName);
       } 
       return responseBody;
    }
@@ -144,17 +144,18 @@ public class RunDetailsRoute extends RunsRoute {
    private void cancelRun(String runName, String result) throws InternalServletException {
       boolean isCanceled = false;
       if (!result.equalsIgnoreCase("cancelled")){
-         ServletError error = new ServletError(GAL5046_UNABLE_TO_DELETE_RUN_INVALID_RESULT, runName, result);
+         ServletError error = new ServletError(GAL5046_UNABLE_TO_CANCEL_RUN_INVALID_RESULT, runName, result);
          throw new InternalServletException(error, HttpServletResponse.SC_BAD_REQUEST);
       }
       try {
+         // Cancelling a run works by deleting all its entries in the DSS
          isCanceled = framework.getFrameworkRuns().delete(runName);
       } catch (FrameworkException e) {
-         ServletError error = new ServletError(GAL5048_UNABLE_TO_DELETE_RUN, runName);
+         ServletError error = new ServletError(GAL5048_UNABLE_TO_CANCEL_RUN, runName);
          throw new InternalServletException(error, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e);
       }
       if (!isCanceled) {
-         ServletError error = new ServletError(GAL5050_UNABLE_TO_DELETE_COMPLETED_RUN, runName);
+         ServletError error = new ServletError(GAL5050_UNABLE_TO_CANCEL_COMPLETED_RUN, runName);
          throw new InternalServletException(error, HttpServletResponse.SC_BAD_REQUEST);
       }
    }

--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunDetailsRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunDetailsRoute.java
@@ -86,9 +86,11 @@ public class RunDetailsRoute extends RunsRoute {
          throw new InternalServletException(error, HttpServletResponse.SC_BAD_REQUEST);
       } else if (status == RunActionStatus.QUEUED) {
          resetRun(runName);
+         logger.info("Run reset by external source.");
          responseBody = String.format("Successfully reset run %s", runName);
       } else if (status == RunActionStatus.FINISHED) {
          cancelRun(runName, result);
+         logger.info("Run cancelled by external source.");
          responseBody = String.format("Successfully deleted run %s", runName);
       } 
       return responseBody;

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunDetailsRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunDetailsRoute.java
@@ -360,7 +360,7 @@ public class TestRunDetailsRoute extends RasServletTest {
 	}
 
 	@Test
-	public void testRequestToDeleteRunReturnsOK() throws Exception {
+	public void testRequestToCancelRunReturnsOK() throws Exception {
 		// Given...
 		String runId = "xx12345xx";
 		String runName = "U123";
@@ -390,11 +390,11 @@ public class TestRunDetailsRoute extends RasServletTest {
 
 		// Then...
 		assertThat(resp.getStatus()).isEqualTo(200);
-		assertThat(outStream.toString()).isEqualTo("Successfully deleted run " + runName);
+		assertThat(outStream.toString()).isEqualTo("Successfully cancelled run " + runName);
 	}
 
 	@Test
-	public void testRequestToDeleteRunCapitalCaseValuesReturnsOK() throws Exception {
+	public void testRequestToCancelRunCapitalCaseValuesReturnsOK() throws Exception {
 		// Given...
 		String runId = "xx12345xx";
 		String runName = "U123";
@@ -424,7 +424,7 @@ public class TestRunDetailsRoute extends RasServletTest {
 
 		// Then...
 		assertThat(resp.getStatus()).isEqualTo(200);
-		assertThat(outStream.toString()).isEqualTo("Successfully deleted run " + runName);
+		assertThat(outStream.toString()).isEqualTo("Successfully cancelled run " + runName);
 	}
 
 	@Test
@@ -505,7 +505,7 @@ public class TestRunDetailsRoute extends RasServletTest {
 	}
 
 	@Test
-	public void testRequestToDeleteRunFailsReturnsError() throws Exception {
+	public void testRequestToCancelRunFailsReturnsError() throws Exception {
 		// Given...
 		String runId = "xx12345xx";
 		String runName = "U123";
@@ -542,7 +542,7 @@ public class TestRunDetailsRoute extends RasServletTest {
 		assertThat(resp.getStatus()).isEqualTo(500);
 		checkErrorStructure(outStream.toString(), 
 			5048, 
-			"E: Error occured when trying to delete the run 'U123'. Report the problem to your Galasa Ecosystem owner.");
+			"E: Error occured when trying to cancel the run 'U123'. Report the problem to your Galasa Ecosystem owner.");
 	}
 	
 	@Test
@@ -587,7 +587,7 @@ public class TestRunDetailsRoute extends RasServletTest {
 	}
 
 	@Test
-	public void testRequestToDeleteRunNoLongerProcessingReturnsError() throws Exception {
+	public void testRequestToCancelRunNoLongerProcessingReturnsError() throws Exception {
 		// Given...
 		String runId = "xx12345xx";
 		String runName = "U123";
@@ -624,11 +624,11 @@ public class TestRunDetailsRoute extends RasServletTest {
 		assertThat(resp.getStatus()).isEqualTo(400);
 		checkErrorStructure(outStream.toString(), 
 			5050, 
-			"E: Error occured when trying to delete the run 'U123'. The run has already completed.");
+			"E: Error occured when trying to cancel the run 'U123'. The run has already completed.");
 	}
 
 	@Test
-	public void testRequestToDeleteRunBadResultReturnsError() throws Exception {
+	public void testRequestToCancelRunBadResultReturnsError() throws Exception {
 		// Given...
 		String runId = "xx12345xx";
 		String runName = "U123";
@@ -660,7 +660,7 @@ public class TestRunDetailsRoute extends RasServletTest {
 		assertThat(resp.getStatus()).isEqualTo(400);
 		checkErrorStructure(outStream.toString(), 
 			5046, 
-			"E: Error occured when trying to delete the run 'U123'. The 'result' 'deleted supplied is not supported. Supported values are: 'cancelled'.");
+			"E: Error occured when trying to cancel the run 'U123'. The 'result' 'deleted' supplied is not supported. Supported values are: 'cancelled'.");
 	}
 
 }


### PR DESCRIPTION
...for test runs to know when they've been reset or cancelled.

1. I've made this change as the plural "results" made me think the body of the PUT request should be "results":"finished" but it is "result", as that's what the transport bean expects.

Additionally, the functions for the CLI don't seem quite right when using the plural:
`updateRunStatusRequest.SetResults(result)`

Confirmed with Mike it's more suitable as "result".

2. Additionally, I have added a logging message into the servlet as from the test's run logs perspective, unless you were the person who reset or cancelled the run, there is no info for why the run reset/cancelled. 
```29/01/2024 11:53:38.020 INFO  d.g.l.i.s.LinuxSharedImage - Discarded Linux shared image X with username X
29/01/2024 11:53:38.750 DEBUG d.g.f.TestRunner - isRunOK: true runType: TEST
29/01/2024 11:53:38.752 DEBUG d.g.f.TestRunner - Test did not run OK... or runtype is not SHARED_ENVIRONMENT_BUILD
29/01/2024 11:53:38.854 DEBUG d.g.f.TestRunner - Stopping heartbeat...
```

3. "Delete" changed to "Cancel" as the CLI command will be `galasactl runs cancel` so this is more aligned.