### PR TITLE
Add dex as hidden CPS namespace, remove unused path parameter in auth routes

### DIFF
--- a/galasa-parent/dev.galasa.framework.api.authentication/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api.authentication/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 description = 'Galasa Authentication API'
 
-version = '0.32.0'
+version = '0.33.0'
 
 dependencies {
     implementation project(':dev.galasa.framework')

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/AuthenticationServlet.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/AuthenticationServlet.java
@@ -52,9 +52,9 @@ public class AuthenticationServlet extends BaseServlet {
 
         initialiseDexClients(dexIssuerUrl, dexGrpcHostname);
 
-        addRoute(new AuthRoute(getResponseBuilder(), getServletInfo(), oidcProvider, dexGrpcClient));
-        addRoute(new AuthClientsRoute(getResponseBuilder(), getServletInfo(), dexGrpcClient));
-        addRoute(new AuthCallbackRoute(getResponseBuilder(), getServletInfo(), externalApiServerUrl));
+        addRoute(new AuthRoute(getResponseBuilder(), oidcProvider, dexGrpcClient));
+        addRoute(new AuthClientsRoute(getResponseBuilder(), dexGrpcClient));
+        addRoute(new AuthCallbackRoute(getResponseBuilder(), externalApiServerUrl));
 
         logger.info("Galasa Authentication API initialised");
     }

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthCallbackRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthCallbackRoute.java
@@ -26,7 +26,7 @@ public class AuthCallbackRoute extends BaseRoute {
 
     private static String externalApiServerUrl;
 
-    public AuthCallbackRoute(ResponseBuilder responseBuilder, String path, String externalApiServerUrl) {
+    public AuthCallbackRoute(ResponseBuilder responseBuilder, String externalApiServerUrl) {
         // Regex to match /auth/callback only
         super(responseBuilder, "\\/callback");
         AuthCallbackRoute.externalApiServerUrl = externalApiServerUrl;

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthClientsRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthClientsRoute.java
@@ -28,7 +28,7 @@ public class AuthClientsRoute extends BaseRoute {
 
     private DexGrpcClient dexGrpcClient;
 
-    public AuthClientsRoute(ResponseBuilder responseBuilder, String path, DexGrpcClient dexGrpcClient) {
+    public AuthClientsRoute(ResponseBuilder responseBuilder, DexGrpcClient dexGrpcClient) {
         // Regex to match /auth/clients and /auth/clients/
         super(responseBuilder, "\\/clients\\/?");
         this.dexGrpcClient = dexGrpcClient;

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthRoute.java
@@ -35,7 +35,7 @@ public class AuthRoute extends BaseRoute {
     private static final String ID_TOKEN_KEY      = "id_token";
     private static final String REFRESH_TOKEN_KEY = "refresh_token";
 
-    public AuthRoute(ResponseBuilder responseBuilder, String path, OidcProvider oidcProvider, DexGrpcClient dexGrpcClient) {
+    public AuthRoute(ResponseBuilder responseBuilder, OidcProvider oidcProvider, DexGrpcClient dexGrpcClient) {
         // Regex to match endpoint /auth and /auth/
         super(responseBuilder, "\\/?");
         this.oidcProvider = oidcProvider;

--- a/galasa-parent/dev.galasa.framework.api.common/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api.common/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 description = 'Framework API - Common Packages'
 
-version = '0.32.0'
+version = '0.33.0'
 
 dependencies {
     implementation project(':dev.galasa.framework')

--- a/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/resources/CPSFacade.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/resources/CPSFacade.java
@@ -28,6 +28,7 @@ public class CPSFacade {
         addNamespace("framework",Visibility.NORMAL,framework);
         addNamespace("secure",Visibility.SECURE,framework);
         addNamespace("dss",Visibility.HIDDEN,framework);
+        addNamespace("dex",Visibility.HIDDEN,framework);
     }
 
     private void addNamespace(String name, Visibility visibility , @NotNull IFramework framework ) throws ConfigurationPropertyStoreException  {

--- a/galasa-parent/dev.galasa.framework.api.common/src/test/java/dev/galasa/framework/api/common/resources/TestCPSFacade.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/test/java/dev/galasa/framework/api/common/resources/TestCPSFacade.java
@@ -51,6 +51,20 @@ public class TestCPSFacade {
     }
 
     @Test
+    public void TestNamespacesListContainsDex() throws ConfigurationPropertyStoreException{
+
+        IConfigurationPropertyStoreService cps = new MockIConfigurationPropertyStoreService();
+        IFramework mockFramework = new MockFramework(cps);
+        CPSFacade facade = new CPSFacade(mockFramework);
+        Map<String,CPSNamespace> spaces = facade.getNamespaces();
+
+        assertThat(spaces).containsKeys("dex");
+        CPSNamespace ns = spaces.get("dex");
+        assertThat(ns.getName()).isEqualTo("dex");
+        assertThat(ns.getVisibility()).isEqualTo(Visibility.HIDDEN);
+    }
+
+    @Test
     public void TestNamespacesListContainsSecure() throws ConfigurationPropertyStoreException{
 
         IConfigurationPropertyStoreService cps = new MockIConfigurationPropertyStoreService();
@@ -113,13 +127,17 @@ public class TestCPSFacade {
     }
 
     @Test
-    public void TestGetNamespaceSecureNamespaceIsHidden() throws ConfigurationPropertyStoreException {
+    public void TestGetNamespaceSecureNamespaceIsSecure() throws ConfigurationPropertyStoreException {
         checkGetOfNamespace("secure",true,false);
     }
 
     @Test
-    public void TestGetNamespaceDssNamespaceIsSecure() throws ConfigurationPropertyStoreException {
+    public void TestGetNamespaceDssNamespaceIsHidden() throws ConfigurationPropertyStoreException {
         checkGetOfNamespace("dss",false,true);
     }
 
+    @Test
+    public void TestGetNamespaceDexNamespaceIsHidden() throws ConfigurationPropertyStoreException {
+        checkGetOfNamespace("dex",false,true);
+    }
 }

--- a/release.yaml
+++ b/release.yaml
@@ -81,7 +81,7 @@ api:
     codecoverage: true
 
   - artifact: dev.galasa.framework.api.authentication
-    version: 0.32.0
+    version: 0.33.0
     obr: true
     isolated: true
     codecoverage: true
@@ -93,7 +93,7 @@ api:
     codecoverage: true
 
   - artifact: dev.galasa.framework.api.common
-    version: 0.32.0
+    version: 0.33.0
     obr: true
     isolated: true
     codecoverage: true


### PR DESCRIPTION
Related to https://github.com/galasa-dev/projectmanagement/issues/1698

Changes:
- Hides the `dex` namespace from the CPS REST API as it was previously appearing as a normal namespace
- Minor clean up to the auth APIs, removing an unused `path` parameter from route constructors