### PR TITLE
Iss1767 - Fix feature flag for event production.

### DIFF
--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
@@ -118,7 +118,7 @@ public class TestRunner {
         this.framework = frameworkInitialisation.getFramework();
 
         try {
-            this.produceEvents = produceEventsFeatureFlagIsTrue(this.framework);
+            this.produceEvents = produceEventsFeatureFlagIsTrue();
         } catch (ConfigurationPropertyStoreException e) {
             throw new TestRunException("Problem loading the CPS property for event production.");
         }
@@ -484,13 +484,12 @@ public class TestRunner {
         frameworkInitialisation.shutdownFramework();
     }
 
-    private boolean produceEventsFeatureFlagIsTrue(IFramework framework) throws ConfigurationPropertyStoreException {
+    private boolean produceEventsFeatureFlagIsTrue() throws ConfigurationPropertyStoreException {
         boolean produceEvents = false;
-        IConfigurationPropertyStoreService cpsFramework = framework.getConfigurationPropertyService("framework");
-        String produceEventsProp = cpsFramework.getProperty("produce", "events");
-        if (!produceEventsProp.equals("") && produceEventsProp != null) {
+        String produceEventsProp = this.cps.getProperty("produce", "events");
+        if (produceEventsProp != null) {
+            logger.debug("CPS property framework.produce.events was found and is set to: " + produceEventsProp);
             produceEvents = Boolean.parseBoolean(produceEventsProp);
-            logger.debug("CPS property to produce events is set to: " + produceEventsProp);
         }
         return produceEvents;
     }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
@@ -92,6 +92,8 @@ public class TestRunner {
 
     private IFramework                          framework;
 
+    private boolean produceEvents;
+
     /**
      * Run the supplied test class
      * 
@@ -114,6 +116,12 @@ public class TestRunner {
         }
 
         this.framework = frameworkInitialisation.getFramework();
+
+        try {
+            this.produceEvents = produceEventsFeatureFlagIsTrue(this.framework);
+        } catch (ConfigurationPropertyStoreException e) {
+            throw new TestRunException("Problem loading the CPS property for event production.");
+        }
 
         IRun run = this.framework.getTestRun();
         if (run == null) {
@@ -476,6 +484,17 @@ public class TestRunner {
         frameworkInitialisation.shutdownFramework();
     }
 
+    private boolean produceEventsFeatureFlagIsTrue(IFramework framework) throws ConfigurationPropertyStoreException {
+        boolean produceEvents = false;
+        IConfigurationPropertyStoreService cpsFramework = framework.getConfigurationPropertyService("framework");
+        String produceEventsProp = cpsFramework.getProperty("produce", "events");
+        if (!produceEventsProp.equals("") && produceEventsProp != null) {
+            produceEvents = Boolean.parseBoolean(produceEventsProp);
+            logger.debug("CPS property to produce events is set to: " + produceEventsProp);
+        }
+        return produceEvents;
+    }
+
     private void generateEnvironment(TestClassWrapper testClassWrapper, TestRunManagers managers) throws TestRunException {
         if(isRunOK){
             try {
@@ -631,6 +650,10 @@ public class TestRunner {
     }
 
     private void updateStatus(TestRunLifecycleStatus status, String timestamp) throws TestRunException {
+
+        if (this.produceEvents) {
+            logger.debug("Producing a test lifecycle status change event.");
+        }
 
         this.testStructure.setStatus(status.toString());
         if ("finished".equals(status.toString())) {


### PR DESCRIPTION
- Used the global variable cps that already existed to get the property we are looking for as even though it's set, it doesn't seem to be finding the value, hence the NullPointer being returned later on.
- Removed string equality check in case the result is null, just checking if it's null is enough. We shouldn't get a NullPointer now.