### PR TITLE
Updating the value of SOURCE_MAVEN in the builds 

### DIFF
--- a/build-locally.sh
+++ b/build-locally.sh
@@ -263,7 +263,7 @@ fi
 
 # Over-rode SOURCE_MAVEN if you want to build from a different maven repo...
 if [[ -z ${SOURCE_MAVEN} ]]; then
-    export SOURCE_MAVEN=https://development.galasa.dev/main/maven-repo/obr/
+    export SOURCE_MAVEN=https://development.galasa.dev/main/maven-repo/maven/
     info "SOURCE_MAVEN repo defaulting to ${SOURCE_MAVEN}."
     info "Set this environment variable if you want to over-ride this value."
 else

--- a/galasa-parent/build.gradle
+++ b/galasa-parent/build.gradle
@@ -32,11 +32,11 @@ allprojects {
 
     repositories {
         gradlePluginPortal()
-        mavenCentral()
         mavenLocal()
         maven {
             url "https://development.galasa.dev/main/maven-repo/maven/"
         }
+        mavenCentral()
     }
 }
 

--- a/galasa-parent/build.gradle
+++ b/galasa-parent/build.gradle
@@ -35,7 +35,7 @@ allprojects {
         mavenCentral()
         mavenLocal()
         maven {
-            url "https://development.galasa.dev/main/maven-repo/obr/"
+            url "https://development.galasa.dev/main/maven-repo/maven/"
         }
     }
 }


### PR DESCRIPTION
- Updating the SOURCE_MAVEN value in the build locally script and gradle file to match the remote builds, to pull from the repo before this one in the chain.