### PR TITLE
bumped version to 0.34.0

### DIFF
--- a/galasa-parent/build.gradle
+++ b/galasa-parent/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 // Note: The following line is changed by the set-version.sh script.
 // It is also read by other build scrips as required.
-version = "0.33.0"
+version = "0.34.0"
 
 signing {
     sign publishing.publications
@@ -294,7 +294,7 @@ publishing {
                 name = "Manifest for framework bundle versions"
                 artifactId = "dev.galasa.framework.manifest"
                 groupId = 'dev.galasa'
-                version = "0.33.0"
+                version = "0.34.0"
                 description = "Conveys bundle version information to OBR builds."
                 licenses {
                     license {

--- a/galasa-parent/dev.galasa.framework.api.openapi/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api.openapi/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 description = 'Galasa Open API specification'
 
-version = "0.33.0"
+version = "0.34.0"
 
 repositories {
     maven {

--- a/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -6,7 +6,7 @@
 openapi: 3.0.3
 info:
   title: Galasa Ecosystem API
-  version : "0.33.0"
+  version : "0.34.0"
   description: The Galasa Ecosystem REST API allows you to interact with a Galasa Ecosystem.
   contact:
     url: https://galasa.dev/support

--- a/galasa-parent/dev.galasa.framework/build.gradle
+++ b/galasa-parent/dev.galasa.framework/build.gradle
@@ -7,7 +7,7 @@ description = 'Galasa Framework'
 
 // Note: The following line is changed by the set-version.sh script.
 // It is also read by other build scrips as required.
-version = "0.33.0"
+version = "0.34.0"
 
 dependencies {
 

--- a/galasa-parent/dev.galasa.framework/settings.gradle
+++ b/galasa-parent/dev.galasa.framework/settings.gradle
@@ -1,3 +1,3 @@
 rootProject.name = "dev.galasa.framework"
 
-bundleVersion = 0.33.0
+bundleVersion = 0.34.0

--- a/release.yaml
+++ b/release.yaml
@@ -111,7 +111,7 @@ api:
     codecoverage: true
 
   - artifact: dev.galasa.framework.api.openapi
-    version: 0.32.0
+    version: 0.34.0
     obr: true
     isolated: true
     mvp: true
@@ -151,3 +151,4 @@ api:
     obr: true
     bom: true
     mvp: true
+isolated: true

--- a/release.yaml
+++ b/release.yaml
@@ -151,4 +151,4 @@ api:
     obr: true
     bom: true
     mvp: true
-isolated: true
+    isolated: true

--- a/release.yaml
+++ b/release.yaml
@@ -21,7 +21,7 @@ framework:
     codecoverage: true
 
   - artifact: dev.galasa.framework
-    version: 0.33.0
+    version: 0.34.0
     obr: true
     bom: true
     mvp: true
@@ -151,4 +151,3 @@ api:
     obr: true
     bom: true
     mvp: true
-    isolated: true


### PR DESCRIPTION
## Why? 
 As part of the release process the development version numbers need to be bumped to the next version