### PR TITLE
Update test structure in RAS for cancelled runs

### DIFF
--- a/galasa-parent/dev.galasa.framework.api.ras/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api.ras/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 description = 'Galasa API - RAS'
 
-version '0.32.0'
+version '0.34.0'
 
 dependencies {
     implementation project(':dev.galasa.framework')

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/mocks/MockArchiveStore.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/mocks/MockArchiveStore.java
@@ -16,10 +16,10 @@ import javax.validation.constraints.NotNull;
 
 public class MockArchiveStore implements IResultArchiveStore {
 
+    private List<IResultArchiveStoreDirectoryService> directoryServices;
 
-    private List<IResultArchiveStoreDirectoryService> directoryServices ;
 
-    public MockArchiveStore( List<IResultArchiveStoreDirectoryService> directoryServices ) {
+    public MockArchiveStore(List<IResultArchiveStoreDirectoryService> directoryServices) {
         this.directoryServices = directoryServices;
     }
 
@@ -35,7 +35,11 @@ public class MockArchiveStore implements IResultArchiveStore {
 
     @Override
     public void updateTestStructure(@NotNull TestStructure testStructure) throws ResultArchiveStoreException {
-        throw new UnsupportedOperationException("Unimplemented method 'updateTestStructure'");
+        try {
+            testStructure.normalise();
+        } catch (final Exception e) {
+            throw new ResultArchiveStoreException("Unable to write the test structure", e);
+        }
     }
 
     @Override

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestResultNamesRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestResultNamesRoute.java
@@ -81,6 +81,7 @@ public class TestResultNamesRoute extends RasServletTest{
 		resultNames.add("Failed");
 		resultNames.add("EnvFail");
 		resultNames.add("Ignored");
+		resultNames.add("Cancelled");
 		for (IRunResult run : mockInputRunResults){
 				String result  = run.getTestStructure().getResult().toString();
 				if (!resultNames.contains(result)){

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunDetailsRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunDetailsRoute.java
@@ -388,9 +388,16 @@ public class TestRunDetailsRoute extends RasServletTest {
 		servlet.init();
 		servlet.doPut(req, resp);
 
+		IRunResult run = mockrasService.getRunById(runId);
+		String result = run.getTestStructure().getResult();
+		String status = run.getTestStructure().getStatus();
+
 		// Then...
 		assertThat(resp.getStatus()).isEqualTo(202);
 		assertThat(outStream.toString()).isEqualTo("The request to cancel run " + runName + " has been received.");
+
+		assertThat(result).isEqualTo("Cancelled");
+		assertThat(status).isEqualTo("finished");
 	}
 
 	@Test
@@ -422,9 +429,16 @@ public class TestRunDetailsRoute extends RasServletTest {
 		servlet.init();
 		servlet.doPut(req, resp);
 
+		IRunResult run = mockrasService.getRunById(runId);
+		String result = run.getTestStructure().getResult();
+		String status = run.getTestStructure().getStatus();
+
 		// Then...
 		assertThat(resp.getStatus()).isEqualTo(202);
 		assertThat(outStream.toString()).isEqualTo("The request to cancel run " + runName + " has been received.");
+
+		assertThat(result).isEqualTo("Cancelled");
+		assertThat(status).isEqualTo("finished");
 	}
 
 	@Test

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/Result.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/Result.java
@@ -16,6 +16,7 @@ public class Result {
     private static final String PASSED      = "Passed";
     private static final String FAILED      = "Failed";
     private static final String ENVFAIL     = "EnvFail";
+    private static final String CANCELLED   = "Cancelled";
 
     private String              name;
     private String              reason;
@@ -27,6 +28,7 @@ public class Result {
     private boolean             failed      = false;
     private boolean             defects     = false;
     private boolean             ignored     = false;
+    private boolean             cancelled   = false;
     private boolean             environment = false;
     private boolean             resources   = false;
     private boolean             fullStop    = false;
@@ -41,6 +43,7 @@ public class Result {
         resultNames.add(PASSED);
         resultNames.add(FAILED);
         resultNames.add(ENVFAIL);
+        resultNames.add(CANCELLED);
         return resultNames;
     }
 
@@ -99,6 +102,16 @@ public class Result {
         return result;
     }
 
+    public static Result cancelled(String reason) {
+        Result result = new Result();
+        result.name = CANCELLED;
+        result.cancelled = true;
+        result.iconUri = "internalicon:cancelled";
+        result.reason = reason;
+
+        return result;
+    }
+
     public static Result custom(String name, 
             boolean passed, 
             boolean failed, 
@@ -145,6 +158,10 @@ public class Result {
 
     public boolean isEnvFail() {
         return this.environment;
+    }
+
+    public boolean isCancelled() {
+        return this.cancelled;
     }
 
     public boolean isFullStop() {

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestResultNames.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestResultNames.java
@@ -16,6 +16,6 @@ public class TestResultNames {
     @Test
     public void TestGetDefaultResultNames(){
         List<String> resultNames = ResultNames.getDefaultResultNames();
-        assertArrayEquals(resultNames.toArray(), new String[]{"Ignored","Passed","Failed","EnvFail"});
+        assertArrayEquals(resultNames.toArray(), new String[]{"Ignored","Passed","Failed","EnvFail","Cancelled"});
     } 
 }

--- a/release.yaml
+++ b/release.yaml
@@ -118,7 +118,7 @@ api:
     codecoverage: true
 
   - artifact: dev.galasa.framework.api.ras
-    version: 0.32.0
+    version: 0.34.0
     obr: true
     isolated: true
     codecoverage: true


### PR DESCRIPTION
## Why?

For story [galasa-dev/projectmamagemen](https://github.com/galasa-dev/projectmanagement/issues/1775)

- Adds a new result option of Cancelled
- Updates tests that check results
- Updates servlet for cancelling run to update the test structure
- Update unit test