### PR TITLE
Add more error handling around getting Dex clients via gRPC

### DIFF
--- a/galasa-parent/dev.galasa.framework.api.authentication/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api.authentication/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 description = 'Galasa Authentication API'
 
-version = '0.33.0'
+version = '0.34.0'
 
 dependencies {
     implementation project(':dev.galasa.framework')

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthRoute.java
@@ -152,7 +152,7 @@ public class AuthRoute extends BaseRoute {
      *                        for the /token endpoint
      */
     private JsonObject sendTokenPost(HttpServletRequest request, TokenPayload requestBodyJson)
-            throws IOException, InterruptedException {
+            throws IOException, InterruptedException, InternalServletException {
         String refreshToken = requestBodyJson.getRefreshToken();
         String clientId = requestBodyJson.getClientId();
         Client dexClient = dexGrpcClient.getClient(clientId);

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/mocks/MockDexGrpcClient.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/mocks/MockDexGrpcClient.java
@@ -8,6 +8,8 @@ import com.coreos.dex.api.DexOuterClass.GetClientResp;
 import com.coreos.dex.api.DexOuterClass.CreateClientResp.Builder;
 
 import dev.galasa.framework.api.authentication.internal.DexGrpcClient;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 
 // A class that only mocks out methods that interact with Dex's gRPC service
 public class MockDexGrpcClient extends DexGrpcClient {
@@ -43,7 +45,11 @@ public class MockDexGrpcClient extends DexGrpcClient {
     public GetClientResp sendGetClientRequest(GetClientReq getClientReq) {
         com.coreos.dex.api.DexOuterClass.GetClientResp.Builder getClientRespBuilder = GetClientResp.newBuilder();
         if (this.dexClient != null) {
-            getClientRespBuilder.setClient(this.dexClient);
+            if (this.dexClient.getId().equals("error")) {
+                throw new StatusRuntimeException(Status.UNKNOWN);
+            } else {
+                getClientRespBuilder.setClient(this.dexClient);
+            }
         }
         return getClientRespBuilder.build();
     }

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthRouteTest.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthRouteTest.java
@@ -236,7 +236,8 @@ public class AuthRouteTest extends BaseServletTest {
         OidcProvider mockOidcProvider = mock(OidcProvider.class);
         when(mockOidcProvider.sendTokenPost(any(), any(), any())).thenThrow(new IOException("simulating an unexpected failure!"));
 
-        DexGrpcClient mockDexGrpcClient = new MockDexGrpcClient("http://issuer");
+        String clientId = "myclient";
+        MockDexGrpcClient mockDexGrpcClient = new MockDexGrpcClient("http://issuer", clientId, "secret", "http://callback");
         MockEnvironment mockEnv = new MockEnvironment();
         setRequiredEnvironmentVariables(mockEnv);
 
@@ -274,7 +275,8 @@ public class AuthRouteTest extends BaseServletTest {
         OidcProvider mockOidcProvider = mock(OidcProvider.class);
         when(mockOidcProvider.sendTokenPost(any(), any(), any())).thenReturn(mockResponse);
 
-        DexGrpcClient mockDexGrpcClient = new MockDexGrpcClient("http://issuer");
+        String clientId = "myclient";
+        MockDexGrpcClient mockDexGrpcClient = new MockDexGrpcClient("http://issuer", clientId, "secret", "http://callback");
         MockEnvironment mockEnv = new MockEnvironment();
         setRequiredEnvironmentVariables(mockEnv);
 

--- a/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
@@ -28,7 +28,7 @@ public enum ServletErrorMessage {
     GAL5048_UNABLE_TO_CANCEL_RUN                      (5048, "E: Error occured when trying to cancel the run ''{0}''. Report the problem to your Galasa Ecosystem owner."),
     GAL5049_UNABLE_TO_RESET_COMPLETED_RUN             (5049, "E: Error occured when trying to reset the run ''{0}''. The run has already completed."),
     GAL5050_UNABLE_TO_CANCEL_COMPLETED_RUN            (5050, "E: Error occured when trying to cancel the run ''{0}''. The run has already completed."),
-    
+
     // RunArtifactsList...
     GAL5007_ERROR_RETRIEVING_ARTIFACTS_LIST           (5007,"E: Error retrieving artifacts for run with identifier ''{0}''."),
 
@@ -76,11 +76,15 @@ public enum ServletErrorMessage {
     GAL5042_INVALID_PROPERTY_NAME_INVALID_CHAR        (5042, "E: Invalid property name. ''{0}'' must not contain the ''{1}'' character. Allowable characters after the first character are 'a'-'z', 'A'-'Z', '0'-'9', '-' (dash), '.' (dot) and '_' (underscore)"),
     GAL5043_INVALID_PROPERTY_NAME_NO_DOT_SEPARATOR    (5043, "E: Invalid property name. Property name ''{0}'' much have at least two parts seperated by a '.' (dot)."),
     GAL5044_INVALID_PROPERTY_NAME_TRAILING_DOT        (5044, "E: Invalid property name. Property name ''{0}'' must not end with a '.' (dot) seperator."),
-    
+
     //Resources APIs...
     GAL5025_UNSUPPORTED_ACTION                        (5025, "E: Error occured. The field 'action' in the request body is invalid. The 'action' value''{0}'' supplied is not supported. Supported actions are: create, apply and update. This could indicate a mis-match between client and server levels. Please check with your Ecosystem administrator the level. You may have to upgrade/downgrade your client program."),
     GAL5026_UNSUPPORTED_RESOURCE_TYPE                 (5026, "E: Error occured. The field 'kind' in the request body is invalid. The value ''{0}'' is not supported. This could indicate a mis-match between client and server levels. Please check with your Ecosystem administrator the level. You may have to upgrade/downgrade your client program."),
-    GAL5027_UNSUPPORTED_API_VERSION                   (5027, "E: Error occured. The field 'apiVersion' in the request body is invalid. The value ''{0}'' is not a supported version. Currently the ecosystem accepts the ''{1}'' api version. This could indicate a mis-match between client and server levels. Please check with your Ecosystem administrator the level. You may have to upgrade/downgrade your client program.")
+    GAL5027_UNSUPPORTED_API_VERSION                   (5027, "E: Error occured. The field 'apiVersion' in the request body is invalid. The value ''{0}'' is not a supported version. Currently the ecosystem accepts the ''{1}'' api version. This could indicate a mis-match between client and server levels. Please check with your Ecosystem administrator the level. You may have to upgrade/downgrade your client program."),
+
+    // Auth APIs...
+    GAL5051_INVALID_GALASA_TOKEN_PROVIDED             (5051, "E: Invalid GALASA_TOKEN value provided. Please ensure you have set the correct GALASA_TOKEN property for the targeted ecosystem and try again."),
+    GAL5052_FAILED_TO_RETRIEVE_CLIENT                 (5052, "E: Unable to retrieve client for authentication. Please ensure you have set the correct GALASA_TOKEN property for the targeted ecosystem and try again.")
     ;
 
 

--- a/release.yaml
+++ b/release.yaml
@@ -81,7 +81,7 @@ api:
     codecoverage: true
 
   - artifact: dev.galasa.framework.api.authentication
-    version: 0.33.0
+    version: 0.34.0
     obr: true
     isolated: true
     codecoverage: true


### PR DESCRIPTION
## Why?
Resolves a different issue around https://github.com/galasa-dev/projectmanagement/issues/1846

When the gRPC call is made to get the details of a Dex client, if a client with the given client ID doesn't exist, then the Dex gRPC client responds with a StatusRuntimeException, causing a 500 internal server error.

## Changes
- Added more error handling around the retrieval of Dex clients via Dex's gRPC API
  - If a StatusRuntimeException is encountered, then this is marked as a bad request as the GALASA_TOKEN property didn't include a valid client ID value
  - If the response doesn't contain a client, then this is marked as an internal server error as we should have received a valid client object.