### PR TITLE
cps interface can throw more exceptions

### DIFF
--- a/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/resources/CPSNamespace.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/resources/CPSNamespace.java
@@ -50,7 +50,7 @@ public class CPSNamespace {
         return this.visibility == Visibility.HIDDEN;
     }
 
-    public Map<GalasaPropertyName,CPSProperty> getProperties(){
+    public Map<GalasaPropertyName,CPSProperty> getProperties() throws ConfigurationPropertyStoreException{
         Map<GalasaPropertyName,CPSProperty> properties = new HashMap<GalasaPropertyName,CPSProperty>();
         if (visibility != Visibility.HIDDEN){
             Map<String,String> cpsProperties = propertyStore.getAllProperties();

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/common/TestRasQueryParameters.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/common/TestRasQueryParameters.java
@@ -318,7 +318,7 @@ public class TestRasQueryParameters extends RasServletTest{
 
 
         Throwable thrown = catchThrowable( () -> {
-            boolean isAscending = params.isAscending("runname");
+            params.isAscending("runname");
         });
 
         assertThat(thrown.getMessage()).contains("GAL5011","runname","sort");
@@ -331,7 +331,7 @@ public class TestRasQueryParameters extends RasServletTest{
         RasQueryParameters params = new RasQueryParameters(new QueryParameters(map));
 
         Throwable thrown = catchThrowable( () -> {
-            boolean isAscending = params.isAscending("runname");
+            params.isAscending("runname");
         });
 
         assertThat(thrown).isNotNull();

--- a/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/K8sController.java
+++ b/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/K8sController.java
@@ -164,7 +164,7 @@ public class K8sController {
 
         // *** Stop the metics server
         if (metricsPort > 0) {
-            this.metricsServer.stop();
+            this.metricsServer.close();
         }
 
         // *** Stop the health server

--- a/galasa-parent/dev.galasa.framework.metrics/src/main/java/dev/galasa/framework/metrics/MetricsServer.java
+++ b/galasa-parent/dev.galasa.framework.metrics/src/main/java/dev/galasa/framework/metrics/MetricsServer.java
@@ -24,7 +24,6 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 
 import dev.galasa.framework.FrameworkInitialisation;
-import dev.galasa.framework.TestRunException;
 import dev.galasa.framework.spi.AbstractManager;
 import dev.galasa.framework.spi.DynamicStatusStoreException;
 import dev.galasa.framework.spi.FrameworkException;

--- a/galasa-parent/dev.galasa.framework.metrics/src/main/java/dev/galasa/framework/metrics/MetricsServerHealth.java
+++ b/galasa-parent/dev.galasa.framework.metrics/src/main/java/dev/galasa/framework/metrics/MetricsServerHealth.java
@@ -15,7 +15,6 @@ import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 
-@SuppressWarnings("restriction")
 public class MetricsServerHealth implements HttpHandler {
 
     private final MetricsServer resourceManagement;

--- a/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/ResourceManagement.java
+++ b/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/ResourceManagement.java
@@ -24,7 +24,6 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 
 import dev.galasa.framework.FrameworkInitialisation;
-import dev.galasa.framework.TestRunException;
 import dev.galasa.framework.spi.AbstractManager;
 import dev.galasa.framework.spi.DynamicStatusStoreException;
 import dev.galasa.framework.spi.FrameworkException;

--- a/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/ResourceManagementHealth.java
+++ b/galasa-parent/dev.galasa.framework.resource.management/src/main/java/dev/galasa/framework/resource/management/internal/ResourceManagementHealth.java
@@ -19,7 +19,6 @@ import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 
-@SuppressWarnings("restriction")
 public class ResourceManagementHealth implements HttpHandler {
     
     private Log                      logger = LogFactory.getLog(this.getClass());

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkInitialisation.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkInitialisation.java
@@ -19,11 +19,7 @@ import dev.galasa.framework.spi.creds.*;
 public class FrameworkInitialisation implements IFrameworkInitialisation {
 
     private static final String                      USER_HOME = "user.home";
-    private static final String                      GALASA_HOME = "GALASA_HOME";
-
     private Framework                                framework;
-
-    private final Properties                         bootstrapProperties;
 
     private final URI                                uriConfigurationPropertyStore;
     private final URI                                uriDynamicStatusStore;
@@ -148,7 +144,6 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
         Environment env
     ) throws URISyntaxException, InvalidSyntaxException, FrameworkException {
 
-        this.bootstrapProperties = bootstrapProperties;
         this.fileSystem = fileSystem;
 
         if (initLogger == null) {

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkRuns.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkRuns.java
@@ -45,7 +45,7 @@ public class FrameworkRuns implements IFrameworkRuns {
     private final String                             NO_GROUP     = "none";
     private final String                             NO_BUNDLE     = "none";
     private final String                             NO_RUNTYPE   = "UNKNOWN";
-    private final String                             NO_REQUESTER = "unknown";
+    // private final String                             NO_REQUESTER = "unknown";
 
     private final String                             RUN_PREFIX   = "run.";
 

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestClassWrapper.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestClassWrapper.java
@@ -6,6 +6,7 @@
 package dev.galasa.framework;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -162,8 +163,10 @@ public class TestClassWrapper {
      */
     public void instantiateTestClass() throws TestRunException {
         try {
-            testClassObject = testClass.newInstance();
-        } catch (InstantiationException | IllegalAccessException | NullPointerException e) {
+            testClassObject = testClass.getDeclaredConstructor().newInstance();
+        } catch (InstantiationException | IllegalAccessException | NullPointerException | 
+                 IllegalArgumentException | InvocationTargetException | NoSuchMethodException | 
+                 SecurityException  e ) {
             throw new TestRunException("Unable to instantiate test class", e);
         }
     }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/cps/FrameworkConfigurationPropertyService.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/cps/FrameworkConfigurationPropertyService.java
@@ -5,7 +5,6 @@
  */
 package dev.galasa.framework.internal.cps;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -13,9 +12,6 @@ import java.util.Map.Entry;
 import java.util.Properties;
 
 import javax.validation.constraints.NotNull;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 
 import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
 import dev.galasa.framework.spi.IConfigurationPropertyStore;
@@ -34,7 +30,6 @@ public class FrameworkConfigurationPropertyService implements IConfigurationProp
     private Properties                  record;
     private Properties                  overrides;
     private IConfigurationPropertyStore cpsStore;
-    private Log logger = LogFactory.getLog(this.getClass());
 
     /**
      * <p>
@@ -101,8 +96,9 @@ public class FrameworkConfigurationPropertyService implements IConfigurationProp
      * </p>
      * 
      * @return all properties from a given namespace
+     * @throws ConfigurationPropertyStoreException 
      */
-    public Map<String,String> getAllProperties() {
+    public Map<String,String> getAllProperties() throws ConfigurationPropertyStoreException {
         return cpsStore.getPropertiesFromNamespace(namespace);
     }
 
@@ -241,11 +237,9 @@ public class FrameworkConfigurationPropertyService implements IConfigurationProp
     }
 
     /**
-     * <p>
      * This method takes passed infixes and generates the list of infixes of
      * hierachy order, which is will be surrounded by the prefix and suffix to
      * genterate the kys to be searched.
-     * </p>
      * 
      * @param infixes - all the heirachy levels that could be appended to the
      *                namespace and prefix.
@@ -264,7 +258,7 @@ public class FrameworkConfigurationPropertyService implements IConfigurationProp
         return infixOrderList;
     }
 
-    public List<String> getCPSNamespaces() {
+    public List<String> getCPSNamespaces() throws ConfigurationPropertyStoreException {
         return cpsStore.getNamespaces();
     }
     

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IConfigurationPropertyStore.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IConfigurationPropertyStore.java
@@ -12,34 +12,22 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Null;
 
 /**
- * <p>
  * Used by the Galasa Framework to initialise the various Configuration Property
  * Stores that may exist within the OSGi instance. Only 1 CPS maybe enabled
  * during the lifetime of a Galasa test run or server instance.
- * </p>
  * 
- * <p>
  * The CPS should request from the framework the URI that is defined in the
  * bootstrap. It should examine the returned URI to determine if it is this CPS
  * that is required to be initialised. If the CPS should be initialised, the CPS
  * should do so and then register itself in the Framework.
- * </p>
- * 
- * @author Michael Baylis
- * @author Matthew Chivers
- *
  */
 public interface IConfigurationPropertyStore {
 
     /**
-     * <p>
      * Retrieve the property from the underlying configuration property store.
-     * </p>
      * 
-     * <p>
      * The framework will prefix with the appropriate namespace and apply the
      * infixes before calling this method
-     * </p>
      * 
      * @param key - The key of the property to retrieve
      * @return - The value of the property, or null if it does not exist
@@ -62,14 +50,10 @@ public interface IConfigurationPropertyStore {
     Map<String, String> getPrefixedProperties(@NotNull String prefix) throws ConfigurationPropertyStoreException;
 
     /**
-     * <p>
      * Set the property from the underlying configuration property store.
-     * </p>
      * 
-     * <p>
      * The framework will prefix with the appropriate namespace and apply the
      * infixes before calling this method
-     * </p>
      * 
      * @param key - The key of the property to retrieve
      * @param value - The value of the property to retrieve
@@ -80,38 +64,40 @@ public interface IConfigurationPropertyStore {
     void setProperty(@NotNull String key, @NotNull String value) throws ConfigurationPropertyStoreException;
 
     /**
-     * <p>
      * Delete the property from the underlying configuration property store.
-     * </p>
      * 
-     * <p>
      * The framework will prefix with the appropriate namespace and apply the
      * infixes before calling this method
-     * </p>
      * 
-     * @param key
-     * @throws ConfigurationPropertyStoreException
+     * @param key The key of the property being deleted.
+     * @throws ConfigurationPropertyStoreException - An error occurred.
      */
     void deleteProperty(@NotNull String key) throws ConfigurationPropertyStoreException;
     
     /**
-     * <p>
      * Retrieves all possible different properties set from a given namespace
-     * </p>
+     * 
      * @param namespace The namespace for which properties will be gathered.
      * @return Map of names and values of all properties
+     * @throws ConfigurationPropertyStoreException - An error occurred.
      */
-    Map<String,String> getPropertiesFromNamespace(String namespace);
+    Map<String,String> getPropertiesFromNamespace(String namespace) throws ConfigurationPropertyStoreException;
 
     /**
-     * <p>
      * Return all namespaces which have properties set
-     * </p>
      * 
      * @return List all namespaces with properties set
+     * @throws ConfigurationPropertyStoreException - An error occurred.
      */
-    List<String> getNamespaces();
+    List<String> getNamespaces() throws ConfigurationPropertyStoreException;
 
+    /**
+     * Called by the framework when shutting down.
+     * 
+     * It gives this extension a chance to shut down, cleanly and free any held resources.
+     * 
+     * @throws ConfigurationPropertyStoreException - An error occurred during shutdown.
+     */
     void shutdown() throws ConfigurationPropertyStoreException;
 
 }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IConfigurationPropertyStoreService.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IConfigurationPropertyStoreService.java
@@ -30,9 +30,6 @@ import javax.validation.constraints.Null;
  * An {@link IConfigurationPropertyStore} can be obtained from
  * {@link IFramework#getCertificateStoreService()}.
  * </p>
- * 
- * @author Michael Baylis
- * @author Matthew Chivers
  *
  */
 public interface IConfigurationPropertyStoreService {
@@ -151,24 +148,19 @@ public interface IConfigurationPropertyStoreService {
     void deleteProperty(@NotNull String name) throws ConfigurationPropertyStoreException;
 
     /**
-     * <p>
      * Retrieves all possible different properties set from a namespace
-     * </p>
      * 
      * @return Map of names and values of all properties
+     * @throws ConfigurationPropertyStoreException - Something went wrong accessing the persistent property store
      */
-    Map<String,String> getAllProperties();
+    Map<String,String> getAllProperties() throws ConfigurationPropertyStoreException;
 
     /**
-     * <p>
      * Retrieves all possible different property variations that would be searched,
      * in the search order.
-     * </p>
      * 
-     * <p>
      * If a manager cant get a property, it can report all the properties you could
      * set to get a resolve the problem
-     * </p>
      * 
      * @param prefix  - The prefix of the property name within the namespace.
      * @param suffix  - The suffix of the property name.
@@ -201,7 +193,8 @@ public interface IConfigurationPropertyStoreService {
      * </p>
      * 
      * @return List all namespaces with properties set
+     * @throws ConfigurationPropertyStoreException - Something went wrong accessing the persistent property store
      */
-    List<String> getCPSNamespaces();
+    List<String> getCPSNamespaces() throws ConfigurationPropertyStoreException;
 
 }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/language/gherkin/GherkinTest.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/language/gherkin/GherkinTest.java
@@ -8,7 +8,6 @@ package dev.galasa.framework.spi.language.gherkin;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
-import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/creds/FileCredentialsRegistrationTest.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/creds/FileCredentialsRegistrationTest.java
@@ -23,7 +23,6 @@ import org.osgi.framework.InvalidSyntaxException;
 
 import dev.galasa.framework.internal.cps.FpfConfigurationPropertyStore;
 import dev.galasa.framework.internal.cps.FrameworkConfigurationPropertyService;
-import dev.galasa.framework.internal.creds.FileCredentialsRegistration;
 import dev.galasa.framework.spi.Api;
 import dev.galasa.framework.spi.CertificateStoreException;
 import dev.galasa.framework.spi.ConfidentialTextException;

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/creds/FileCredentialsStoreTest.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/creds/FileCredentialsStoreTest.java
@@ -25,9 +25,7 @@ import org.junit.Test;
 
 import dev.galasa.framework.internal.cps.FpfConfigurationPropertyStore;
 import dev.galasa.framework.internal.cps.FrameworkConfigurationPropertyService;
-import dev.galasa.framework.internal.creds.FileCredentialsStore;
 import dev.galasa.framework.spi.Api;
-import dev.galasa.framework.spi.CertificateStoreException;
 import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
 import dev.galasa.framework.spi.DynamicStatusStoreException;
 import dev.galasa.framework.spi.FrameworkException;

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/creds/FrameworkCredentialsTest.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/creds/FrameworkCredentialsTest.java
@@ -22,10 +22,7 @@ import org.junit.Test;
 
 import dev.galasa.framework.internal.cps.FpfConfigurationPropertyStore;
 import dev.galasa.framework.internal.cps.FrameworkConfigurationPropertyService;
-import dev.galasa.framework.internal.creds.FileCredentialsStore;
-import dev.galasa.framework.internal.creds.FrameworkCredentialsService;
 import dev.galasa.framework.spi.Api;
-import dev.galasa.framework.spi.CertificateStoreException;
 import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
 import dev.galasa.framework.spi.DynamicStatusStoreException;
 import dev.galasa.framework.spi.FrameworkException;

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/dss/FpfDynamicStatusStoreRegistrationTest.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/internal/dss/FpfDynamicStatusStoreRegistrationTest.java
@@ -17,7 +17,6 @@ import javax.validation.constraints.NotNull;
 import org.junit.Test;
 
 import dev.galasa.framework.internal.cps.FpfConfigurationPropertyStore;
-import dev.galasa.framework.internal.dss.FpfDynamicStatusStoreRegistration;
 import dev.galasa.framework.spi.CertificateStoreException;
 import dev.galasa.framework.spi.ConfidentialTextException;
 import dev.galasa.framework.spi.ConfigurationPropertyStoreException;

--- a/galasa-parent/galasa-testharness/src/main/java/dev/galasa/testharness/TestHarnessFramework.java
+++ b/galasa-parent/galasa-testharness/src/main/java/dev/galasa/testharness/TestHarnessFramework.java
@@ -16,7 +16,6 @@ import dev.galasa.framework.internal.cps.FrameworkConfigurationPropertyService;
 import dev.galasa.framework.internal.cts.FrameworkConfidentialTextService;
 import dev.galasa.framework.internal.dss.FrameworkDynamicStatusStoreService;
 import dev.galasa.framework.spi.Api;
-import dev.galasa.framework.spi.CertificateStoreException;
 import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
 import dev.galasa.framework.spi.DynamicStatusStoreException;
 import dev.galasa.framework.spi.FrameworkException;


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
Local test run to be able to use remote CPS
[#1813](https://github.com/galasa-dev/projectmanagement/issues/1813)

The CPS interface should have had some exceptions possibly throwing failures on 
getNamespaces() and shutdown(). It's possible something will go wrong with these and there is no other way of reporting a failure with them.

Adding extra throws clauses and fixing all the implementations to be able to throw them also.