### PR TITLE
created a function to mask the DGALASA_JWT value in the log output and unit tests

### DIFF
--- a/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/Launcher.java
+++ b/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/Launcher.java
@@ -222,6 +222,21 @@ public class Launcher {
         }
     }
 
+
+    protected String logCommandLineArguments(String[] args) {
+        StringBuilder messageBuffer = new StringBuilder();
+        messageBuffer.append("Supplied command line arguments: ");
+        for (String arg : args) {
+            if (arg.contains("DGALASA_JWT")){
+                String[] argument = arg.split("=");
+                messageBuffer.append(argument[0] + "=******* ");
+            }else{
+                messageBuffer.append(arg + " ");
+            }
+        }
+        return messageBuffer.toString();
+    }
+
     /**
      * Process the supplied command line augments
      * 
@@ -230,12 +245,7 @@ public class Launcher {
      */
     private void processCommandLine(String[] args) throws ParseException {
 
-        StringBuilder messageBuffer = new StringBuilder();
-        messageBuffer.append("Supplied command line arguments: ");
-        for (String arg : args) {
-            messageBuffer.append(arg + " ");
-        }
-        logger.debug(messageBuffer.toString());
+        logger.debug(logCommandLineArguments(args));
 
         Options options = new Options();
         Option propertyOption = Option.builder().longOpt("D").argName("property=value").hasArgs().valueSeparator()

--- a/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/TestLauncher.java
+++ b/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/TestLauncher.java
@@ -192,4 +192,49 @@ public class TestLauncher {
         }
         fail("LauncherException should have been thrown");
     }
+
+    @Test
+    public void testLogCommandLineArgumentsWithJWTReturnsMask() throws LauncherException, InterruptedException{
+        // Given...
+        String jwtValue = "myJWT15h3r3";
+        Launcher launcher = new Launcher();
+        String[] arguments = new String[]{"--bootstrap","file://home/.galasa/bootstrap.properties","-DGALASA_JWT="+jwtValue, "--obr","file://path/to/my/obr"};
+        
+        // When...
+        String output = launcher.logCommandLineArguments(arguments);
+
+        // Then...
+        String expectedOutput = "Supplied command line arguments: --bootstrap file://home/.galasa/bootstrap.properties -DGALASA_JWT=******* --obr file://path/to/my/obr ";
+        assertThat(output).contains("GALASA_JWT");
+        assertThat(output).doesNotContain(jwtValue);
+        assertThat(output).isEqualTo(expectedOutput);
+    }
+
+    @Test
+    public void testLogCommandLineArgumentsWithoutJWTReturnsvalues() throws LauncherException, InterruptedException{
+        // Given...
+        Launcher launcher = new Launcher();
+        String[] arguments = new String[]{"--bootstrap","file://home/.galasa/bootstrap.properties","--test", "please-test.java", "--obr","file://path/to/my/obr"};
+        
+        // When...
+        String output = launcher.logCommandLineArguments(arguments);
+
+        // Then...
+        String expectedOutput = "Supplied command line arguments: --bootstrap file://home/.galasa/bootstrap.properties --test please-test.java --obr file://path/to/my/obr ";
+        assertThat(output).isEqualTo(expectedOutput);
+    }
+
+    @Test
+    public void testLogCommandLineArgumentsWithBadJWTFlagReturnsvalues() throws LauncherException, InterruptedException{
+        // Given...
+        Launcher launcher = new Launcher();
+        String[] arguments = new String[]{"--bootstrap","file://home/.galasa/bootstrap.properties","--jwt", "im4d3am15tak3", "--obr","file://path/to/my/obr"};
+        
+        // When...
+        String output = launcher.logCommandLineArguments(arguments);
+
+        // Then...
+        String expectedOutput = "Supplied command line arguments: --bootstrap file://home/.galasa/bootstrap.properties --jwt im4d3am15tak3 --obr file://path/to/my/obr ";
+        assertThat(output).isEqualTo(expectedOutput);
+    }
 }


### PR DESCRIPTION
## Why?

Logs should not contain user identifying information which can be used to access the  galasa ecosystem