### PR TITLE
Issue 1835 cps endpoints

### DIFF
--- a/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/AccessCps.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/AccessCps.java
@@ -98,20 +98,25 @@ public class AccessCps extends HttpServlet {
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException {
         try {
             resp.setHeader("Content-Type", "application/json");
-
-            Matcher matcher1 = pattern1.matcher(req.getPathInfo());
+            String url = req.getPathInfo();
+            if (url == null) {
+                // There is no path information, so this must be the root path (i.e. /cps/namespace)
+                // This allows pattern1 to match rather than throwing a null pointer exception
+                url = "";
+            }
+            Matcher matcher1 = pattern1.matcher(url);
             if (matcher1.matches()) {
                 getNamespaces(resp);
                 return;
             }
-            Matcher matcher2 = pattern2.matcher(req.getPathInfo());
+            Matcher matcher2 = pattern2.matcher(url);
             if (matcher2.matches()) {
                 String namespace = matcher2.group(1);
                 nameValidator.assertNamespaceCharPatternIsValid(namespace);
                 getNamespaceProperties(resp,namespace);
                 return;
             }
-            Matcher matcher3 = pattern3.matcher(req.getPathInfo());
+            Matcher matcher3 = pattern3.matcher(url);
             if (matcher3.matches()) {
                 String namespace = matcher3.group(1);
                 nameValidator.assertNamespaceCharPatternIsValid(namespace);
@@ -123,7 +128,7 @@ public class AccessCps extends HttpServlet {
                 return;
             }
 
-            sendError(resp, "Invalid GET URL - " + req.getPathInfo()
+            sendError(resp, "Invalid GET URL - " + url
                      , HttpServletResponse.SC_BAD_REQUEST // Bad Request
                      );
 

--- a/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/routes/NamespacesRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/routes/NamespacesRoute.java
@@ -41,7 +41,7 @@ public class NamespacesRoute extends CPSRoute {
     public NamespacesRoute(ResponseBuilder responseBuilder, IFramework framework ) {
 		/* Regex to match endpoints: 
 		*  -> /cps
-        *  -> /cps/
+		*  -> /cps/
 		*/
 		super(responseBuilder, path, framework);
 	}

--- a/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/routes/NamespacesRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/routes/NamespacesRoute.java
@@ -40,7 +40,8 @@ public class NamespacesRoute extends CPSRoute {
 
     public NamespacesRoute(ResponseBuilder responseBuilder, IFramework framework ) {
 		/* Regex to match endpoints: 
-		*  -> /cps/
+		*  -> /cps
+        *  -> /cps/
 		*/
 		super(responseBuilder, path, framework);
 	}

--- a/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/routes/NamespacesRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/routes/NamespacesRoute.java
@@ -34,7 +34,7 @@ import dev.galasa.framework.spi.utils.GalasaGson;
  */
 public class NamespacesRoute extends CPSRoute {
 
-    protected static final String path = "\\/";
+    protected static final String path = "\\/?";
     private static final GalasaGson gson = new GalasaGson();
 
 

--- a/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestNamespacesRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestNamespacesRoute.java
@@ -91,7 +91,7 @@ public class TestNamespacesRoute extends CpsServletTest{
     }
 
     @Test
-    public void TestPathRegexEmptyPathReturnsFalse(){
+    public void TestPathRegexEmptyPathReturnsTrue(){
         //Given...
         String expectedPath = NamespacesRoute.path;
         String inputPath = "";
@@ -100,7 +100,7 @@ public class TestNamespacesRoute extends CpsServletTest{
         boolean matches = Pattern.compile(expectedPath).matcher(inputPath).matches();
 
         //Then...
-        assertThat(matches).isFalse();
+        assertThat(matches).isTrue();
     }
 
     @Test
@@ -199,6 +199,29 @@ public class TestNamespacesRoute extends CpsServletTest{
 	public void TestGetNamespacesWithFrameworkWithDataReturnsOk() throws Exception{
 		// Given...
 		setServlet("/","framework",new HashMap<String,String[]>());
+		MockCpsServlet servlet = getServlet();
+		HttpServletRequest req = getRequest();
+		HttpServletResponse resp = getResponse();
+		ServletOutputStream outStream = resp.getOutputStream();	
+
+		// When...
+		servlet.init();
+		servlet.doGet(req,resp);
+	
+		// Then...
+		assertThat(resp.getStatus()).isEqualTo(200);
+		assertThat(resp.getContentType()).isEqualTo("application/json");
+		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
+		assertThat(outStream.toString()).isEqualTo("[\n"+
+		"  {\n    \"name\": \"framework\",\n    \"propertiesUrl\": \"/framework/properties\",\n    \"type\": \"NORMAL\"\n  },\n"+
+		"  {\n    \"name\": \"secure\",\n    \"propertiesUrl\": \"/secure/properties\",\n    \"type\": \"SECURE\"\n  }"+
+		"\n]");
+	}
+
+	@Test
+	public void TestGetNamespacesWithFrameworkWithDataEmptyPathReturnsOk() throws Exception{
+		// Given...
+		setServlet("","framework",new HashMap<String,String[]>());
 		MockCpsServlet servlet = getServlet();
 		HttpServletRequest req = getRequest();
 		HttpServletResponse resp = getResponse();

--- a/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -213,7 +213,7 @@ paths:
   #--------------------------------------
   # List all known Namespaces in CPS, excluding hidden namespaces
   #--------------------------------------
-  /cps/:
+  /cps:
     parameters:
       - $ref: '#/components/parameters/ClientApiVersion'
     get:


### PR DESCRIPTION
## Why?

This is to remove the need for the trailing '/' on the '/cps' and '/cps/namespace' endpoints, as well as preventing the null pointer exception raised whe 'request.getPathInfo()' returns null