### PR TITLE
Remove client secret from auth request parameters, use Dex's new GetClient gRPC method

### DIFF
--- a/galasa-parent/build.gradle
+++ b/galasa-parent/build.gradle
@@ -53,6 +53,7 @@ subprojects {
 //----------------------------------------------------------
 // Download the Dex gRPC API .proto file
 //----------------------------------------------------------
+def dexVersion = "v2.38.0"
 def protoDirPath = "$rootDir/dev.galasa.framework.api.authentication/src/main/proto"
 def protoDir = new File(protoDirPath)
 def dexProtoFile = new File("$protoDirPath/dex.proto")
@@ -66,7 +67,7 @@ task downloadDexProto() {
         }
 
         // Download Dex's api.proto file from GitHub
-        new URL("https://raw.githubusercontent.com/dexidp/dex/v2.37.0/api/v2/api.proto").withInputStream{
+        new URL("https://raw.githubusercontent.com/dexidp/dex/$dexVersion/api/v2/api.proto").withInputStream{
             inputStream -> dexProtoFile.withOutputStream{ outputStream -> outputStream << inputStream }
         }
     }

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/JwtAuthFilter.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/JwtAuthFilter.java
@@ -46,8 +46,15 @@ public class JwtAuthFilter implements Filter {
 
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
-        oidcProvider = new OidcProvider(env.getenv(EnvironmentVariables.GALASA_DEX_ISSUER), HttpClient.newHttpClient());
-        logger.info("Galasa JWT Auth Filter initialised");
+        String dexIssuerUrl = env.getenv(EnvironmentVariables.GALASA_DEX_ISSUER);
+
+        if (dexIssuerUrl != null) {
+            oidcProvider = new OidcProvider(dexIssuerUrl, HttpClient.newHttpClient());
+            logger.info("Galasa JWT Auth Filter initialised");
+        } else {
+            throw new ServletException("Unable to initialise JWT auth filter. Required environment variable '"
+                + EnvironmentVariables.GALASA_DEX_ISSUER + "' has not been set.");
+        }
     }
 
     @Override

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/DexClient.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/DexClient.java
@@ -15,19 +15,11 @@ public class DexClient {
     @SerializedName("client_id")
     private String clientId;
 
-    @SerializedName("client_secret")
-    private String clientSecret;
-
-    public DexClient(String clientId, String clientSecret) {
+    public DexClient(String clientId) {
         this.clientId = clientId;
-        this.clientSecret = clientSecret;
     }
 
     public String getClientId() {
         return clientId;
-    }
-
-    public String getClientSecret() {
-        return clientSecret;
     }
 }

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/DexGrpcClient.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/DexGrpcClient.java
@@ -13,6 +13,8 @@ import com.coreos.dex.api.DexGrpc.DexBlockingStub;
 import com.coreos.dex.api.DexOuterClass.Client;
 import com.coreos.dex.api.DexOuterClass.CreateClientReq;
 import com.coreos.dex.api.DexOuterClass.CreateClientResp;
+import com.coreos.dex.api.DexOuterClass.GetClientReq;
+import com.coreos.dex.api.DexOuterClass.GetClientResp;
 import com.coreos.dex.api.DexOuterClass.CreateClientReq.Builder;
 
 import io.grpc.ManagedChannel;
@@ -63,6 +65,32 @@ public class DexGrpcClient {
     }
 
     /**
+     * Returns a Dex client with a given client ID, or null if no such client exists.
+     *
+     * @param clientId the ID of the client to retrieve
+     */
+    public Client getClient(String clientId) {
+        logger.info("Retrieving Dex client with ID: " + clientId);
+
+        // Build the GetClient request
+        com.coreos.dex.api.DexOuterClass.GetClientReq.Builder getClientReqBuilder = GetClientReq.newBuilder();
+        getClientReqBuilder.setId(clientId);
+
+        // Send the gRPC call to get the Dex client
+        GetClientReq getClientReq = getClientReqBuilder.build();
+        GetClientResp clientResp = sendGetClientRequest(getClientReq);
+
+        Client client = null;
+        if (clientResp.hasClient()) {
+            logger.info("Dex client successfully retrieved");
+            client = clientResp.getClient();
+        } else {
+            logger.error("Failed to get the Dex client with ID: " + clientId);
+        }
+        return client;
+    }
+
+    /**
      * Initialises a blocking stub to be used when sending requests to Dex's gRPC
      * API.
      *
@@ -81,5 +109,15 @@ public class DexGrpcClient {
      */
     protected CreateClientResp sendCreateClientRequest(CreateClientReq createClientReq) {
         return blockingStub.createClient(createClientReq);
+    }
+
+    /**
+     * Sends a request to get a Dex client.
+     *
+     * @param getClientReq the request to send
+     * @return the response received from Dex's gRPC API
+     */
+    protected GetClientResp sendGetClientRequest(GetClientReq getClientReq) {
+        return blockingStub.getClient(getClientReq);
     }
 }

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/TokenPayload.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/TokenPayload.java
@@ -17,9 +17,6 @@ public class TokenPayload {
     @SerializedName("client_id")
     private String clientId;
 
-    @SerializedName("secret")
-    private String secret;
-
     @SerializedName("refresh_token")
     private String refreshToken;
 
@@ -30,19 +27,11 @@ public class TokenPayload {
         return clientId;
     }
 
-    public String getSecret() {
-        return secret;
-    }
-
     public String getRefreshToken() {
         return refreshToken;
     }
 
     public String getCode() {
         return code;
-    }
-
-    public boolean isValid() {
-        return (clientId != null) && (secret != null) && (refreshToken != null || code != null);
     }
 }

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthClientsRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthClientsRoute.java
@@ -51,7 +51,7 @@ public class AuthClientsRoute extends BaseRoute {
         }
 
         // Marshal into a structure to be returned as JSON
-        DexClient clientToReturn = new DexClient(newDexClient.getId(), newDexClient.getSecret());
+        DexClient clientToReturn = new DexClient(newDexClient.getId());
         return getResponseBuilder().buildResponse(response, "application/json", gson.toJson(clientToReturn),
                 HttpServletResponse.SC_CREATED);
     }

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthRoute.java
@@ -161,8 +161,9 @@ public class AuthRoute extends BaseRoute {
         if (dexClient != null) {
             String clientSecret = dexClient.getSecret();
 
-            // Refresh tokens and authorization codes can be used in exchange for JWTs,
-            // so we need to find out what method was used
+            // Refresh tokens and authorization codes can be used in exchange for JWTs.
+            // At this point, we either have a refresh token or an authorization code,
+            // so perform the relevant POST request
             HttpResponse<String> tokenResponse = null;
             if (refreshToken != null) {
                 tokenResponse = oidcProvider.sendTokenPost(clientId, clientSecret, refreshToken);

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/DexGrpcClientTest.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/DexGrpcClientTest.java
@@ -10,74 +10,61 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.Test;
 
 import com.coreos.dex.api.DexOuterClass.Client;
-import com.coreos.dex.api.DexOuterClass.CreateClientReq;
-import com.coreos.dex.api.DexOuterClass.CreateClientResp;
-import com.coreos.dex.api.DexOuterClass.CreateClientResp.Builder;
 
-import dev.galasa.framework.api.authentication.internal.DexGrpcClient;
+import dev.galasa.framework.api.authentication.mocks.MockDexGrpcClient;
 
 public class DexGrpcClientTest {
-
-    class MockDexGrpcClient extends DexGrpcClient {
-
-        private Client mockClient;
-
-        public MockDexGrpcClient(String issuerHostname, Client mockClient) {
-            super(issuerHostname);
-            this.mockClient = mockClient;
-        }
-
-        // Mock out the creation of the blocking stub
-        @Override
-        public void initialiseBlockingStub(String issuerHostname) {
-            // Do nothing...
-        }
-
-        // Mock out the response from Dex's gRPC API
-        @Override
-        public CreateClientResp sendCreateClientRequest(CreateClientReq createClientReq) {
-            Builder createClientRespBuilder = CreateClientResp.newBuilder();
-            if (this.mockClient != null) {
-                createClientRespBuilder.setClient(this.mockClient);
-            }
-            return createClientRespBuilder.build();
-        }
-    }
-
-    private Client createMockDexClient(String callbackUrl) {
-        com.coreos.dex.api.DexOuterClass.Client.Builder clientBuilder = Client.newBuilder();
-        clientBuilder.setId("dummy-id");
-        clientBuilder.setSecret("dummy-secret");
-        clientBuilder.addRedirectUris(callbackUrl);
-
-        return clientBuilder.build();
-    }
 
     @Test
     public void testCreateClientWithValidClientResponseCreatesDexClient() throws Exception {
         // Given...
         String callbackUrl = "http://my-app/callback";
-        Client mockClient = createMockDexClient(callbackUrl);
-        MockDexGrpcClient client = new MockDexGrpcClient("http://my.issuer", mockClient);
+        MockDexGrpcClient client = new MockDexGrpcClient("http://my.issuer", "client-id", "secret", callbackUrl);
 
         // When...
         Client responseClient = client.createClient(callbackUrl);
 
         // Then...
-        assertThat(responseClient).isEqualTo(mockClient);
+        assertThat(responseClient).isEqualTo(client.getDexClient());
     }
 
     @Test
     public void testCreateClientWithEmptyClientResponseReturnsNull() throws Exception {
         // Given...
         String callbackUrl = "http://my-app/callback";
-        Client mockClient = null;
-        MockDexGrpcClient client = new MockDexGrpcClient("http://my.issuer", mockClient);
+        MockDexGrpcClient client = new MockDexGrpcClient("http://my.issuer");
 
         // When...
         Client responseClient = client.createClient(callbackUrl);
 
         // Then...
         assertThat(responseClient).isNull();
+    }
+
+    @Test
+    public void testGetClientWithEmptyClientResponseReturnsNull() throws Exception {
+        // Given...
+        String clientId = "myclient";
+
+        MockDexGrpcClient client = new MockDexGrpcClient("http://my.issuer");
+
+        // When...
+        Client responseClient = client.getClient(clientId);
+
+        // Then...
+        assertThat(responseClient).isNull();
+    }
+
+    @Test
+    public void testGetClientWithValidClientResponseReturnsClient() throws Exception {
+        // Given...
+        String clientId = "myclient";
+        MockDexGrpcClient client = new MockDexGrpcClient("http://my.issuer", clientId, "secret", "http://callback");
+
+        // When...
+        Client responseClient = client.getClient(clientId);
+
+        // Then...
+        assertThat(responseClient).isEqualTo(client.getDexClient());
     }
 }

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/JwtAuthFilterTest.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/JwtAuthFilterTest.java
@@ -77,6 +77,24 @@ public class JwtAuthFilterTest extends BaseServletTest {
     }
 
     @Test
+    public void testFilterInitWithNoIssuerUrlThrowsServletException() throws Exception {
+        // Given...
+        MockEnvironment mockEnv = new MockEnvironment();
+
+        OidcProvider mockOidcProvider = mock(OidcProvider.class);
+
+        JwtAuthFilter authFilter = new MockJwtAuthFilter(mockEnv, mockOidcProvider);
+
+        // When...
+        Throwable thrown = catchThrowable(() -> {
+            authFilter.init(null);
+        });
+
+        // Then...
+        assertThat(thrown).isInstanceOf(ServletException.class);
+    }
+
+    @Test
     public void testRequestWithBadAuthorizationHeaderReturnsUnauthorized() throws Exception {
         // Given...
         MockEnvironment mockEnv = new MockEnvironment();

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/mocks/MockAuthenticationServlet.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/mocks/MockAuthenticationServlet.java
@@ -23,7 +23,7 @@ public class MockAuthenticationServlet extends AuthenticationServlet {
     }
 
     @Override
-    protected void initialiseDexClients() {
+    protected void initialiseDexClients(String dexIssuerUrl, String dexGrpcHostname) {
         // Do nothing...
     }
 }

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/mocks/MockDexGrpcClient.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/mocks/MockDexGrpcClient.java
@@ -1,0 +1,63 @@
+package dev.galasa.framework.api.authentication.mocks;
+
+import com.coreos.dex.api.DexOuterClass.Client;
+import com.coreos.dex.api.DexOuterClass.CreateClientReq;
+import com.coreos.dex.api.DexOuterClass.CreateClientResp;
+import com.coreos.dex.api.DexOuterClass.GetClientReq;
+import com.coreos.dex.api.DexOuterClass.GetClientResp;
+import com.coreos.dex.api.DexOuterClass.CreateClientResp.Builder;
+
+import dev.galasa.framework.api.authentication.internal.DexGrpcClient;
+
+// A class that only mocks out methods that interact with Dex's gRPC service
+public class MockDexGrpcClient extends DexGrpcClient {
+
+    private Client dexClient;
+
+    public MockDexGrpcClient(String issuerHostname, String clientId, String clientSecret, String callbackUrl) {
+        super(issuerHostname);
+        this.dexClient = createDexClient(clientId, clientSecret, callbackUrl);
+    }
+
+    public MockDexGrpcClient(String issuerHostname) {
+        super(issuerHostname);
+    }
+
+    // Mock out the creation of the blocking stub
+    @Override
+    public void initialiseBlockingStub(String issuerHostname) {
+        // Do nothing...
+    }
+
+    // Mock out the response from Dex's gRPC API
+    @Override
+    public CreateClientResp sendCreateClientRequest(CreateClientReq createClientReq) {
+        Builder createClientRespBuilder = CreateClientResp.newBuilder();
+        if (this.dexClient != null) {
+            createClientRespBuilder.setClient(this.dexClient);
+        }
+        return createClientRespBuilder.build();
+    }
+
+    @Override
+    public GetClientResp sendGetClientRequest(GetClientReq getClientReq) {
+        com.coreos.dex.api.DexOuterClass.GetClientResp.Builder getClientRespBuilder = GetClientResp.newBuilder();
+        if (this.dexClient != null) {
+            getClientRespBuilder.setClient(this.dexClient);
+        }
+        return getClientRespBuilder.build();
+    }
+
+    private Client createDexClient(String clientId, String clientSecret, String callbackUrl) {
+        com.coreos.dex.api.DexOuterClass.Client.Builder clientBuilder = Client.newBuilder();
+        clientBuilder.setId(clientId);
+        clientBuilder.setSecret(clientSecret);
+        clientBuilder.addRedirectUris(callbackUrl);
+
+        return clientBuilder.build();
+    }
+
+    public Client getDexClient() {
+        return dexClient;
+    }
+}

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthCallbackRouteTest.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthCallbackRouteTest.java
@@ -13,6 +13,7 @@ import java.util.Map;
 
 import javax.servlet.ServletOutputStream;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import dev.galasa.framework.api.authentication.internal.DexGrpcClient;
@@ -26,13 +27,21 @@ import dev.galasa.framework.api.common.mocks.MockHttpSession;
 
 public class AuthCallbackRouteTest extends BaseServletTest {
 
+    private DexGrpcClient mockDexGrpcClient;
+    private OidcProvider mockOidcProvider;
+    private MockEnvironment mockEnv;
+
+    @Before
+    public void setUp() {
+        mockDexGrpcClient = mock(DexGrpcClient.class);
+        mockOidcProvider = mock(OidcProvider.class);
+        mockEnv = new MockEnvironment();
+        setRequiredEnvironmentVariables(mockEnv);
+    }
+
     @Test
     public void testAuthCallbackGetRequestWithMissingAuthCodeAndStateReturnsBadRequest() throws Exception {
         // Given...
-        DexGrpcClient mockDexGrpcClient = mock(DexGrpcClient.class);
-        OidcProvider mockOidcProvider = mock(OidcProvider.class);
-        MockEnvironment mockEnv = new MockEnvironment();
-
         MockAuthenticationServlet servlet = new MockAuthenticationServlet(mockEnv, mockOidcProvider, mockDexGrpcClient);
 
         Map<String, String[]> queryParams = new HashMap<>();
@@ -59,10 +68,6 @@ public class AuthCallbackRouteTest extends BaseServletTest {
     @Test
     public void testAuthCallbackGetRequestWithMissingAuthCodeReturnsBadRequest() throws Exception {
         // Given...
-        DexGrpcClient mockDexGrpcClient = mock(DexGrpcClient.class);
-        OidcProvider mockOidcProvider = mock(OidcProvider.class);
-        MockEnvironment mockEnv = new MockEnvironment();
-
         MockAuthenticationServlet servlet = new MockAuthenticationServlet(mockEnv, mockOidcProvider, mockDexGrpcClient);
 
         Map<String, String[]> queryParams = Map.of("state", new String[] { "my-state" });
@@ -89,10 +94,6 @@ public class AuthCallbackRouteTest extends BaseServletTest {
     @Test
     public void testAuthCallbackGetRequestWithMissingStateReturnsBadRequest() throws Exception {
         // Given...
-        DexGrpcClient mockDexGrpcClient = mock(DexGrpcClient.class);
-        OidcProvider mockOidcProvider = mock(OidcProvider.class);
-        MockEnvironment mockEnv = new MockEnvironment();
-
         MockAuthenticationServlet servlet = new MockAuthenticationServlet(mockEnv, mockOidcProvider, mockDexGrpcClient);
 
         Map<String, String[]> queryParams = Map.of("code", new String[] { "my-auth-code" });
@@ -119,10 +120,6 @@ public class AuthCallbackRouteTest extends BaseServletTest {
     @Test
     public void testAuthCallbackGetRequestWithBadCallbackUrlReturnsError() throws Exception {
         // Given...
-        DexGrpcClient mockDexGrpcClient = mock(DexGrpcClient.class);
-        OidcProvider mockOidcProvider = mock(OidcProvider.class);
-        MockEnvironment mockEnv = new MockEnvironment();
-
         MockAuthenticationServlet servlet = new MockAuthenticationServlet(mockEnv, mockOidcProvider, mockDexGrpcClient);
 
         String expectedCode = "my-auth-code";
@@ -161,10 +158,6 @@ public class AuthCallbackRouteTest extends BaseServletTest {
     @Test
     public void testAuthCallbackGetRequestWithValidStateAndCodeReturnsCode() throws Exception {
         // Given...
-        DexGrpcClient mockDexGrpcClient = mock(DexGrpcClient.class);
-        OidcProvider mockOidcProvider = mock(OidcProvider.class);
-        MockEnvironment mockEnv = new MockEnvironment();
-
         MockAuthenticationServlet servlet = new MockAuthenticationServlet(mockEnv, mockOidcProvider, mockDexGrpcClient);
 
         String expectedCode = "my-auth-code";
@@ -196,10 +189,6 @@ public class AuthCallbackRouteTest extends BaseServletTest {
     @Test
     public void testAuthCallbackGetRequestCallbackUrlWithQueryAppendsCodeToQueryParams() throws Exception {
         // Given...
-        DexGrpcClient mockDexGrpcClient = mock(DexGrpcClient.class);
-        OidcProvider mockOidcProvider = mock(OidcProvider.class);
-        MockEnvironment mockEnv = new MockEnvironment();
-
         MockAuthenticationServlet servlet = new MockAuthenticationServlet(mockEnv, mockOidcProvider, mockDexGrpcClient);
 
         String expectedCode = "my-auth-code";
@@ -231,10 +220,6 @@ public class AuthCallbackRouteTest extends BaseServletTest {
     @Test
     public void testAuthCallbackGetRequestWithInvalidStateReturnsBadRequest() throws Exception {
         // Given...
-        DexGrpcClient mockDexGrpcClient = mock(DexGrpcClient.class);
-        OidcProvider mockOidcProvider = mock(OidcProvider.class);
-        MockEnvironment mockEnv = new MockEnvironment();
-
         MockAuthenticationServlet servlet = new MockAuthenticationServlet(mockEnv, mockOidcProvider, mockDexGrpcClient);
 
         String expectedCode = "my-auth-code";
@@ -271,10 +256,6 @@ public class AuthCallbackRouteTest extends BaseServletTest {
     @Test
     public void testAuthCallbackGetRequestWithNoMatchingStateSessionReturnsBadRequest() throws Exception {
         // Given...
-        DexGrpcClient mockDexGrpcClient = mock(DexGrpcClient.class);
-        OidcProvider mockOidcProvider = mock(OidcProvider.class);
-        MockEnvironment mockEnv = new MockEnvironment();
-
         MockAuthenticationServlet servlet = new MockAuthenticationServlet(mockEnv, mockOidcProvider, mockDexGrpcClient);
 
         String expectedCode = "my-auth-code";
@@ -311,10 +292,6 @@ public class AuthCallbackRouteTest extends BaseServletTest {
     @Test
     public void testAuthCallbackGetRequestWithMissingStateSessionReturnsBadRequest() throws Exception {
         // Given...
-        DexGrpcClient mockDexGrpcClient = mock(DexGrpcClient.class);
-        OidcProvider mockOidcProvider = mock(OidcProvider.class);
-        MockEnvironment mockEnv = new MockEnvironment();
-
         MockAuthenticationServlet servlet = new MockAuthenticationServlet(mockEnv, mockOidcProvider, mockDexGrpcClient);
 
         String expectedCode = "my-auth-code";

--- a/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/BaseServletTest.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/BaseServletTest.java
@@ -10,6 +10,8 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
+import dev.galasa.framework.api.common.mocks.MockEnvironment;
+
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.Map;
@@ -61,5 +63,11 @@ public class BaseServletTest {
             }
             assertThat(fieldMatches).isTrue();
         }
+    }
+
+    protected void setRequiredEnvironmentVariables(MockEnvironment mockEnv) {
+        mockEnv.setenv(EnvironmentVariables.GALASA_EXTERNAL_API_URL, "http://my-api.server");
+        mockEnv.setenv(EnvironmentVariables.GALASA_DEX_ISSUER, "http://my-dex.issuer");
+        mockEnv.setenv(EnvironmentVariables.GALASA_DEX_GRPC_HOSTNAME, "dex-grpc:1234");
     }
 }

--- a/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -173,7 +173,7 @@ paths:
       - Authentication API
       responses:
         '201':
-          description: Returns a JSON Object containing the created client's ID and secret
+          description: Returns a JSON Object containing the created client's ID
           content:
             application/json:
               schema:
@@ -1847,9 +1847,6 @@ components:
         client_id:
           type: string
           description: The ID of a Galasa client that is being authenticated.
-        secret:
-          type: string
-          description: The secret for the client that is being authenticated.
         refresh_token:
           type: string
           description: The refresh token to be exchanged for a JWT, mutually exclusive with "code".
@@ -1861,9 +1858,6 @@ components:
         client_id:
           type: string
           description: An alphanumeric string representing the ID of the Dex client.
-        client_secret:
-          type: string
-          description: An alphanumeric string representing the secret of the Dex client.
     TokenResponse:
       properties:
         jwt:


### PR DESCRIPTION
For https://github.com/galasa-dev/projectmanagement/issues/1744

Main changes:
- Removed the client secret parameter from auth requests since it can now be retrieved from Dex's new GetClient gRPC method
- Updated the version of the Dex gRPC API being used to v2.38.0
- Added more error reporting when one or more required environment variables have not been set when starting the API server