### PR TITLE
Cache JWKs when validating JWTs

### DIFF
--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/OidcProvider.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/OidcProvider.java
@@ -215,7 +215,7 @@ public class OidcProvider {
         HttpResponse<String> response = httpClient.send(getRequest, BodyHandlers.ofString());
 
         JsonObject responseBodyJson = gson.fromJson(response.body(), JsonObject.class);
-        JsonArray updatedJwks = null;
+        JsonArray updatedJwks = new JsonArray();
         if (responseBodyJson.has("keys")) {
             logger.info("Successfully retrieved JSON Web Keys from issuer");
             updatedJwks = responseBodyJson.get("keys").getAsJsonArray();

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/OidcProvider.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/OidcProvider.java
@@ -21,6 +21,8 @@ import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.RSAPublicKeySpec;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.Base64.Decoder;
 import java.util.Optional;
@@ -42,6 +44,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
 
+import dev.galasa.framework.api.authentication.internal.beans.JsonWebKey;
 import dev.galasa.framework.spi.utils.GalasaGson;
 
 /**
@@ -53,14 +56,18 @@ public class OidcProvider {
 
     private static final GalasaGson gson = new GalasaGson();
 
+    private static final String BEARER_TOKEN_SCOPE = "openid offline_access profile";
+    private static final int JWK_REFRESH_INTERVAL_MINUTES = 10;
+
+    private JsonArray jsonWebKeys;
+    private Instant nextJwkRefresh = Instant.EPOCH;
+
     private String issuerUrl;
     private String authorizationEndpoint;
     private String tokenEndpoint;
     private String jwksUri;
 
     private HttpClient httpClient = HttpClient.newHttpClient();
-
-    private static final String BEARER_TOKEN_SCOPE = "openid offline_access profile";
 
     public OidcProvider(String issuerUrl, HttpClient httpClient) {
         this.issuerUrl = issuerUrl;
@@ -84,10 +91,6 @@ public class OidcProvider {
         logger.info("Authorization endpoint is: " + this.authorizationEndpoint);
         logger.info("Token endpoint is: " + this.tokenEndpoint);
         logger.info("JWKs endpoint is: " + this.jwksUri);
-    }
-
-    public String getIssuer() {
-        return this.issuerUrl;
     }
 
     /**
@@ -192,7 +195,8 @@ public class OidcProvider {
     /**
      * Gets a JSON array of the JSON Web Keys (JWKs) from a GET request to an issuer's /keys endpoint
      */
-    public JsonArray getJsonWebKeysFromIssuer(String issuer) throws IOException, InterruptedException {
+    public JsonArray getJsonWebKeysFromIssuer() throws IOException, InterruptedException {
+        logger.info("Retrieving JSON Web Keys from issuer");
         HttpRequest getRequest = HttpRequest.newBuilder()
             .GET()
             .header("Accept", "application/json")
@@ -203,25 +207,32 @@ public class OidcProvider {
         HttpResponse<String> response = httpClient.send(getRequest, BodyHandlers.ofString());
 
         JsonObject responseBodyJson = gson.fromJson(response.body(), JsonObject.class);
-        if (!responseBodyJson.has("keys")) {
-            logger.error("Error: No JSON Web Keys were found at the '" + issuer + "/keys' endpoint.");
-            return null;
+        JsonArray updatedJwks = null;
+        if (responseBodyJson.has("keys")) {
+            logger.info("Successfully retrieved JSON Web Keys from issuer");
+            updatedJwks = responseBodyJson.get("keys").getAsJsonArray();
+        } else {
+            logger.error("Error: No JSON Web Keys were found at the '" + issuerUrl + "/keys' endpoint.");
         }
-        return responseBodyJson.get("keys").getAsJsonArray();
+        return updatedJwks;
     }
 
     /**
      * Gets a JSON Web Key with a given key ID ('kid') from an OpenID connect issuer's /keys endpoint, returned as a JSON object
      */
-    public JsonObject getJsonWebKeyFromIssuerByKeyId(String keyId, String issuer) throws IOException, InterruptedException {
-        JsonArray jsonWebKeys = getJsonWebKeysFromIssuer(issuer);
+    public JsonWebKey getJsonWebKeyByKeyId(String keyId) throws IOException, InterruptedException {
+        // Check if it is time to refresh the cached JSON web keys
+        if (jsonWebKeys == null || nextJwkRefresh.isBefore(Instant.now())) {
+            logger.info("Refreshing cached JSON Web Keys");
+            refreshJsonWebKeys();
+        }
 
         // Iterate over the JSON array of JWKs, finding the one that matches the given key ID
-        JsonObject matchingKey = null;
-        for (JsonElement key : jsonWebKeys) {
-            JsonObject keyAsJsonObject = key.getAsJsonObject();
-            if (keyAsJsonObject.get("kid").getAsString().equals(keyId)) {
-                matchingKey = keyAsJsonObject;
+        JsonWebKey matchingKey = null;
+        for (JsonElement keyElement : jsonWebKeys) {
+            JsonWebKey key = gson.fromJson(keyElement.toString(), JsonWebKey.class);
+            if (key.getKeyId().equals(keyId)) {
+                matchingKey = key;
                 break;
             }
         }
@@ -235,7 +246,7 @@ public class OidcProvider {
         try {
 
             DecodedJWT decodedJwt = JWT.decode(jwt);
-            RSAPublicKey publicKey = getRSAPublicKeyFromIssuer(decodedJwt.getKeyId(), issuerUrl);
+            RSAPublicKey publicKey = getRSAPublicKeyFromIssuer(decodedJwt.getKeyId());
             Algorithm algorithm = Algorithm.RSA256(publicKey, null);
             JWTVerifier verifier = JWT.require(algorithm).withIssuer(issuerUrl).build();
 
@@ -259,20 +270,27 @@ public class OidcProvider {
     //   "n": "abcdefg",
     //   "e": "xyz"
     // }
-    private RSAPublicKey getRSAPublicKeyFromIssuer(String keyId, String issuer)
+    private RSAPublicKey getRSAPublicKeyFromIssuer(String keyId)
             throws IOException, InterruptedException, NoSuchAlgorithmException, InvalidKeySpecException {
 
         // Get the JWK with the given key ID
-        JsonObject matchingJwk = getJsonWebKeyFromIssuerByKeyId(keyId, issuer);
+        JsonWebKey matchingJwk = getJsonWebKeyByKeyId(keyId);
         if (matchingJwk == null) {
-            logger.error("Error: No matching JSON Web Key was found with key ID '" + keyId + "'.");
-            return null;
+            // Force the cached keys to be refreshed and try again
+            nextJwkRefresh = Instant.EPOCH;
+            matchingJwk = getJsonWebKeyByKeyId(keyId);
+
+            // If we still failed to get a matching key, then this must be a bad key ID
+            if (matchingJwk == null) {
+                logger.error("Error: No matching JSON Web Key was found with key ID '" + keyId + "'.");
+                return null;
+            }
         }
 
         // A JWK contains an 'n' field to represent the key's modulus, and an 'e' field to represent the key's exponent, both are Base64URL-encoded
         Decoder decoder = Base64.getUrlDecoder();
-        BigInteger modulus = new BigInteger(1, decoder.decode(matchingJwk.get("n").getAsString()));
-        BigInteger exponent = new BigInteger(1, decoder.decode(matchingJwk.get("e").getAsString()));
+        BigInteger modulus = new BigInteger(1, decoder.decode(matchingJwk.getRsaModulus()));
+        BigInteger exponent = new BigInteger(1, decoder.decode(matchingJwk.getRsaExponent()));
 
         // Build a public key from the JWK that was matched
         RSAPublicKeySpec keySpec = new RSAPublicKeySpec(modulus, exponent);
@@ -316,5 +334,16 @@ public class OidcProvider {
     private HttpResponse<String> sendGetRequest(URI uri) throws IOException, InterruptedException {
         HttpRequest getRequest = HttpRequest.newBuilder().GET().uri(uri).build();
         return httpClient.send(getRequest, BodyHandlers.ofString());
+    }
+
+
+    /**
+     * Refreshes the cached JSON Web Keys used to verify the signature of JWTs
+     */
+    private void refreshJsonWebKeys() throws IOException, InterruptedException {
+        jsonWebKeys = getJsonWebKeysFromIssuer();
+
+        // Update the next refresh time by the refresh interval
+        nextJwkRefresh = Instant.now().plus(JWK_REFRESH_INTERVAL_MINUTES, ChronoUnit.MINUTES);
     }
 }

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/beans/JsonWebKey.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/beans/JsonWebKey.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package dev.galasa.framework.api.authentication.internal.beans;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * A bean class representing a JSON Web Key (JWK) retrieved from Dex.
+ * A JWK contains the following fields:
+ * {
+ *   "use": "sig",
+ *   "kty": "RSA",
+ *   "kid": "123abc",
+ *   "alg": "RS256",
+ *   "n": "abcdefg",
+ *   "e": "xyz"
+ * }
+ */
+public class JsonWebKey {
+
+    @SerializedName("use")
+    private String use;
+
+    @SerializedName("kty")
+    private String keyType;
+
+    @SerializedName("kid")
+    private String keyId;
+
+    @SerializedName("alg")
+    private String algorithm;
+
+    @SerializedName("n")
+    private String rsaModulus;
+
+    @SerializedName("e")
+    private String rsaExponent;
+
+    public String getUse() {
+        return use;
+    }
+
+    public String getKeyType() {
+        return keyType;
+    }
+
+    public String getKeyId() {
+        return keyId;
+    }
+
+    public String getAlgorithm() {
+        return algorithm;
+    }
+
+    public String getRsaModulus() {
+        return rsaModulus;
+    }
+
+    public String getRsaExponent() {
+        return rsaExponent;
+    }
+}

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/beans/TokenPayload.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/beans/TokenPayload.java
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package dev.galasa.framework.api.authentication.internal;
+package dev.galasa.framework.api.authentication.internal.beans;
 
 import com.google.gson.annotations.SerializedName;
 

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthRoute.java
@@ -17,7 +17,7 @@ import com.google.gson.JsonObject;
 
 import dev.galasa.framework.api.authentication.internal.DexGrpcClient;
 import dev.galasa.framework.api.authentication.internal.OidcProvider;
-import dev.galasa.framework.api.authentication.internal.TokenPayload;
+import dev.galasa.framework.api.authentication.internal.beans.TokenPayload;
 import dev.galasa.framework.api.common.BaseRoute;
 import dev.galasa.framework.api.common.InternalServletException;
 import dev.galasa.framework.api.common.QueryParameters;

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/OidcProviderTest.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/OidcProviderTest.java
@@ -55,6 +55,16 @@ public class OidcProviderTest {
         return jwkJson;
     }
 
+    private HttpResponse<Object> createMockOidcDiscoveryResponse() {
+        JsonObject mockOidcConfig = new JsonObject();
+        mockOidcConfig.addProperty("authorization_endpoint", "http://my-issuer/auth");
+        mockOidcConfig.addProperty("token_endpoint", "http://my-issuer/token");
+        mockOidcConfig.addProperty("jwks_uri", "http://my-issuer/keys");
+
+        HttpResponse<Object> mockOidcDiscoveryResponse = new MockHttpResponse<Object>(gson.toJson(mockOidcConfig));
+        return mockOidcDiscoveryResponse;
+    }
+
     @Test
     public void testTokenPostWithRefreshTokenValidRequestReturnsValidResponse() throws Exception {
         // Given...
@@ -179,7 +189,7 @@ public class OidcProviderTest {
         HttpResponse<Object> mockResponse = new MockHttpResponse<Object>(gson.toJson(mockJwks));
 
         HttpClient mockHttpClient = mock(HttpClient.class);
-        when(mockHttpClient.send(any(), any())).thenThrow(new IOException());
+        when(mockHttpClient.send(any(), any())).thenReturn(createMockOidcDiscoveryResponse());
 
         OidcProvider oidcProvider = new OidcProvider("http://dummy-issuer", mockHttpClient);
 
@@ -214,7 +224,7 @@ public class OidcProviderTest {
         HttpResponse<Object> mockResponse = new MockHttpResponse<Object>(gson.toJson(mockJwks));
 
         HttpClient mockHttpClient = mock(HttpClient.class);
-        when(mockHttpClient.send(any(), any())).thenThrow(new IOException());
+        when(mockHttpClient.send(any(), any())).thenReturn(createMockOidcDiscoveryResponse());
 
         OidcProvider oidcProvider = new OidcProvider("http://dummy-issuer", mockHttpClient);
 
@@ -244,7 +254,7 @@ public class OidcProviderTest {
         HttpResponse<Object> mockResponse = new MockHttpResponse<Object>(gson.toJson(mockJwks));
 
         HttpClient mockHttpClient = mock(HttpClient.class);
-        when(mockHttpClient.send(any(), any())).thenThrow(new IOException());
+        when(mockHttpClient.send(any(), any())).thenReturn(createMockOidcDiscoveryResponse());
 
         OidcProvider oidcProvider = new OidcProvider("http://dummy-issuer", mockHttpClient);
 

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthRouteTest.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthRouteTest.java
@@ -311,7 +311,6 @@ public class AuthRouteTest extends BaseServletTest {
 
         OidcProvider mockOidcProvider = mock(OidcProvider.class);
         when(mockOidcProvider.getConnectorRedirectUrl(eq(clientId), any(), any())).thenReturn(redirectLocation);
-        when(mockOidcProvider.getIssuer()).thenReturn("http://dummy.issuer");
 
         DexGrpcClient mockDexGrpcClient = new MockDexGrpcClient("http://issuer");
         MockEnvironment mockEnv = new MockEnvironment();
@@ -346,10 +345,8 @@ public class AuthRouteTest extends BaseServletTest {
         BiPredicate<String, String> defaultFilter = (a, b) -> true;
         HttpResponse<String> mockResponse = new MockHttpResponse<String>("", HttpHeaders.of(headers, defaultFilter));
 
-        String mockIssuerUrl = "http://dummy.issuer";
         OidcProvider mockOidcProvider = mock(OidcProvider.class);
         when(mockOidcProvider.sendAuthorizationGet(any(), any(), any())).thenReturn(mockResponse);
-        when(mockOidcProvider.getIssuer()).thenReturn(mockIssuerUrl);
 
         DexGrpcClient mockDexGrpcClient = new MockDexGrpcClient("http://issuer");
         MockEnvironment mockEnv = new MockEnvironment();

--- a/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ITimeService.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ITimeService.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.api.common;
+
+import java.time.Instant;
+
+/**
+ * An interface to allow the mocking of time-related method calls.
+ */
+public interface ITimeService {
+    Instant now();
+}

--- a/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/SystemTimeService.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/SystemTimeService.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.api.common;
+
+import java.time.Instant;
+
+public class SystemTimeService implements ITimeService {
+
+    @Override
+    public Instant now() {
+        return Instant.now();
+    }
+}

--- a/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockHttpClient.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockHttpClient.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.api.common.mocks;
+
+import java.io.IOException;
+import java.net.Authenticator;
+import java.net.CookieHandler;
+import java.net.ProxySelector;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandler;
+import java.net.http.HttpResponse.PushPromiseHandler;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+
+public class MockHttpClient extends HttpClient {
+
+    private HttpResponse<?> mockResponse;
+
+    public MockHttpClient(HttpResponse<?> mockResponse) {
+        this.mockResponse = mockResponse;
+    }
+
+    public void setMockResponse(HttpResponse<?> mockResponse) {
+        this.mockResponse = mockResponse;
+    }
+
+    // Casting to HttpResponse<T> is safe since we're returning a mock response of the
+    // same type in our tests, so let's suppress the type safety warning
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> HttpResponse<T> send(HttpRequest request, BodyHandler<T> responseBodyHandler)
+            throws IOException, InterruptedException {
+        return (HttpResponse<T>) mockResponse;
+    }
+
+    @Override
+    public Optional<CookieHandler> cookieHandler() {
+        throw new UnsupportedOperationException("Unimplemented method 'cookieHandler'");
+    }
+
+    @Override
+    public Optional<Duration> connectTimeout() {
+        throw new UnsupportedOperationException("Unimplemented method 'connectTimeout'");
+    }
+
+    @Override
+    public Redirect followRedirects() {
+        throw new UnsupportedOperationException("Unimplemented method 'followRedirects'");
+    }
+
+    @Override
+    public Optional<ProxySelector> proxy() {
+        throw new UnsupportedOperationException("Unimplemented method 'proxy'");
+    }
+
+    @Override
+    public SSLContext sslContext() {
+        throw new UnsupportedOperationException("Unimplemented method 'sslContext'");
+    }
+
+    @Override
+    public SSLParameters sslParameters() {
+        throw new UnsupportedOperationException("Unimplemented method 'sslParameters'");
+    }
+
+    @Override
+    public Optional<Authenticator> authenticator() {
+        throw new UnsupportedOperationException("Unimplemented method 'authenticator'");
+    }
+
+    @Override
+    public Version version() {
+        throw new UnsupportedOperationException("Unimplemented method 'version'");
+    }
+
+    @Override
+    public Optional<Executor> executor() {
+        throw new UnsupportedOperationException("Unimplemented method 'executor'");
+    }
+
+    @Override
+    public <T> CompletableFuture<HttpResponse<T>> sendAsync(HttpRequest request, BodyHandler<T> responseBodyHandler) {
+        throw new UnsupportedOperationException("Unimplemented method 'sendAsync'");
+    }
+
+    @Override
+    public <T> CompletableFuture<HttpResponse<T>> sendAsync(HttpRequest request, BodyHandler<T> responseBodyHandler,
+            PushPromiseHandler<T> pushPromiseHandler) {
+        throw new UnsupportedOperationException("Unimplemented method 'sendAsync'");
+    }
+}

--- a/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockTimeService.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockTimeService.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.api.common.mocks;
+
+import java.time.Instant;
+
+import dev.galasa.framework.api.common.ITimeService;
+
+public class MockTimeService implements ITimeService {
+
+    private Instant currentTime;
+
+    public MockTimeService(Instant currentTime) {
+        this.currentTime = currentTime;
+    }
+
+    @Override
+    public Instant now() {
+        return currentTime;
+    }
+
+    public void setCurrentTime(Instant currentTime) {
+        this.currentTime = currentTime;
+    }
+}


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1834

## Changes
- Added in-memory storage of JSON Web Keys (JWKs) to remove the need to constantly request JWKs from Dex when validating JWT signatures.
  - By default, the cached JWKs will be refreshed every 10 minutes