### PR TITLE
bumped version of dev.galasa to 0.34.0

### DIFF
--- a/galasa-parent/dev.galasa/build.gradle
+++ b/galasa-parent/dev.galasa/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'galasa.framework'
 }
 
-version = '0.21.0'
+version = '0.34.0'
 
 description = 'Galasa Testers Programmer Interface (TPI)'
 

--- a/release.yaml
+++ b/release.yaml
@@ -13,7 +13,7 @@ metadata:
 framework:
   bundles:
   - artifact: dev.galasa
-    version: 0.21.0
+    version: 0.34.0
     obr: true
     bom: true
     mvp: true


### PR DESCRIPTION
## Why?

there are changes to the dev.galasa package that have not been used as the package version was not bumped. To resolve this the version is bumped to the current development version 0.34.0