### PR TITLE
Temporary fix for local build script pending the better method

### DIFF
--- a/build-locally.sh
+++ b/build-locally.sh
@@ -194,6 +194,10 @@ function cleaning_up_before_we_start {
         info "Skipping clean phase because this is a delta build."
     else
         h2 "Cleaning..."
+
+        warn "Temporary fix: Remove the dex proto file so we don't use debris from last time."
+        rm -fr ${WORKSPACE_DIR}/galasa-parent/dev.galasa.framework.api.authentication/src/java/dev/galasa/framework/api/authentication/proto/dex.proto
+
         gradle --no-daemon \
         ${CONSOLE_FLAG} \
         --warning-mode=all --debug \


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

Temporary fix:
- The dex.proto file is downloaded, but not if it already exists.
- The clean builds never clean it up.
- Need to discuss further with @eamansour about how to make this better later.

