### PR TITLE
Exception message was getting lost, and unused imports removed

### DIFF
--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BundleManagement.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BundleManagement.java
@@ -9,6 +9,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.text.*;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
@@ -146,17 +147,27 @@ public class BundleManagement {
                 // *** is a reference
                 ArrayList<Bundle> bundlesToStart = new ArrayList<>();
                 try {
+
                     Resource[] startRequiredResources = resolver.getRequiredResources();
                     for (Resource requiredResource : startRequiredResources) {
+                        if (logger.isTraceEnabled()) {
+                            logger.trace("  startRequiredResource: adding resource" +requiredResource.getURI().toString());
+                        }
                         bundlesToStart.add(bundleContext.installBundle(requiredResource.getURI().toString()));
                     }
                     Resource[] startOptionalResources = resolver.getOptionalResources();
                     for (Resource optionalResource : startOptionalResources) {
+                        if (logger.isTraceEnabled()) {
+                            logger.trace("  getOptionalResources: adding resource" +optionalResource.getURI().toString());
+                        }
                         bundlesToStart.add(bundleContext.installBundle(optionalResource.getURI().toString()));
                     }
 
                     bundlesToStart.add(bundleContext.installBundle(resource.getURI().toString()));
                     for (Bundle bundle : bundlesToStart) {
+                        if (logger.isTraceEnabled()) {
+                            logger.trace("  bundlesToStart: starting" +bundle.getClass().toString());
+                        }
                         bundle.start();
                     }
                 } catch (Exception e) {
@@ -165,7 +176,8 @@ public class BundleManagement {
             }
 
             if (!isBundleActive(bundleContext, bundleSymbolicName)) {
-                throw new FrameworkException("Bundle failed to install and activate");
+                String msg = MessageFormat.format("Bundle %s failed to install and activate",bundleSymbolicName);
+                throw new FrameworkException(msg);
             }
 
             printBundles(bundleContext);

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunManagers.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunManagers.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.text.*;
 
 import javax.validation.constraints.NotNull;
 
@@ -362,7 +363,8 @@ public class TestRunManagers {
             }
 
             if (!isBundleActive(bundleSymbolicName)) {
-                throw new FrameworkException("Bundle failed to install and activate");
+                String msg = MessageFormat.format("Bundle %s failed to install and activate",bundleSymbolicName);
+                throw new FrameworkException(msg);
             }
 
             printBundles();

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/FrameworkException.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/FrameworkException.java
@@ -68,7 +68,7 @@ public class FrameworkException extends Exception {
     public FrameworkException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
         this((cause instanceof FrameworkException) ?
                 ((FrameworkException)cause).getErrorDetails() :
-                new FrameworkErrorDetailsBase(FrameworkErrorDetailsBase.UNKNOWN, cause.getMessage()),
+                new FrameworkErrorDetailsBase(FrameworkErrorDetailsBase.UNKNOWN, message),
              cause, enableSuppression, writableStackTrace);
     }
 

--- a/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/felix/FelixFramework.java
+++ b/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/felix/FelixFramework.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
+import java.text.*;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -1001,7 +1002,8 @@ public class FelixFramework {
             }
 
             if (!isBundleActive(bundleSymbolicName)) {
-                throw new LauncherException("Bundle failed to install and activate");
+                String msg = MessageFormat.format("Bundle %s failed to install and activate",bundleSymbolicName);
+                throw new LauncherException(msg);
             }
 
             printBundles();


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

- Noticed this when debugging a different issue.
- The message passed on the exception gets lost, and replaced with the cause message. Wrong.
- Some unnecessary java imports removed.