### PR TITLE
Move auth store initialisation into API server only

### DIFF
--- a/galasa-parent/dev.galasa.framework.api/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     implementation 'org.osgi:org.osgi.service.cm:1.6.0'
     implementation 'org.apache.felix:org.apache.felix.bundlerepository:2.0.2'
 
-    testCompile project(':dev.galasa.framework').sourceSets.test.output
+    testImplementation project(':dev.galasa.framework').sourceSets.test.output
 }
 
 // Note: These values are consumed by the parent build process

--- a/galasa-parent/dev.galasa.framework.api/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 description = 'Framework API'
 
-version = '0.27.0'
+version = '0.34.0'
 
 dependencies {
 
@@ -14,6 +14,7 @@ dependencies {
     implementation 'org.osgi:org.osgi.service.cm:1.6.0'
     implementation 'org.apache.felix:org.apache.felix.bundlerepository:2.0.2'
 
+    testCompile project(':dev.galasa.framework').sourceSets.test.output
 }
 
 // Note: These values are consumed by the parent build process

--- a/galasa-parent/dev.galasa.framework.api/src/main/java/dev/galasa/framework/api/internal/ApiServerInitialisation.java
+++ b/galasa-parent/dev.galasa.framework.api/src/main/java/dev/galasa/framework/api/internal/ApiServerInitialisation.java
@@ -96,8 +96,7 @@ public class ApiServerInitialisation extends FrameworkInitialisation implements 
         return storeUri;
     }
 
-    void initialiseAuthStore(Log logger, BundleContext bundleContext)
-            throws FrameworkException, InvalidSyntaxException {
+    void initialiseAuthStore(Log logger, BundleContext bundleContext) throws FrameworkException, InvalidSyntaxException {
 
         logger.trace("Searching for Auth Store providers");
         final ServiceReference<?>[] authStoreServiceReference = bundleContext

--- a/galasa-parent/dev.galasa.framework.api/src/main/java/dev/galasa/framework/api/internal/ApiServerInitialisation.java
+++ b/galasa-parent/dev.galasa.framework.api/src/main/java/dev/galasa/framework/api/internal/ApiServerInitialisation.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.api.internal;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Properties;
+
+import javax.validation.constraints.NotNull;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+
+import dev.galasa.framework.FileSystem;
+import dev.galasa.framework.FrameworkInitialisation;
+import dev.galasa.framework.IFileSystem;
+import dev.galasa.framework.spi.Environment;
+import dev.galasa.framework.spi.FrameworkException;
+import dev.galasa.framework.spi.IApiServerInitialisation;
+import dev.galasa.framework.spi.SystemEnvironment;
+import dev.galasa.framework.spi.auth.AuthStoreException;
+import dev.galasa.framework.spi.auth.IAuthStore;
+import dev.galasa.framework.spi.auth.IAuthStoreRegistration;
+
+/**
+ * This is a subclass of the FrameworkInitialisation class responsible for
+ * initialising additional stores that are only used by Galasa's API server.
+ * These additional stores should not be initialised when starting the core
+ * framework in local or hybrid test runs.
+ */
+public class ApiServerInitialisation extends FrameworkInitialisation implements IApiServerInitialisation {
+
+    private final URI uriAuthStore;
+    private Log logger;
+
+    public ApiServerInitialisation(
+        Properties bootstrapProperties,
+        Properties overrideProperties
+    ) throws URISyntaxException, InvalidSyntaxException, FrameworkException {
+        this(bootstrapProperties, overrideProperties, null, getBundleContext(), new FileSystem(), new SystemEnvironment());
+    }
+
+    public ApiServerInitialisation(
+        Properties bootstrapProperties,
+        Properties overrideProperties,
+        Log initLogger,
+        BundleContext bundleContext,
+        IFileSystem fileSystem, 
+        Environment env
+    ) throws URISyntaxException, InvalidSyntaxException, FrameworkException {
+        super(bootstrapProperties, overrideProperties, false, initLogger, bundleContext, fileSystem, env);
+
+        if (initLogger == null) {
+            logger = LogFactory.getLog(this.getClass());
+        } else {
+            logger = initLogger;
+        }
+
+        this.uriAuthStore = locateAuthStore(logger, overrideProperties);
+        initialiseAuthStore(logger, bundleContext);
+    }
+
+    private static BundleContext getBundleContext() {
+        return FrameworkUtil.getBundle(ApiServerInitialisation.class).getBundleContext();
+    }
+
+    @Override
+    public URI getAuthStoreUri() {
+        return this.uriAuthStore;
+    }
+
+    @Override
+    public void registerAuthStore(@NotNull IAuthStore authStore) throws AuthStoreException {
+        this.framework.setAuthStore(authStore);
+    }
+
+    /**
+     * Find where the auth store is located, or return null if one has not been set.
+     */
+    URI locateAuthStore(Log logger, Properties overrideProperties) throws URISyntaxException {
+        URI storeUri = null;
+        String propUri = overrideProperties.getProperty("framework.auth.store");
+
+        if (propUri != null && !propUri.isEmpty()) {
+            logger.debug("Bootstrap property framework.auth.store used to determine Auth Store location");
+            storeUri = new URI(propUri);
+            logger.debug("Auth Store is " + storeUri.toString());
+        }
+        return storeUri;
+    }
+
+    void initialiseAuthStore(Log logger, BundleContext bundleContext)
+            throws FrameworkException, InvalidSyntaxException {
+
+        logger.trace("Searching for Auth Store providers");
+        final ServiceReference<?>[] authStoreServiceReference = bundleContext
+                .getAllServiceReferences(IAuthStoreRegistration.class.getName(), null);
+        if ((authStoreServiceReference == null) || (authStoreServiceReference.length == 0)) {
+            throw new FrameworkException("No Auth Store Services have been found");
+        }
+        for (final ServiceReference<?> authStoreReference : authStoreServiceReference) {
+            final IAuthStoreRegistration authStoreRegistration = (IAuthStoreRegistration) bundleContext
+                    .getService(authStoreReference);
+            logger.trace("Found Auth Store Provider " + authStoreRegistration.getClass().getName());
+
+            // The registration code calls back to registerAuthStore to set the auth
+            // store object in this.framework, so it can be retrieved by the
+            // this.framework.getAuthStore() call...
+            authStoreRegistration.initialise(this);
+        }
+        if (this.framework.getAuthStore() == null) {
+            throw new FrameworkException("Failed to initialise an Auth Store, unable to continue");
+        }
+        logger.debug("Selected Auth Store Service is " + this.framework.getAuthStore().getClass().getName());
+    }
+}

--- a/galasa-parent/dev.galasa.framework.api/src/main/java/dev/galasa/framework/api/internal/ApiStartup.java
+++ b/galasa-parent/dev.galasa.framework.api/src/main/java/dev/galasa/framework/api/internal/ApiStartup.java
@@ -28,8 +28,8 @@ import org.apache.felix.bundlerepository.RepositoryAdmin;
 import org.apache.felix.bundlerepository.Resource;
 
 import dev.galasa.framework.BundleManagement;
-import dev.galasa.framework.FrameworkInitialisation;
 import dev.galasa.framework.spi.FrameworkException;
+import dev.galasa.framework.spi.IFrameworkInitialisation;
 
 @Component(service = { ApiStartup.class })
 public class ApiStartup {
@@ -76,9 +76,9 @@ public class ApiStartup {
         }
 
         // *** Initialise the framework
-        FrameworkInitialisation frameworkInitialisation = null;
+        IFrameworkInitialisation frameworkInitialisation = null;
         try {
-            frameworkInitialisation = new FrameworkInitialisation(bootstrapProperties, overrideProperties);
+            frameworkInitialisation = new ApiServerInitialisation(bootstrapProperties, overrideProperties);
         } catch (Exception e) {
             throw new FrameworkException("Unable to initialise the Framework Services", e);
         }

--- a/galasa-parent/dev.galasa.framework.api/src/test/java/dev/galasa/framework/api/internal/TestApiServerInitialisation.java
+++ b/galasa-parent/dev.galasa.framework.api/src/test/java/dev/galasa/framework/api/internal/TestApiServerInitialisation.java
@@ -5,33 +5,17 @@
  */
 package dev.galasa.framework.api.internal;
 
-import dev.galasa.ICredentials;
+import dev.galasa.framework.FrameworkInitialisationTestBase;
 import dev.galasa.framework.api.mocks.MockAuthStore;
 import dev.galasa.framework.api.mocks.MockAuthStoreRegistration;
 import dev.galasa.framework.mocks.MockBundleContext;
-import dev.galasa.framework.mocks.MockCPSRegistration;
-import dev.galasa.framework.mocks.MockCPSStore;
-import dev.galasa.framework.mocks.MockConfidentialTextStore;
-import dev.galasa.framework.mocks.MockConfidentialTextStoreRegistration;
-import dev.galasa.framework.mocks.MockCredentialsStore;
-import dev.galasa.framework.mocks.MockCredentialsStoreRegistration;
-import dev.galasa.framework.mocks.MockDSSRegistration;
-import dev.galasa.framework.mocks.MockDSSStore;
 import dev.galasa.framework.mocks.MockEnvironment;
 import dev.galasa.framework.mocks.MockFileSystem;
 import dev.galasa.framework.mocks.MockFramework;
 import dev.galasa.framework.mocks.MockLog;
-import dev.galasa.framework.mocks.MockRASRegistration;
-import dev.galasa.framework.mocks.MockRASStoreService;
 import dev.galasa.framework.mocks.MockServiceReference;
-import dev.galasa.framework.spi.IConfidentialTextServiceRegistration;
-import dev.galasa.framework.spi.IConfigurationPropertyStoreRegistration;
-import dev.galasa.framework.spi.IDynamicStatusStoreRegistration;
-import dev.galasa.framework.spi.IFramework;
-import dev.galasa.framework.spi.IResultArchiveStoreRegistration;
 import dev.galasa.framework.spi.auth.IAuthStore;
 import dev.galasa.framework.spi.auth.IAuthStoreRegistration;
-import dev.galasa.framework.spi.creds.ICredentialsStoreRegistration;
 
 import org.apache.commons.logging.Log;
 import org.junit.Test;
@@ -42,7 +26,7 @@ import static org.assertj.core.api.Assertions.*;
 import java.net.URI;
 import java.util.*;
 
-public class TestApiServerInitialisation {
+public class TestApiServerInitialisation extends FrameworkInitialisationTestBase {
 
     private ApiServerInitialisation createApiServerInit(Properties bootstrapProps) throws Exception {
         return createApiServerInit(bootstrapProps, new MockEnvironment());
@@ -51,24 +35,22 @@ public class TestApiServerInitialisation {
     private ApiServerInitialisation createApiServerInit(Properties bootstrapProps, MockEnvironment mockEnv)
             throws Exception {
         // Given...
-        Properties bootstrapProperties = bootstrapProps;
+        Map<String, String> cpsProperties = new HashMap<String, String>();
         Properties overrideProperties = new Properties();
         Log logger = new MockLog();
+        Bundle bundle = null;
 
         // A fake OSGi service registry...
         Map<String, MockServiceReference<?>> services = new HashMap<String, MockServiceReference<?>>();
 
-        Bundle bundle = null;
-
         MockFramework mockFramework = addMockFrameworkToMockServiceRegistry(services, bundle);
-
-        Map<String, String> cpsProperties = new HashMap<String, String>();
 
         addMockCPSToMockServiceRegistry(services, cpsProperties, bundle);
         addMockConfidentialTextServiceToMockServiceRegistry(services, bundle);
         addMockDSSToMockServiceRegistry(services, bundle);
         addMockRASToMockServiceRegistry(services, bundle);
         addMockCredentialsStoreToMockServiceRegistry(services, bundle);
+        addMockEventsServiceToMockServiceRegistry(services, bundle);
 
         MockAuthStore mockAuthStore = addMockAuthStoreToMockServiceRegistry(services, bundle);
 
@@ -76,7 +58,7 @@ public class TestApiServerInitialisation {
         MockFileSystem mockFileSystem = new MockFileSystem();
 
         // When...
-        ApiServerInitialisation frameworkInitUnderTest = new ApiServerInitialisation(bootstrapProperties,
+        ApiServerInitialisation frameworkInitUnderTest = new ApiServerInitialisation(bootstrapProps,
                 overrideProperties, logger, bundleContext, mockFileSystem, mockEnv);
 
         // Then...
@@ -85,64 +67,12 @@ public class TestApiServerInitialisation {
         return frameworkInitUnderTest;
     }
 
-    private MockAuthStore addMockAuthStoreToMockServiceRegistry(Map<String, MockServiceReference<?>> services,
-            Bundle bundle) {
+    private MockAuthStore addMockAuthStoreToMockServiceRegistry(Map<String, MockServiceReference<?>> services, Bundle bundle) {
         MockAuthStore mockAuthStore = new MockAuthStore();
         MockAuthStoreRegistration mockAuthStoreRegistration = new MockAuthStoreRegistration(mockAuthStore);
-        MockServiceReference<IAuthStoreRegistration> mockAuthStoreRef = new MockServiceReference<IAuthStoreRegistration>(
-                mockAuthStoreRegistration, bundle);
+        MockServiceReference<IAuthStoreRegistration> mockAuthStoreRef = new MockServiceReference<>(mockAuthStoreRegistration, bundle);
         services.put(IAuthStoreRegistration.class.getName(), mockAuthStoreRef);
         return mockAuthStore;
-    }
-
-    private MockFramework addMockFrameworkToMockServiceRegistry(Map<String,MockServiceReference<?>> services, Bundle bundle) {
-        MockFramework mockFramework = new MockFramework();
-        MockServiceReference<IFramework> mockFrameworkRef = new MockServiceReference<IFramework>(mockFramework, bundle);
-        services.put(IFramework.class.getName(), mockFrameworkRef);
-        return mockFramework;
-    }
-
-    private void addMockCPSToMockServiceRegistry(Map<String,MockServiceReference<?>> services, Map<String,String> cpsProperties, Bundle bundle) {
-        MockCPSStore mockCPSStore = new MockCPSStore(cpsProperties);
-        MockCPSRegistration mockCPSRegistration = new MockCPSRegistration(mockCPSStore);
-        MockServiceReference<IConfigurationPropertyStoreRegistration> mockCPSRef = new MockServiceReference<IConfigurationPropertyStoreRegistration>(mockCPSRegistration, bundle);
-        services.put(IConfigurationPropertyStoreRegistration.class.getName(), mockCPSRef);
-    }
-
-    private void addMockDSSToMockServiceRegistry(Map<String,MockServiceReference<?>> services, Bundle bundle) {
-        Map<String,String> dssProps = new HashMap<String,String>();
-        MockDSSStore mockDSSStore = new MockDSSStore(dssProps);
-        MockDSSRegistration mockDSSRegistration = new MockDSSRegistration(mockDSSStore);
-        MockServiceReference<IDynamicStatusStoreRegistration> mockDSSRef = 
-            new MockServiceReference<IDynamicStatusStoreRegistration>(mockDSSRegistration, bundle);
-        services.put(IDynamicStatusStoreRegistration.class.getName(), mockDSSRef);
-    }
-
-    private void addMockRASToMockServiceRegistry(Map<String,MockServiceReference<?>> services, Bundle bundle) {
-        Map<String,String> rasProps = new HashMap<String,String>();
-        MockRASStoreService mockRASStoreService = new MockRASStoreService(rasProps);
-        MockRASRegistration mockRASRegistration = new MockRASRegistration(mockRASStoreService);
-        MockServiceReference<IResultArchiveStoreRegistration> mockRASRef = 
-            new MockServiceReference<IResultArchiveStoreRegistration>(mockRASRegistration, bundle);
-        services.put(IResultArchiveStoreRegistration.class.getName(), mockRASRef);
-    }
-
-    private void addMockCredentialsStoreToMockServiceRegistry(Map<String,MockServiceReference<?>> services, Bundle bundle) {
-        Map<String,ICredentials> credsProps = new HashMap<String,ICredentials>();
-        MockCredentialsStore mockCredentialsStore = new MockCredentialsStore(credsProps);
-        MockCredentialsStoreRegistration mockCredentialsStoreRegistration = new MockCredentialsStoreRegistration(mockCredentialsStore);
-        MockServiceReference<ICredentialsStoreRegistration> mockCredsRegRef = 
-            new MockServiceReference<ICredentialsStoreRegistration>(mockCredentialsStoreRegistration, bundle);
-        services.put(ICredentialsStoreRegistration.class.getName(),mockCredsRegRef);
-    }
-
-    private void addMockConfidentialTextServiceToMockServiceRegistry(Map<String,MockServiceReference<?>> services, Bundle bundle) {
-        Map<String,String> confidentialTextProps = new HashMap<String,String>();
-        MockConfidentialTextStore mockConfidentialTextStore = new MockConfidentialTextStore(confidentialTextProps);
-        MockConfidentialTextStoreRegistration mockConfidentialTextStoreRegistration = new MockConfidentialTextStoreRegistration(mockConfidentialTextStore);
-        MockServiceReference<IConfidentialTextServiceRegistration> mockConfidentialTextServiceRegRef = 
-            new MockServiceReference<IConfidentialTextServiceRegistration>(mockConfidentialTextStoreRegistration, bundle);
-        services.put(IConfidentialTextServiceRegistration.class.getName(), mockConfidentialTextServiceRegRef);
     }
 
     @Test

--- a/galasa-parent/dev.galasa.framework.api/src/test/java/dev/galasa/framework/api/internal/TestApiServerInitialisation.java
+++ b/galasa-parent/dev.galasa.framework.api/src/test/java/dev/galasa/framework/api/internal/TestApiServerInitialisation.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.api.internal;
+
+import dev.galasa.ICredentials;
+import dev.galasa.framework.api.mocks.MockAuthStore;
+import dev.galasa.framework.api.mocks.MockAuthStoreRegistration;
+import dev.galasa.framework.mocks.MockBundleContext;
+import dev.galasa.framework.mocks.MockCPSRegistration;
+import dev.galasa.framework.mocks.MockCPSStore;
+import dev.galasa.framework.mocks.MockConfidentialTextStore;
+import dev.galasa.framework.mocks.MockConfidentialTextStoreRegistration;
+import dev.galasa.framework.mocks.MockCredentialsStore;
+import dev.galasa.framework.mocks.MockCredentialsStoreRegistration;
+import dev.galasa.framework.mocks.MockDSSRegistration;
+import dev.galasa.framework.mocks.MockDSSStore;
+import dev.galasa.framework.mocks.MockEnvironment;
+import dev.galasa.framework.mocks.MockFileSystem;
+import dev.galasa.framework.mocks.MockFramework;
+import dev.galasa.framework.mocks.MockLog;
+import dev.galasa.framework.mocks.MockRASRegistration;
+import dev.galasa.framework.mocks.MockRASStoreService;
+import dev.galasa.framework.mocks.MockServiceReference;
+import dev.galasa.framework.spi.IConfidentialTextServiceRegistration;
+import dev.galasa.framework.spi.IConfigurationPropertyStoreRegistration;
+import dev.galasa.framework.spi.IDynamicStatusStoreRegistration;
+import dev.galasa.framework.spi.IFramework;
+import dev.galasa.framework.spi.IResultArchiveStoreRegistration;
+import dev.galasa.framework.spi.auth.IAuthStore;
+import dev.galasa.framework.spi.auth.IAuthStoreRegistration;
+import dev.galasa.framework.spi.creds.ICredentialsStoreRegistration;
+
+import org.apache.commons.logging.Log;
+import org.junit.Test;
+import org.osgi.framework.Bundle;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.net.URI;
+import java.util.*;
+
+public class TestApiServerInitialisation {
+
+    private ApiServerInitialisation createApiServerInit(Properties bootstrapProps) throws Exception {
+        return createApiServerInit(bootstrapProps, new MockEnvironment());
+    }
+
+    private ApiServerInitialisation createApiServerInit(Properties bootstrapProps, MockEnvironment mockEnv)
+            throws Exception {
+        // Given...
+        Properties bootstrapProperties = bootstrapProps;
+        Properties overrideProperties = new Properties();
+        Log logger = new MockLog();
+
+        // A fake OSGi service registry...
+        Map<String, MockServiceReference<?>> services = new HashMap<String, MockServiceReference<?>>();
+
+        Bundle bundle = null;
+
+        MockFramework mockFramework = addMockFrameworkToMockServiceRegistry(services, bundle);
+
+        Map<String, String> cpsProperties = new HashMap<String, String>();
+
+        addMockCPSToMockServiceRegistry(services, cpsProperties, bundle);
+        addMockConfidentialTextServiceToMockServiceRegistry(services, bundle);
+        addMockDSSToMockServiceRegistry(services, bundle);
+        addMockRASToMockServiceRegistry(services, bundle);
+        addMockCredentialsStoreToMockServiceRegistry(services, bundle);
+
+        MockAuthStore mockAuthStore = addMockAuthStoreToMockServiceRegistry(services, bundle);
+
+        MockBundleContext bundleContext = new MockBundleContext(services);
+        MockFileSystem mockFileSystem = new MockFileSystem();
+
+        // When...
+        ApiServerInitialisation frameworkInitUnderTest = new ApiServerInitialisation(bootstrapProperties,
+                overrideProperties, logger, bundleContext, mockFileSystem, mockEnv);
+
+        // Then...
+        assertThat(mockFramework.getAuthStore()).isEqualTo(mockAuthStore);
+
+        return frameworkInitUnderTest;
+    }
+
+    private MockAuthStore addMockAuthStoreToMockServiceRegistry(Map<String, MockServiceReference<?>> services,
+            Bundle bundle) {
+        MockAuthStore mockAuthStore = new MockAuthStore();
+        MockAuthStoreRegistration mockAuthStoreRegistration = new MockAuthStoreRegistration(mockAuthStore);
+        MockServiceReference<IAuthStoreRegistration> mockAuthStoreRef = new MockServiceReference<IAuthStoreRegistration>(
+                mockAuthStoreRegistration, bundle);
+        services.put(IAuthStoreRegistration.class.getName(), mockAuthStoreRef);
+        return mockAuthStore;
+    }
+
+    private MockFramework addMockFrameworkToMockServiceRegistry(Map<String,MockServiceReference<?>> services, Bundle bundle) {
+        MockFramework mockFramework = new MockFramework();
+        MockServiceReference<IFramework> mockFrameworkRef = new MockServiceReference<IFramework>(mockFramework, bundle);
+        services.put(IFramework.class.getName(), mockFrameworkRef);
+        return mockFramework;
+    }
+
+    private void addMockCPSToMockServiceRegistry(Map<String,MockServiceReference<?>> services, Map<String,String> cpsProperties, Bundle bundle) {
+        MockCPSStore mockCPSStore = new MockCPSStore(cpsProperties);
+        MockCPSRegistration mockCPSRegistration = new MockCPSRegistration(mockCPSStore);
+        MockServiceReference<IConfigurationPropertyStoreRegistration> mockCPSRef = new MockServiceReference<IConfigurationPropertyStoreRegistration>(mockCPSRegistration, bundle);
+        services.put(IConfigurationPropertyStoreRegistration.class.getName(), mockCPSRef);
+    }
+
+    private void addMockDSSToMockServiceRegistry(Map<String,MockServiceReference<?>> services, Bundle bundle) {
+        Map<String,String> dssProps = new HashMap<String,String>();
+        MockDSSStore mockDSSStore = new MockDSSStore(dssProps);
+        MockDSSRegistration mockDSSRegistration = new MockDSSRegistration(mockDSSStore);
+        MockServiceReference<IDynamicStatusStoreRegistration> mockDSSRef = 
+            new MockServiceReference<IDynamicStatusStoreRegistration>(mockDSSRegistration, bundle);
+        services.put(IDynamicStatusStoreRegistration.class.getName(), mockDSSRef);
+    }
+
+    private void addMockRASToMockServiceRegistry(Map<String,MockServiceReference<?>> services, Bundle bundle) {
+        Map<String,String> rasProps = new HashMap<String,String>();
+        MockRASStoreService mockRASStoreService = new MockRASStoreService(rasProps);
+        MockRASRegistration mockRASRegistration = new MockRASRegistration(mockRASStoreService);
+        MockServiceReference<IResultArchiveStoreRegistration> mockRASRef = 
+            new MockServiceReference<IResultArchiveStoreRegistration>(mockRASRegistration, bundle);
+        services.put(IResultArchiveStoreRegistration.class.getName(), mockRASRef);
+    }
+
+    private void addMockCredentialsStoreToMockServiceRegistry(Map<String,MockServiceReference<?>> services, Bundle bundle) {
+        Map<String,ICredentials> credsProps = new HashMap<String,ICredentials>();
+        MockCredentialsStore mockCredentialsStore = new MockCredentialsStore(credsProps);
+        MockCredentialsStoreRegistration mockCredentialsStoreRegistration = new MockCredentialsStoreRegistration(mockCredentialsStore);
+        MockServiceReference<ICredentialsStoreRegistration> mockCredsRegRef = 
+            new MockServiceReference<ICredentialsStoreRegistration>(mockCredentialsStoreRegistration, bundle);
+        services.put(ICredentialsStoreRegistration.class.getName(),mockCredsRegRef);
+    }
+
+    private void addMockConfidentialTextServiceToMockServiceRegistry(Map<String,MockServiceReference<?>> services, Bundle bundle) {
+        Map<String,String> confidentialTextProps = new HashMap<String,String>();
+        MockConfidentialTextStore mockConfidentialTextStore = new MockConfidentialTextStore(confidentialTextProps);
+        MockConfidentialTextStoreRegistration mockConfidentialTextStoreRegistration = new MockConfidentialTextStoreRegistration(mockConfidentialTextStore);
+        MockServiceReference<IConfidentialTextServiceRegistration> mockConfidentialTextServiceRegRef = 
+            new MockServiceReference<IConfidentialTextServiceRegistration>(mockConfidentialTextStoreRegistration, bundle);
+        services.put(IConfidentialTextServiceRegistration.class.getName(), mockConfidentialTextServiceRegRef);
+    }
+
+    @Test
+    public void testLocateAuthStoreDefaultsToNull() throws Exception {
+
+        // Given...
+        Properties bootstrap = new Properties();
+
+        // The framework.auth.store property hasn't been set, so there is no auth store to use.
+        ApiServerInitialisation frameworkInit = createApiServerInit(bootstrap);
+
+        Log logger = new MockLog();
+
+        // When...
+        URI uri = frameworkInit.locateAuthStore(logger, bootstrap);
+
+        // Then...
+        assertThat(uri).isNull();
+    }
+
+    @Test
+    public void testLocateAuthStoreGetsFrameworkAuthStoreUri() throws Exception {
+
+        // Given...
+        Properties bootstrap = new Properties();
+
+        URI authStoreUri = URI.create("couchdb:http://my-user-store");
+
+        bootstrap.setProperty("framework.auth.store", authStoreUri.toString());
+        ApiServerInitialisation frameworkInit = createApiServerInit(bootstrap);
+
+        Log logger = new MockLog();
+
+        // When...
+        URI uri = frameworkInit.locateAuthStore(logger, bootstrap);
+
+        // Then...
+        assertThat(uri).isNotNull();
+        assertThat(uri).isEqualTo(authStoreUri);
+    }
+
+    @Test
+    public void testInitialiseAuthStoreSetsFrameworkAuthStore() throws Exception {
+
+        // Given...
+        Properties bootstrap = new Properties();
+
+        URI authStoreUri = URI.create("couchdb:http://my-user-store");
+
+        bootstrap.setProperty("framework.auth.store", authStoreUri.toString());
+        ApiServerInitialisation frameworkInit = createApiServerInit(bootstrap);
+
+        // When...
+        IAuthStore authStore = frameworkInit.getFramework().getAuthStore();
+
+        // Then...
+        assertThat(authStore).isNotNull();
+        assertThat(authStore.getClass().getName()).isEqualTo(MockAuthStore.class.getName());
+    }
+}

--- a/galasa-parent/dev.galasa.framework.api/src/test/java/dev/galasa/framework/api/mocks/MockAuthStore.java
+++ b/galasa-parent/dev.galasa.framework.api/src/test/java/dev/galasa/framework/api/mocks/MockAuthStore.java
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package dev.galasa.framework.mocks;
+package dev.galasa.framework.api.mocks;
 
 import java.util.List;
 

--- a/galasa-parent/dev.galasa.framework.api/src/test/java/dev/galasa/framework/api/mocks/MockAuthStoreRegistration.java
+++ b/galasa-parent/dev.galasa.framework.api/src/test/java/dev/galasa/framework/api/mocks/MockAuthStoreRegistration.java
@@ -3,9 +3,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package dev.galasa.framework.mocks;
+package dev.galasa.framework.api.mocks;
 
-import dev.galasa.framework.spi.IFrameworkInitialisation;
+import dev.galasa.framework.spi.IApiServerInitialisation;
 import dev.galasa.framework.spi.auth.IAuthStore;
 import dev.galasa.framework.spi.auth.IAuthStoreRegistration;
 import dev.galasa.framework.spi.auth.AuthStoreException;
@@ -19,7 +19,7 @@ public class MockAuthStoreRegistration implements IAuthStoreRegistration {
     }
 
     @Override
-    public void initialise(IFrameworkInitialisation frameworkInitialisation) throws AuthStoreException {
+    public void initialise(IApiServerInitialisation frameworkInitialisation) throws AuthStoreException {
         frameworkInitialisation.registerAuthStore(store);
     }
 }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IApiServerInitialisation.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IApiServerInitialisation.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.spi;
+
+import java.net.URI;
+
+import javax.validation.constraints.NotNull;
+
+import dev.galasa.framework.spi.auth.IAuthStore;
+import dev.galasa.framework.spi.auth.AuthStoreException;
+
+/**
+ * This interface provides methods to register additional stores
+ * used only by Galasa's API server and should server initialisation.
+ */
+public interface IApiServerInitialisation extends IFrameworkInitialisation {
+
+    URI getAuthStoreUri();
+
+    /**
+     * Register an Auth Store Service, which allows the framework to retrieve user
+     * and token information.
+     *
+     * @param authStore the auth store service to be registered
+     * @throws AuthStoreException if there is a problem registering the service
+     */
+    void registerAuthStore(@NotNull IAuthStore authStore) throws AuthStoreException;
+}

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IFrameworkInitialisation.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IFrameworkInitialisation.java
@@ -10,8 +10,6 @@ import java.util.List;
 
 import javax.validation.constraints.NotNull;
 
-import dev.galasa.framework.spi.auth.IAuthStore;
-import dev.galasa.framework.spi.auth.AuthStoreException;
 import dev.galasa.framework.spi.creds.CredentialsException;
 import dev.galasa.framework.spi.creds.ICredentialsStore;
 
@@ -37,8 +35,6 @@ public interface IFrameworkInitialisation {
     URI getDynamicStatusStoreUri();
 
     URI getCredentialsStoreUri();
-
-    URI getAuthStoreUri();
 
     /**
      * Retrieves a list of Result Archive URIs that need to be initialised
@@ -99,15 +95,6 @@ public interface IFrameworkInitialisation {
     void registerCredentialsStore(@NotNull ICredentialsStore credentialsStore) throws CredentialsException;
 
     void registerEventsService(@NotNull IEventsService eventsService) throws EventsException;
-
-    /**
-     * Register an Auth Store Service, which allows the framework to retrieve user
-     * and token information.
-     *
-     * @param authStore the auth store service to be registered
-     * @throws AuthStoreException if there is a problem registering the service
-     */
-    void registerAuthStore(@NotNull IAuthStore authStore) throws AuthStoreException;
 
     /**
      * <p>

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/auth/IAuthStoreRegistration.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/auth/IAuthStoreRegistration.java
@@ -7,9 +7,9 @@ package dev.galasa.framework.spi.auth;
 
 import javax.validation.constraints.NotNull;
 
-import dev.galasa.framework.spi.IFrameworkInitialisation;
+import dev.galasa.framework.spi.IApiServerInitialisation;
 
 public interface IAuthStoreRegistration {
 
-    void initialise(@NotNull IFrameworkInitialisation frameworkInitialisation) throws AuthStoreException;
+    void initialise(@NotNull IApiServerInitialisation frameworkInitialisation) throws AuthStoreException;
 }

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/FrameworkInitialisationTestBase.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/FrameworkInitialisationTestBase.java
@@ -37,7 +37,7 @@ public class FrameworkInitialisationTestBase {
 
     protected MockFramework addMockFrameworkToMockServiceRegistry(Map<String,MockServiceReference<?>> services, Bundle bundle) {
         MockFramework mockFramework = new MockFramework();
-        MockServiceReference<IFramework> mockFrameworkRef = new MockServiceReference<IFramework>(mockFramework, bundle );
+        MockServiceReference<IFramework> mockFrameworkRef = new MockServiceReference<>(mockFramework, bundle );
         services.put(IFramework.class.getName(),mockFrameworkRef);
         return mockFramework;
     }
@@ -45,7 +45,7 @@ public class FrameworkInitialisationTestBase {
     protected void addMockCPSToMockServiceRegistry(Map<String,MockServiceReference<?>> services, Map<String,String> cpsProperties, Bundle bundle) {
         MockCPSStore mockCPSStore = new MockCPSStore(cpsProperties);
         MockCPSRegistration mockCPSRegistration = new MockCPSRegistration(mockCPSStore);
-        MockServiceReference<IConfigurationPropertyStoreRegistration> mockCPSRef = new MockServiceReference<IConfigurationPropertyStoreRegistration>(mockCPSRegistration, bundle );
+        MockServiceReference<IConfigurationPropertyStoreRegistration> mockCPSRef = new MockServiceReference<>(mockCPSRegistration, bundle );
         services.put(IConfigurationPropertyStoreRegistration.class.getName(),mockCPSRef);
     }
 
@@ -54,7 +54,7 @@ public class FrameworkInitialisationTestBase {
         MockDSSStore mockDSSStore = new MockDSSStore(dssProps);
         MockDSSRegistration mockDSSRegistration = new MockDSSRegistration(mockDSSStore);
         MockServiceReference<IDynamicStatusStoreRegistration> mockDSSRef = 
-            new MockServiceReference<IDynamicStatusStoreRegistration>(mockDSSRegistration, bundle );
+            new MockServiceReference<>(mockDSSRegistration, bundle );
         services.put(IDynamicStatusStoreRegistration.class.getName(),mockDSSRef);
         return mockDSSStore;
     }
@@ -64,7 +64,7 @@ public class FrameworkInitialisationTestBase {
         MockRASStoreService mockRASStoreService = new MockRASStoreService(rasProps);
         MockRASRegistration mockRASRegistration = new MockRASRegistration(mockRASStoreService);
         MockServiceReference<IResultArchiveStoreRegistration> mockRASRef = 
-            new MockServiceReference<IResultArchiveStoreRegistration>(mockRASRegistration, bundle );
+            new MockServiceReference<>(mockRASRegistration, bundle );
         services.put(IResultArchiveStoreRegistration.class.getName(),mockRASRef);
         return mockRASStoreService;
     }
@@ -74,7 +74,7 @@ public class FrameworkInitialisationTestBase {
         MockCredentialsStore mockCredentialsStore = new MockCredentialsStore(credsProps);
         MockCredentialsStoreRegistration mockCredentialsStoreRegistration = new MockCredentialsStoreRegistration(mockCredentialsStore);
         MockServiceReference<ICredentialsStoreRegistration> mockCredsRegRef = 
-            new MockServiceReference<ICredentialsStoreRegistration>(mockCredentialsStoreRegistration, bundle );
+            new MockServiceReference<>(mockCredentialsStoreRegistration, bundle );
         services.put(ICredentialsStoreRegistration.class.getName(),mockCredsRegRef);
         return mockCredentialsStore;
     }
@@ -84,7 +84,7 @@ public class FrameworkInitialisationTestBase {
         MockConfidentialTextStore mockConfidentialTextStore = new MockConfidentialTextStore(confidentialTextProps);
         MockConfidentialTextStoreRegistration mockConfidentialTextStoreRegistration = new MockConfidentialTextStoreRegistration(mockConfidentialTextStore);
         MockServiceReference<IConfidentialTextServiceRegistration> mockConfidentialTextServiceRegRef = 
-            new MockServiceReference<IConfidentialTextServiceRegistration>(mockConfidentialTextStoreRegistration, bundle );
+            new MockServiceReference<>(mockConfidentialTextStoreRegistration, bundle );
         services.put(IConfidentialTextServiceRegistration.class.getName(),mockConfidentialTextServiceRegRef);
         return mockConfidentialTextStore;
     }
@@ -93,7 +93,7 @@ public class FrameworkInitialisationTestBase {
         MockEventsService mockEventsService = new MockEventsService();
         MockEventsServiceRegistration mockEventsServiceRegistration = new MockEventsServiceRegistration(mockEventsService);
         MockServiceReference<IEventsServiceRegistration> mockEventsServiceRegRef =
-            new MockServiceReference<IEventsServiceRegistration>(mockEventsServiceRegistration, bundle);
+            new MockServiceReference<>(mockEventsServiceRegistration, bundle);
         services.put(IEventsServiceRegistration.class.getName(), mockEventsServiceRegRef);
         return mockEventsService;
     }

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/FrameworkInitialisationTestBase.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/FrameworkInitialisationTestBase.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.osgi.framework.Bundle;
+
+import dev.galasa.ICredentials;
+import dev.galasa.framework.mocks.MockCPSRegistration;
+import dev.galasa.framework.mocks.MockCPSStore;
+import dev.galasa.framework.mocks.MockConfidentialTextStore;
+import dev.galasa.framework.mocks.MockConfidentialTextStoreRegistration;
+import dev.galasa.framework.mocks.MockCredentialsStore;
+import dev.galasa.framework.mocks.MockCredentialsStoreRegistration;
+import dev.galasa.framework.mocks.MockDSSRegistration;
+import dev.galasa.framework.mocks.MockDSSStore;
+import dev.galasa.framework.mocks.MockEventsService;
+import dev.galasa.framework.mocks.MockEventsServiceRegistration;
+import dev.galasa.framework.mocks.MockFramework;
+import dev.galasa.framework.mocks.MockRASRegistration;
+import dev.galasa.framework.mocks.MockRASStoreService;
+import dev.galasa.framework.mocks.MockServiceReference;
+import dev.galasa.framework.spi.IConfidentialTextServiceRegistration;
+import dev.galasa.framework.spi.IConfigurationPropertyStoreRegistration;
+import dev.galasa.framework.spi.IDynamicStatusStoreRegistration;
+import dev.galasa.framework.spi.IEventsServiceRegistration;
+import dev.galasa.framework.spi.IFramework;
+import dev.galasa.framework.spi.IResultArchiveStoreRegistration;
+import dev.galasa.framework.spi.creds.ICredentialsStoreRegistration;
+
+public class FrameworkInitialisationTestBase {
+
+    protected MockFramework addMockFrameworkToMockServiceRegistry(Map<String,MockServiceReference<?>> services, Bundle bundle) {
+        MockFramework mockFramework = new MockFramework();
+        MockServiceReference<IFramework> mockFrameworkRef = new MockServiceReference<IFramework>(mockFramework, bundle );
+        services.put(IFramework.class.getName(),mockFrameworkRef);
+        return mockFramework;
+    }
+
+    protected void addMockCPSToMockServiceRegistry(Map<String,MockServiceReference<?>> services, Map<String,String> cpsProperties, Bundle bundle) {
+        MockCPSStore mockCPSStore = new MockCPSStore(cpsProperties);
+        MockCPSRegistration mockCPSRegistration = new MockCPSRegistration(mockCPSStore);
+        MockServiceReference<IConfigurationPropertyStoreRegistration> mockCPSRef = new MockServiceReference<IConfigurationPropertyStoreRegistration>(mockCPSRegistration, bundle );
+        services.put(IConfigurationPropertyStoreRegistration.class.getName(),mockCPSRef);
+    }
+
+    protected MockDSSStore addMockDSSToMockServiceRegistry(Map<String,MockServiceReference<?>> services, Bundle bundle) {
+        Map<String,String> dssProps = new HashMap<String,String>();
+        MockDSSStore mockDSSStore = new MockDSSStore(dssProps);
+        MockDSSRegistration mockDSSRegistration = new MockDSSRegistration(mockDSSStore);
+        MockServiceReference<IDynamicStatusStoreRegistration> mockDSSRef = 
+            new MockServiceReference<IDynamicStatusStoreRegistration>(mockDSSRegistration, bundle );
+        services.put(IDynamicStatusStoreRegistration.class.getName(),mockDSSRef);
+        return mockDSSStore;
+    }
+
+    protected MockRASStoreService addMockRASToMockServiceRegistry(Map<String,MockServiceReference<?>> services, Bundle bundle) {
+        Map<String,String> rasProps = new HashMap<String,String>();
+        MockRASStoreService mockRASStoreService = new MockRASStoreService(rasProps);
+        MockRASRegistration mockRASRegistration = new MockRASRegistration(mockRASStoreService);
+        MockServiceReference<IResultArchiveStoreRegistration> mockRASRef = 
+            new MockServiceReference<IResultArchiveStoreRegistration>(mockRASRegistration, bundle );
+        services.put(IResultArchiveStoreRegistration.class.getName(),mockRASRef);
+        return mockRASStoreService;
+    }
+
+    protected MockCredentialsStore addMockCredentialsStoreToMockServiceRegistry(Map<String,MockServiceReference<?>> services, Bundle bundle) {
+        Map<String,ICredentials> credsProps = new HashMap<String,ICredentials>();
+        MockCredentialsStore mockCredentialsStore = new MockCredentialsStore(credsProps);
+        MockCredentialsStoreRegistration mockCredentialsStoreRegistration = new MockCredentialsStoreRegistration(mockCredentialsStore);
+        MockServiceReference<ICredentialsStoreRegistration> mockCredsRegRef = 
+            new MockServiceReference<ICredentialsStoreRegistration>(mockCredentialsStoreRegistration, bundle );
+        services.put(ICredentialsStoreRegistration.class.getName(),mockCredsRegRef);
+        return mockCredentialsStore;
+    }
+
+    protected MockConfidentialTextStore addMockConfidentialTextServiceToMockServiceRegistry(Map<String,MockServiceReference<?>> services, Bundle bundle) {
+        Map<String,String> confidentialTextProps = new HashMap<String,String>();
+        MockConfidentialTextStore mockConfidentialTextStore = new MockConfidentialTextStore(confidentialTextProps);
+        MockConfidentialTextStoreRegistration mockConfidentialTextStoreRegistration = new MockConfidentialTextStoreRegistration(mockConfidentialTextStore);
+        MockServiceReference<IConfidentialTextServiceRegistration> mockConfidentialTextServiceRegRef = 
+            new MockServiceReference<IConfidentialTextServiceRegistration>(mockConfidentialTextStoreRegistration, bundle );
+        services.put(IConfidentialTextServiceRegistration.class.getName(),mockConfidentialTextServiceRegRef);
+        return mockConfidentialTextStore;
+    }
+
+    protected MockEventsService addMockEventsServiceToMockServiceRegistry(Map<String,MockServiceReference<?>> services, Bundle bundle) {
+        MockEventsService mockEventsService = new MockEventsService();
+        MockEventsServiceRegistration mockEventsServiceRegistration = new MockEventsServiceRegistration(mockEventsService);
+        MockServiceReference<IEventsServiceRegistration> mockEventsServiceRegRef =
+            new MockServiceReference<IEventsServiceRegistration>(mockEventsServiceRegistration, bundle);
+        services.put(IEventsServiceRegistration.class.getName(), mockEventsServiceRegRef);
+        return mockEventsService;
+    }
+}

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestFrameworkInitialisation.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestFrameworkInitialisation.java
@@ -5,27 +5,19 @@
  */
 package dev.galasa.framework;
 
-import dev.galasa.ICredentials;
 import dev.galasa.framework.mocks.MockBundleContext;
-import dev.galasa.framework.mocks.MockCPSRegistration;
 import dev.galasa.framework.mocks.MockCPSStore;
 import dev.galasa.framework.mocks.MockConfidentialTextStore;
-import dev.galasa.framework.mocks.MockConfidentialTextStoreRegistration;
 import dev.galasa.framework.mocks.MockCredentialsStore;
-import dev.galasa.framework.mocks.MockCredentialsStoreRegistration;
-import dev.galasa.framework.mocks.MockDSSRegistration;
 import dev.galasa.framework.mocks.MockDSSStore;
 import dev.galasa.framework.mocks.MockEnvironment;
 import dev.galasa.framework.mocks.MockEventsService;
-import dev.galasa.framework.mocks.MockEventsServiceRegistration;
 import dev.galasa.framework.mocks.MockFileSystem;
 import dev.galasa.framework.mocks.MockFramework;
 import dev.galasa.framework.mocks.MockLog;
-import dev.galasa.framework.mocks.MockRASRegistration;
 import dev.galasa.framework.mocks.MockRASStoreService;
 import dev.galasa.framework.mocks.MockServiceReference;
 import dev.galasa.framework.spi.*;
-import dev.galasa.framework.spi.creds.ICredentialsStoreRegistration;
 
 import org.apache.commons.logging.Log;
 import org.junit.Test;
@@ -37,7 +29,7 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.util.*;
 
-public class TestFrameworkInitialisation {
+public class TestFrameworkInitialisation extends FrameworkInitialisationTestBase {
 
     @Test
     public void testFrameworkCreatedDefaultPathOk() throws Exception {
@@ -160,69 +152,6 @@ public class TestFrameworkInitialisation {
         return frameworkInitUnderTest;
     }
 
-
-    private MockFramework addMockFrameworkToMockServiceRegistry(Map<String,MockServiceReference<?>> services, Bundle bundle) {
-        MockFramework mockFramework = new MockFramework();
-        MockServiceReference<IFramework> mockFrameworkRef = new MockServiceReference<IFramework>(mockFramework, bundle );
-        services.put(IFramework.class.getName(),mockFrameworkRef);
-        return mockFramework;
-    }
-
-    private void addMockCPSToMockServiceRegistry(Map<String,MockServiceReference<?>> services, Map<String,String> cpsProperties, Bundle bundle) {
-        MockCPSStore mockCPSStore = new MockCPSStore(cpsProperties);
-        MockCPSRegistration mockCPSRegistration = new MockCPSRegistration(mockCPSStore);
-        MockServiceReference<IConfigurationPropertyStoreRegistration> mockCPSRef = new MockServiceReference<IConfigurationPropertyStoreRegistration>(mockCPSRegistration, bundle );
-        services.put(IConfigurationPropertyStoreRegistration.class.getName(),mockCPSRef);
-    }
-
-    private MockDSSStore addMockDSSToMockServiceRegistry(Map<String,MockServiceReference<?>> services, Bundle bundle) {
-        Map<String,String> dssProps = new HashMap<String,String>();
-        MockDSSStore mockDSSStore = new MockDSSStore(dssProps);
-        MockDSSRegistration mockDSSRegistration = new MockDSSRegistration(mockDSSStore);
-        MockServiceReference<IDynamicStatusStoreRegistration> mockDSSRef = 
-            new MockServiceReference<IDynamicStatusStoreRegistration>(mockDSSRegistration, bundle );
-        services.put(IDynamicStatusStoreRegistration.class.getName(),mockDSSRef);
-        return mockDSSStore;
-    }
-
-    private MockRASStoreService addMockRASToMockServiceRegistry(Map<String,MockServiceReference<?>> services, Bundle bundle) {
-        Map<String,String> rasProps = new HashMap<String,String>();
-        MockRASStoreService mockRASStoreService = new MockRASStoreService(rasProps);
-        MockRASRegistration mockRASRegistration = new MockRASRegistration(mockRASStoreService);
-        MockServiceReference<IResultArchiveStoreRegistration> mockRASRef = 
-            new MockServiceReference<IResultArchiveStoreRegistration>(mockRASRegistration, bundle );
-        services.put(IResultArchiveStoreRegistration.class.getName(),mockRASRef);
-        return mockRASStoreService;
-    }
-
-    private MockCredentialsStore addMockCredentialsStoreToMockServiceRegistry(Map<String,MockServiceReference<?>> services, Bundle bundle) {
-        Map<String,ICredentials> credsProps = new HashMap<String,ICredentials>();
-        MockCredentialsStore mockCredentialsStore = new MockCredentialsStore(credsProps);
-        MockCredentialsStoreRegistration mockCredentialsStoreRegistration = new MockCredentialsStoreRegistration(mockCredentialsStore);
-        MockServiceReference<ICredentialsStoreRegistration> mockCredsRegRef = 
-            new MockServiceReference<ICredentialsStoreRegistration>(mockCredentialsStoreRegistration, bundle );
-        services.put(ICredentialsStoreRegistration.class.getName(),mockCredsRegRef);
-        return mockCredentialsStore;
-    }
-
-    private MockConfidentialTextStore addMockConfidentialTextServiceToMockServiceRegistry(Map<String,MockServiceReference<?>> services, Bundle bundle) {
-        Map<String,String> confidentialTextProps = new HashMap<String,String>();
-        MockConfidentialTextStore mockConfidentialTextStore = new MockConfidentialTextStore(confidentialTextProps);
-        MockConfidentialTextStoreRegistration mockConfidentialTextStoreRegistration = new MockConfidentialTextStoreRegistration(mockConfidentialTextStore);
-        MockServiceReference<IConfidentialTextServiceRegistration> mockConfidentialTextServiceRegRef = 
-            new MockServiceReference<IConfidentialTextServiceRegistration>(mockConfidentialTextStoreRegistration, bundle );
-        services.put(IConfidentialTextServiceRegistration.class.getName(),mockConfidentialTextServiceRegRef);
-        return mockConfidentialTextStore;
-    }
-
-    private MockEventsService addMockEventsServiceToMockServiceRegistry(Map<String,MockServiceReference<?>> services, Bundle bundle) {
-        MockEventsService mockEventsService = new MockEventsService();
-        MockEventsServiceRegistration mockEventsServiceRegistration = new MockEventsServiceRegistration(mockEventsService);
-        MockServiceReference<IEventsServiceRegistration> mockEventsServiceRegRef =
-            new MockServiceReference<IEventsServiceRegistration>(mockEventsServiceRegistration, bundle);
-        services.put(IEventsServiceRegistration.class.getName(), mockEventsServiceRegRef);
-        return mockEventsService;
-    }
 
     // When no framework service has been found... should be an error.
     @Test

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestFrameworkInitialisation.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/TestFrameworkInitialisation.java
@@ -24,11 +24,7 @@ import dev.galasa.framework.mocks.MockLog;
 import dev.galasa.framework.mocks.MockRASRegistration;
 import dev.galasa.framework.mocks.MockRASStoreService;
 import dev.galasa.framework.mocks.MockServiceReference;
-import dev.galasa.framework.mocks.MockAuthStore;
-import dev.galasa.framework.mocks.MockAuthStoreRegistration;
 import dev.galasa.framework.spi.*;
-import dev.galasa.framework.spi.auth.IAuthStore;
-import dev.galasa.framework.spi.auth.IAuthStoreRegistration;
 import dev.galasa.framework.spi.creds.ICredentialsStoreRegistration;
 
 import org.apache.commons.logging.Log;
@@ -125,7 +121,7 @@ public class TestFrameworkInitialisation {
         // framework.run.name sets the run-name explicitly.
         // cpsProperties.put("framework.run.name","myRunName");
 
-        addMockCPSToMockServiceRegistery(services,cpsProperties, bundle);
+        addMockCPSToMockServiceRegistry(services,cpsProperties, bundle);
 
         MockDSSStore mockDSSStore = addMockDSSToMockServiceRegistry(services, bundle);
 
@@ -137,7 +133,6 @@ public class TestFrameworkInitialisation {
         MockCredentialsStore mockCredentialsStore = addMockCredentialsStoreToMockServiceRegistry(services, bundle);
         MockConfidentialTextStore mockConfidentialTextStore = addMockConfidentialTextServiceToMockServiceRegistry(services, bundle);
 
-        addMockAuthStoreToMockServiceRegistry(services, bundle);
         MockEventsService mockEventsService = addMockEventsServiceToMockServiceRegistry(services, bundle);
 
         // When...
@@ -173,7 +168,7 @@ public class TestFrameworkInitialisation {
         return mockFramework;
     }
 
-    private void addMockCPSToMockServiceRegistery(Map<String,MockServiceReference<?>> services, Map<String,String> cpsProperties, Bundle bundle) {
+    private void addMockCPSToMockServiceRegistry(Map<String,MockServiceReference<?>> services, Map<String,String> cpsProperties, Bundle bundle) {
         MockCPSStore mockCPSStore = new MockCPSStore(cpsProperties);
         MockCPSRegistration mockCPSRegistration = new MockCPSRegistration(mockCPSStore);
         MockServiceReference<IConfigurationPropertyStoreRegistration> mockCPSRef = new MockServiceReference<IConfigurationPropertyStoreRegistration>(mockCPSRegistration, bundle );
@@ -218,14 +213,6 @@ public class TestFrameworkInitialisation {
             new MockServiceReference<IConfidentialTextServiceRegistration>(mockConfidentialTextStoreRegistration, bundle );
         services.put(IConfidentialTextServiceRegistration.class.getName(),mockConfidentialTextServiceRegRef);
         return mockConfidentialTextStore;
-    }
-
-    private void addMockAuthStoreToMockServiceRegistry(Map<String,MockServiceReference<?>> services, Bundle bundle) {
-        MockAuthStore mockAuthStore = new MockAuthStore();
-        MockAuthStoreRegistration mockAuthStoreRegistration = new MockAuthStoreRegistration(mockAuthStore);
-        MockServiceReference<IAuthStoreRegistration> mockAuthStoreRef = new MockServiceReference<IAuthStoreRegistration>(
-                mockAuthStoreRegistration, bundle);
-        services.put(IAuthStoreRegistration.class.getName(), mockAuthStoreRef);
     }
 
     private MockEventsService addMockEventsServiceToMockServiceRegistry(Map<String,MockServiceReference<?>> services, Bundle bundle) {
@@ -535,64 +522,6 @@ public class TestFrameworkInitialisation {
         FrameworkInitialisation frameworkInit = createFrameworkInit(bootstrapProperties, env);
         String home = frameworkInit.getGalasaHome(env);
         assertThat(home).isEqualTo("~/.galasa");
-    }
-
-    @Test
-    public void testLocateAuthStoreDefaultsToNull() throws Exception {
-
-        // Given...
-        Properties bootstrap = new Properties();
-
-        // The framework.auth.store property hasn't been set, so there is no auth store to use.
-        FrameworkInitialisation frameworkInit = createFrameworkInit(bootstrap);
-
-        Log logger = new MockLog();
-
-        // When...
-        URI uri = frameworkInit.locateAuthStore(logger, bootstrap);
-
-        // Then...
-        assertThat(uri).isNull();
-    }
-
-    @Test
-    public void testLocateAuthStoreGetsFrameworkAuthStoreUri() throws Exception {
-
-        // Given...
-        Properties bootstrap = new Properties();
-
-        URI authStoreUri = URI.create("couchdb:http://my-user-store");
-
-        bootstrap.setProperty("framework.auth.store", authStoreUri.toString());
-        FrameworkInitialisation frameworkInit = createFrameworkInit(bootstrap);
-
-        Log logger = new MockLog();
-
-        // When...
-        URI uri = frameworkInit.locateAuthStore(logger, bootstrap);
-
-        // Then...
-        assertThat(uri).isNotNull();
-        assertThat(uri).isEqualTo(authStoreUri);
-    }
-
-    @Test
-    public void testInitialiseAuthStoreSetsFrameworkAuthStore() throws Exception {
-
-        // Given...
-        Properties bootstrap = new Properties();
-
-        URI authStoreUri = URI.create("couchdb:http://my-user-store");
-
-        bootstrap.setProperty("framework.auth.store", authStoreUri.toString());
-        FrameworkInitialisation frameworkInit = createFrameworkInit(bootstrap);
-
-        // When...
-        IAuthStore authStore = frameworkInit.getFramework().getAuthStore();
-
-        // Then...
-        assertThat(authStore).isNotNull();
-        assertThat(authStore.getClass().getName()).isEqualTo(MockAuthStore.class.getName());
     }
 
     @Test

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockFrameworkInitialisation.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockFrameworkInitialisation.java
@@ -24,8 +24,6 @@ import dev.galasa.framework.spi.IFramework;
 import dev.galasa.framework.spi.IFrameworkInitialisation;
 import dev.galasa.framework.spi.IResultArchiveStoreService;
 import dev.galasa.framework.spi.ResultArchiveStoreException;
-import dev.galasa.framework.spi.auth.IAuthStore;
-import dev.galasa.framework.spi.auth.AuthStoreException;
 import dev.galasa.framework.spi.creds.CredentialsException;
 import dev.galasa.framework.spi.creds.ICredentialsStore;
 
@@ -34,7 +32,6 @@ public class MockFrameworkInitialisation implements IFrameworkInitialisation {
     private URI cpsUri;
     private URI dssUri;
     private URI credsUri;
-    private URI authStoreUri;
     private IFramework framework;
 
     public MockFrameworkInitialisation(URI cpsUri) {
@@ -65,11 +62,6 @@ public class MockFrameworkInitialisation implements IFrameworkInitialisation {
     @Override
     public URI getCredentialsStoreUri() {
         return credsUri;
-    }
-
-    @Override
-    public URI getAuthStoreUri() {
-        return authStoreUri;
     }
 
     @Override
@@ -109,11 +101,6 @@ public class MockFrameworkInitialisation implements IFrameworkInitialisation {
 
     @Override
     public void registerCredentialsStore(@NotNull ICredentialsStore credentialsStore) throws CredentialsException {
-        // Do nothing...
-    }
-
-    @Override
-    public void registerAuthStore(@NotNull IAuthStore authStore) throws AuthStoreException {
         // Do nothing...
     }
 

--- a/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/felix/FelixFramework.java
+++ b/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/felix/FelixFramework.java
@@ -46,6 +46,7 @@ import dev.galasa.boot.LauncherException;
  */
 public class FelixFramework {
 
+    private static final String EXTRA_FRAMEWORK_BUNDLES_PROP  = "framework.extra.bundles";
     private static final String EXTRA_API_SERVER_BUNDLES_PROP = "api.extra.bundles";
 
     private BootLogger logger = new BootLogger();
@@ -135,7 +136,7 @@ public class FelixFramework {
             loadBundle("dev.galasa.framework");
 
             // Load extra bundles from the bootstrap
-            String extraBundles = boostrapProperties.getProperty("framework.extra.bundles");
+            String extraBundles = boostrapProperties.getProperty(EXTRA_FRAMEWORK_BUNDLES_PROP);
             if (extraBundles != null) {
                 loadBundlesList(extraBundles);
             }

--- a/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/felix/FelixFramework.java
+++ b/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/felix/FelixFramework.java
@@ -49,26 +49,19 @@ public class FelixFramework {
     private static final String EXTRA_FRAMEWORK_BUNDLES_PROP  = "framework.extra.bundles";
     private static final String EXTRA_API_SERVER_BUNDLES_PROP = "api.extra.bundles";
 
+    protected Framework framework;
+
+    protected RepositoryAdmin repositoryAdmin;
+
     private BootLogger logger = new BootLogger();
 
     private boolean loadConsole = false;
     
     private String bootJarLoacation = null;
 
-    private Framework framework;
-
     private Bundle obrBundle;
-
-    private RepositoryAdmin repositoryAdmin;
         
     private File felixCache;
-
-    public FelixFramework() {}
-
-    public FelixFramework(Framework framework, RepositoryAdmin repositoryAdmin) {
-        this.framework = framework;
-        this.repositoryAdmin = repositoryAdmin;
-    }
 
     /**
      * Initialise and start the Felix framework. Install required bundles and the

--- a/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/felix/FelixFramework.java
+++ b/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/felix/FelixFramework.java
@@ -63,6 +63,13 @@ public class FelixFramework {
         
     private File felixCache;
 
+    public FelixFramework() {}
+
+    public FelixFramework(Framework framework, RepositoryAdmin repositoryAdmin) {
+        this.framework = framework;
+        this.repositoryAdmin = repositoryAdmin;
+    }
+
     /**
      * Initialise and start the Felix framework. Install required bundles and the
      * OBRs. Install the Galasa framework bundle

--- a/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/felix/FelixFramework.java
+++ b/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/felix/FelixFramework.java
@@ -46,6 +46,8 @@ import dev.galasa.boot.LauncherException;
  */
 public class FelixFramework {
 
+    private static final String EXTRA_API_SERVER_BUNDLES_PROP = "api.extra.bundles";
+
     private BootLogger logger = new BootLogger();
 
     private boolean loadConsole = false;
@@ -135,16 +137,27 @@ public class FelixFramework {
             // Load extra bundles from the bootstrap
             String extraBundles = boostrapProperties.getProperty("framework.extra.bundles");
             if (extraBundles != null) {
-                String[] ebs = extraBundles.split(",");
-                for (String eb : ebs) {
-                    eb = eb.trim();
-                    if (!eb.isEmpty()) {
-                        loadBundle(eb);
-                    }
-                }
+                loadBundlesList(extraBundles);
             }
         } catch (IOException | BundleException e) {
             throw new LauncherException("Unable to initialise the Felix framework", e);
+        }
+    }
+
+    private void loadExtraApiBundles(Properties boostrapProperties) throws LauncherException {
+        String extraApiBundles = boostrapProperties.getProperty(EXTRA_API_SERVER_BUNDLES_PROP);
+        if (extraApiBundles != null) {
+            loadBundlesList(extraApiBundles);
+        }
+    }
+
+    private void loadBundlesList(String extraBundles) throws LauncherException {
+        String[] bundlesList = extraBundles.split(",");
+        for (String extraBundle : bundlesList) {
+            extraBundle = extraBundle.trim();
+            if (!extraBundle.isEmpty()) {
+                loadBundle(extraBundle);
+            }
         }
     }
 
@@ -678,6 +691,9 @@ public class FelixFramework {
         Bundle frameWorkBundle = getBundle("dev.galasa.framework");
         // Get the framework bundle
         loadBundle("dev.galasa.framework.api");
+
+        // Load any extra bundles that should only be available when running the API server
+        loadExtraApiBundles(boostrapProperties);
 
         // Get the dev.galasa.framework.api.internal.ApiStartup class service
         String classString = "dev.galasa.framework.api.internal.ApiStartup";

--- a/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/felix/TestFelixFramework.java
+++ b/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/felix/TestFelixFramework.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.boot.felix;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+import org.apache.felix.bundlerepository.Resource;
+import org.junit.Test;
+import org.osgi.framework.Bundle;
+
+import dev.galasa.boot.mocks.MockRunnableService;
+import dev.galasa.boot.mocks.MockBundle;
+import dev.galasa.boot.mocks.MockBundleContext;
+import dev.galasa.boot.mocks.MockOsgiFramework;
+import dev.galasa.boot.mocks.MockRepositoryAdmin;
+import dev.galasa.boot.mocks.MockResolver;
+import dev.galasa.boot.mocks.MockServiceReference;
+
+public class TestFelixFramework {
+
+    @Test
+    public void testRunWebApiServerLoadsExtraApiBundles() throws Exception {
+        // Given...
+        String extraBundleName = "my.api.bundle";
+
+        MockResolver mockResolver = new MockResolver();
+        MockRepositoryAdmin mockRepoAdmin = new MockRepositoryAdmin(mockResolver);
+
+        Map<String, MockServiceReference<?>> services = new HashMap<>();
+        MockServiceReference<MockRunnableService> mockApiStartup = new MockServiceReference<>(new MockRunnableService(), null);
+        services.put("dev.galasa.framework.api.internal.ApiStartup", mockApiStartup);
+
+        MockBundleContext mockFrameworkBundleContext = new MockBundleContext(services);
+        MockBundle mockFrameworkBundle = new MockBundle("dev.galasa.framework", mockFrameworkBundleContext);
+
+        Bundle[] availableBundles = new Bundle[] {
+            mockFrameworkBundle,
+            new MockBundle("org.apache.felix.http.servlet-api"),
+            new MockBundle("org.apache.felix.http.jetty"),
+            new MockBundle("org.apache.felix.fileinstall"),
+            new MockBundle("dev.galasa.framework.api"),
+            new MockBundle(extraBundleName),
+        };
+
+        MockBundleContext mockBundleContext = new MockBundleContext(availableBundles);
+        MockOsgiFramework mockOsgiFramework = new MockOsgiFramework(mockBundleContext);
+
+        FelixFramework felixFramework = new FelixFramework(mockOsgiFramework, mockRepoAdmin);
+        Properties bootstrapProperties = new Properties();
+        Properties overridesProperties = new Properties();
+
+        bootstrapProperties.put("api.extra.bundles", extraBundleName);
+
+        // When...
+        felixFramework.runWebApiServer(bootstrapProperties, overridesProperties, new ArrayList<>(), 0, 0);
+
+        // Then...
+        List<String> addedResourceIds = mockResolver.getAllResources()
+            .stream()
+            .map(Resource::getId)
+            .collect(Collectors.toList());
+
+        assertThat(addedResourceIds).contains(extraBundleName);
+    }
+
+    @Test
+    public void testRunWebApiServerLoadsMultipleExtraApiBundles() throws Exception {
+        // Given...
+        String extraBundle1 = "my.api.bundle";
+        String extraBundle2 = "another.extra.api.bundle";
+        String extraBundle3 = "oh.look.ANOTHER.api.bundle";
+
+        MockResolver mockResolver = new MockResolver();
+        MockRepositoryAdmin mockRepoAdmin = new MockRepositoryAdmin(mockResolver);
+
+        Map<String, MockServiceReference<?>> services = new HashMap<>();
+        MockServiceReference<MockRunnableService> mockApiStartup = new MockServiceReference<>(new MockRunnableService(), null);
+        services.put("dev.galasa.framework.api.internal.ApiStartup", mockApiStartup);
+
+        MockBundleContext mockFrameworkBundleContext = new MockBundleContext(services);
+        MockBundle mockFrameworkBundle = new MockBundle("dev.galasa.framework", mockFrameworkBundleContext);
+
+        Bundle[] availableBundles = new Bundle[] {
+            mockFrameworkBundle,
+            new MockBundle("org.apache.felix.http.servlet-api"),
+            new MockBundle("org.apache.felix.http.jetty"),
+            new MockBundle("org.apache.felix.fileinstall"),
+            new MockBundle("dev.galasa.framework.api"),
+            new MockBundle(extraBundle3),
+            new MockBundle(extraBundle2),
+            new MockBundle(extraBundle1),
+        };
+
+        MockBundleContext mockBundleContext = new MockBundleContext(availableBundles);
+        MockOsgiFramework mockOsgiFramework = new MockOsgiFramework(mockBundleContext);
+
+        FelixFramework felixFramework = new FelixFramework(mockOsgiFramework, mockRepoAdmin);
+        Properties bootstrapProperties = new Properties();
+        Properties overridesProperties = new Properties();
+
+        bootstrapProperties.put("api.extra.bundles", String.join(",", extraBundle1, extraBundle2, extraBundle3));
+
+        // When...
+        felixFramework.runWebApiServer(bootstrapProperties, overridesProperties, new ArrayList<>(), 0, 0);
+
+        // Then...
+        List<String> addedResourceIds = mockResolver.getAllResources()
+            .stream()
+            .map(Resource::getId)
+            .collect(Collectors.toList());
+
+        assertThat(addedResourceIds).contains(extraBundle1);
+        assertThat(addedResourceIds).contains(extraBundle2);
+        assertThat(addedResourceIds).contains(extraBundle3);
+    }
+
+    @Test
+    public void testRunWebApiServerWithoutExtraApiBundlesDoesNotLoadBundles() throws Exception {
+        // Given...
+        String extraBundleName = "dont.load.this.bundle";
+
+        MockResolver mockResolver = new MockResolver();
+        MockRepositoryAdmin mockRepoAdmin = new MockRepositoryAdmin(mockResolver);
+
+        Map<String, MockServiceReference<?>> services = new HashMap<>();
+        MockServiceReference<MockRunnableService> mockApiStartup = new MockServiceReference<>(new MockRunnableService(), null);
+        services.put("dev.galasa.framework.api.internal.ApiStartup", mockApiStartup);
+
+        MockBundleContext mockFrameworkBundleContext = new MockBundleContext(services);
+        MockBundle mockFrameworkBundle = new MockBundle("dev.galasa.framework", mockFrameworkBundleContext);
+
+        Bundle[] availableBundles = new Bundle[] {
+            mockFrameworkBundle,
+            new MockBundle("org.apache.felix.http.servlet-api"),
+            new MockBundle("org.apache.felix.http.jetty"),
+            new MockBundle("org.apache.felix.fileinstall"),
+            new MockBundle("dev.galasa.framework.api"),
+            new MockBundle(extraBundleName),
+        };
+
+        MockBundleContext mockBundleContext = new MockBundleContext(availableBundles);
+        MockOsgiFramework mockOsgiFramework = new MockOsgiFramework(mockBundleContext);
+
+        FelixFramework felixFramework = new FelixFramework(mockOsgiFramework, mockRepoAdmin);
+        
+        // Bootstrap properties don't contain the api.extra.bundles property
+        Properties bootstrapProperties = new Properties();
+        Properties overridesProperties = new Properties();
+
+        // When...
+        felixFramework.runWebApiServer(bootstrapProperties, overridesProperties, new ArrayList<>(), 0, 0);
+
+        // Then...
+        List<String> addedResourceIds = mockResolver.getAllResources()
+            .stream()
+            .map(Resource::getId)
+            .collect(Collectors.toList());
+
+        assertThat(addedResourceIds).doesNotContain(extraBundleName);
+    }
+}

--- a/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/felix/TestFelixFramework.java
+++ b/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/felix/TestFelixFramework.java
@@ -21,6 +21,7 @@ import org.osgi.framework.Bundle;
 import dev.galasa.boot.mocks.MockRunnableService;
 import dev.galasa.boot.mocks.MockBundle;
 import dev.galasa.boot.mocks.MockBundleContext;
+import dev.galasa.boot.mocks.MockFelixFramework;
 import dev.galasa.boot.mocks.MockOsgiFramework;
 import dev.galasa.boot.mocks.MockRepositoryAdmin;
 import dev.galasa.boot.mocks.MockResolver;
@@ -55,7 +56,7 @@ public class TestFelixFramework {
         MockBundleContext mockBundleContext = new MockBundleContext(availableBundles);
         MockOsgiFramework mockOsgiFramework = new MockOsgiFramework(mockBundleContext);
 
-        FelixFramework felixFramework = new FelixFramework(mockOsgiFramework, mockRepoAdmin);
+        FelixFramework felixFramework = new MockFelixFramework(mockOsgiFramework, mockRepoAdmin);
         Properties bootstrapProperties = new Properties();
         Properties overridesProperties = new Properties();
 
@@ -104,7 +105,7 @@ public class TestFelixFramework {
         MockBundleContext mockBundleContext = new MockBundleContext(availableBundles);
         MockOsgiFramework mockOsgiFramework = new MockOsgiFramework(mockBundleContext);
 
-        FelixFramework felixFramework = new FelixFramework(mockOsgiFramework, mockRepoAdmin);
+        FelixFramework felixFramework = new MockFelixFramework(mockOsgiFramework, mockRepoAdmin);
         Properties bootstrapProperties = new Properties();
         Properties overridesProperties = new Properties();
 
@@ -151,7 +152,7 @@ public class TestFelixFramework {
         MockBundleContext mockBundleContext = new MockBundleContext(availableBundles);
         MockOsgiFramework mockOsgiFramework = new MockOsgiFramework(mockBundleContext);
 
-        FelixFramework felixFramework = new FelixFramework(mockOsgiFramework, mockRepoAdmin);
+        FelixFramework felixFramework = new MockFelixFramework(mockOsgiFramework, mockRepoAdmin);
         
         // Bootstrap properties don't contain the api.extra.bundles property
         Properties bootstrapProperties = new Properties();

--- a/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/mocks/MockBundle.java
+++ b/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/mocks/MockBundle.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.boot.mocks;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.security.cert.X509Certificate;
+import java.util.Dictionary;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleException;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.Version;
+
+public class MockBundle implements Bundle {
+
+    private String symbolicName;
+    private BundleContext bundleContext;
+
+    public MockBundle(String symbolicName) {
+        this.symbolicName = symbolicName;
+    }
+
+    public MockBundle(String symbolicName, BundleContext bundleContext) {
+        this.symbolicName = symbolicName;
+        this.bundleContext = bundleContext;
+    }
+
+    @Override
+    public String getSymbolicName() {
+        return symbolicName;
+    }
+
+    @Override
+    public int getState() {
+        return Bundle.ACTIVE;
+    }
+
+    @Override
+    public BundleContext getBundleContext() {
+        return bundleContext;
+    }
+
+    @Override
+    public int compareTo(Bundle o) {
+        throw new UnsupportedOperationException("Unimplemented method 'compareTo'");
+    }
+
+    @Override
+    public void start(int options) throws BundleException {
+        throw new UnsupportedOperationException("Unimplemented method 'start'");
+    }
+
+    @Override
+    public void start() throws BundleException {
+        throw new UnsupportedOperationException("Unimplemented method 'start'");
+    }
+
+    @Override
+    public void stop(int options) throws BundleException {
+        throw new UnsupportedOperationException("Unimplemented method 'stop'");
+    }
+
+    @Override
+    public void stop() throws BundleException {
+        throw new UnsupportedOperationException("Unimplemented method 'stop'");
+    }
+
+    @Override
+    public void update(InputStream input) throws BundleException {
+        throw new UnsupportedOperationException("Unimplemented method 'update'");
+    }
+
+    @Override
+    public void update() throws BundleException {
+        throw new UnsupportedOperationException("Unimplemented method 'update'");
+    }
+
+    @Override
+    public void uninstall() throws BundleException {
+        throw new UnsupportedOperationException("Unimplemented method 'uninstall'");
+    }
+
+    @Override
+    public Dictionary<String, String> getHeaders() {
+        throw new UnsupportedOperationException("Unimplemented method 'getHeaders'");
+    }
+
+    @Override
+    public long getBundleId() {
+        throw new UnsupportedOperationException("Unimplemented method 'getBundleId'");
+    }
+
+    @Override
+    public String getLocation() {
+        throw new UnsupportedOperationException("Unimplemented method 'getLocation'");
+    }
+
+    @Override
+    public ServiceReference<?>[] getRegisteredServices() {
+        throw new UnsupportedOperationException("Unimplemented method 'getRegisteredServices'");
+    }
+
+    @Override
+    public ServiceReference<?>[] getServicesInUse() {
+        throw new UnsupportedOperationException("Unimplemented method 'getServicesInUse'");
+    }
+
+    @Override
+    public boolean hasPermission(Object permission) {
+        throw new UnsupportedOperationException("Unimplemented method 'hasPermission'");
+    }
+
+    @Override
+    public URL getResource(String name) {
+        throw new UnsupportedOperationException("Unimplemented method 'getResource'");
+    }
+
+    @Override
+    public Dictionary<String, String> getHeaders(String locale) {
+        throw new UnsupportedOperationException("Unimplemented method 'getHeaders'");
+    }
+
+    @Override
+    public Class<?> loadClass(String name) throws ClassNotFoundException {
+        throw new UnsupportedOperationException("Unimplemented method 'loadClass'");
+    }
+
+    @Override
+    public Enumeration<URL> getResources(String name) throws IOException {
+        throw new UnsupportedOperationException("Unimplemented method 'getResources'");
+    }
+
+    @Override
+    public Enumeration<String> getEntryPaths(String path) {
+        throw new UnsupportedOperationException("Unimplemented method 'getEntryPaths'");
+    }
+
+    @Override
+    public URL getEntry(String path) {
+        throw new UnsupportedOperationException("Unimplemented method 'getEntry'");
+    }
+
+    @Override
+    public long getLastModified() {
+        throw new UnsupportedOperationException("Unimplemented method 'getLastModified'");
+    }
+
+    @Override
+    public Enumeration<URL> findEntries(String path, String filePattern, boolean recurse) {
+        throw new UnsupportedOperationException("Unimplemented method 'findEntries'");
+    }
+
+    @Override
+    public Map<X509Certificate, List<X509Certificate>> getSignerCertificates(int signersType) {
+        throw new UnsupportedOperationException("Unimplemented method 'getSignerCertificates'");
+    }
+
+    @Override
+    public Version getVersion() {
+        throw new UnsupportedOperationException("Unimplemented method 'getVersion'");
+    }
+
+    @Override
+    public <A> A adapt(Class<A> type) {
+        throw new UnsupportedOperationException("Unimplemented method 'adapt'");
+    }
+
+    @Override
+    public File getDataFile(String filename) {
+        throw new UnsupportedOperationException("Unimplemented method 'getDataFile'");
+    }
+
+}

--- a/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/mocks/MockBundleContext.java
+++ b/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/mocks/MockBundleContext.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.boot.mocks;
+
+import java.io.File;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.Dictionary;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleException;
+import org.osgi.framework.BundleListener;
+import org.osgi.framework.Filter;
+import org.osgi.framework.FrameworkListener;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceFactory;
+import org.osgi.framework.ServiceListener;
+import org.osgi.framework.ServiceObjects;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.ServiceRegistration;
+
+public class MockBundleContext implements BundleContext{
+
+    private Map<String,MockServiceReference<?>> services;
+    private Bundle[] bundles;
+
+    /**
+     * @param services A map. The key is the interface/class name.
+     */
+    public MockBundleContext(Map<String,MockServiceReference<?>> services) {
+        this.services = services;
+    }
+
+    public MockBundleContext(Bundle[] bundles) {
+        this.bundles = bundles;
+    }
+
+    @Override
+    public Bundle[] getBundles() {
+        return bundles;
+    }
+
+    @Override
+    public ServiceReference<?>[] getServiceReferences(String clazz, String filter) throws InvalidSyntaxException {
+        return getAllServiceReferences(clazz, filter);
+    }
+
+    @Override
+    public ServiceReference<?>[] getAllServiceReferences(String clazz, String filter) throws InvalidSyntaxException {
+        int count = 0;
+        for( Entry<String,MockServiceReference<?>> entry : this.services.entrySet() ) {
+            if(entry.getKey().equals(clazz)) {
+                count++;
+            }
+        }
+
+        ServiceReference<?>[] allServiceReferences = new ServiceReference<?>[count];
+
+        int i=0;
+        for( Entry<String,MockServiceReference<?>> entry : this.services.entrySet() ) {
+            if(entry.getKey().equals(clazz)) {
+                allServiceReferences[i] = entry.getValue();
+                i++;
+            }
+        }
+
+        return allServiceReferences;
+    }
+
+    @Override
+    public ServiceReference<?> getServiceReference(String clazz) {
+        // logger.info("getServiceReference(String clazz="+clazz+")");
+        ServiceReference<?> ref = this.services.get(clazz);
+        return ref;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <S> ServiceReference<S> getServiceReference(Class<S> clazz) {
+        String className = clazz.getName();
+        ServiceReference<S> result ;
+
+        ServiceReference<?> rawRef = getServiceReference(className);
+
+        result = (ServiceReference<S>)rawRef;
+        return result;
+    }
+
+    @Override
+    public <S> S getService(ServiceReference<S> reference) {
+        S result = ((MockServiceReference<S>)reference).getService();
+        return result;
+    }
+
+
+    @Override
+    public String getProperty(String key) {
+        throw new UnsupportedOperationException("Unimplemented method 'getProperty'");
+    }
+
+    @Override
+    public Bundle getBundle() {
+        throw new UnsupportedOperationException("Unimplemented method 'getBundle'");
+    }
+
+    @Override
+    public Bundle installBundle(String location, InputStream input) throws BundleException {
+        throw new UnsupportedOperationException("Unimplemented method 'installBundle'");
+    }
+
+    @Override
+    public Bundle installBundle(String location) throws BundleException {
+        throw new UnsupportedOperationException("Unimplemented method 'installBundle'");
+    }
+
+    @Override
+    public Bundle getBundle(long id) {
+        throw new UnsupportedOperationException("Unimplemented method 'getBundle'");
+    }
+
+    @Override
+    public void addServiceListener(ServiceListener listener, String filter) throws InvalidSyntaxException {
+        throw new UnsupportedOperationException("Unimplemented method 'addServiceListener'");
+    }
+
+    @Override
+    public void addServiceListener(ServiceListener listener) {
+        throw new UnsupportedOperationException("Unimplemented method 'addServiceListener'");
+    }
+
+    @Override
+    public void removeServiceListener(ServiceListener listener) {
+        throw new UnsupportedOperationException("Unimplemented method 'removeServiceListener'");
+    }
+
+    @Override
+    public void addBundleListener(BundleListener listener) {
+        throw new UnsupportedOperationException("Unimplemented method 'addBundleListener'");
+    }
+
+    @Override
+    public void removeBundleListener(BundleListener listener) {
+        throw new UnsupportedOperationException("Unimplemented method 'removeBundleListener'");
+    }
+
+    @Override
+    public void addFrameworkListener(FrameworkListener listener) {
+        throw new UnsupportedOperationException("Unimplemented method 'addFrameworkListener'");
+    }
+
+    @Override
+    public void removeFrameworkListener(FrameworkListener listener) {
+        throw new UnsupportedOperationException("Unimplemented method 'removeFrameworkListener'");
+    }
+
+    @Override
+    public ServiceRegistration<?> registerService(String[] clazzes, Object service, Dictionary<String, ?> properties) {
+        throw new UnsupportedOperationException("Unimplemented method 'registerService'");
+    }
+
+    @Override
+    public ServiceRegistration<?> registerService(String clazz, Object service, Dictionary<String, ?> properties) {
+        throw new UnsupportedOperationException("Unimplemented method 'registerService'");
+    }
+
+    @Override
+    public <S> ServiceRegistration<S> registerService(Class<S> clazz, S service, Dictionary<String, ?> properties) {
+        throw new UnsupportedOperationException("Unimplemented method 'registerService'");
+    }
+
+    @Override
+    public <S> ServiceRegistration<S> registerService(Class<S> clazz, ServiceFactory<S> factory,
+            Dictionary<String, ?> properties) {
+        throw new UnsupportedOperationException("Unimplemented method 'registerService'");
+    }
+
+    @Override
+    public <S> Collection<ServiceReference<S>> getServiceReferences(Class<S> clazz, String filter)
+            throws InvalidSyntaxException {
+        throw new UnsupportedOperationException("Unimplemented method 'getServiceReferences'");
+    }
+
+    @Override
+    public boolean ungetService(ServiceReference<?> reference) {
+        throw new UnsupportedOperationException("Unimplemented method 'ungetService'");
+    }
+
+    @Override
+    public <S> ServiceObjects<S> getServiceObjects(ServiceReference<S> reference) {
+        throw new UnsupportedOperationException("Unimplemented method 'getServiceObjects'");
+    }
+
+    @Override
+    public File getDataFile(String filename) {
+        throw new UnsupportedOperationException("Unimplemented method 'getDataFile'");
+    }
+
+    @Override
+    public Filter createFilter(String filter) throws InvalidSyntaxException {
+        throw new UnsupportedOperationException("Unimplemented method 'createFilter'");
+    }
+
+    @Override
+    public Bundle getBundle(String location) {
+        throw new UnsupportedOperationException("Unimplemented method 'getBundle'");
+    }
+}

--- a/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/mocks/MockFelixFramework.java
+++ b/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/mocks/MockFelixFramework.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.boot.mocks;
+
+import org.apache.felix.bundlerepository.RepositoryAdmin;
+import org.osgi.framework.launch.Framework;
+
+import dev.galasa.boot.felix.FelixFramework;
+
+public class MockFelixFramework extends FelixFramework {
+
+    public MockFelixFramework(Framework framework, RepositoryAdmin repositoryAdmin) {
+        super.framework = framework;
+        super.repositoryAdmin = repositoryAdmin;
+    }
+}

--- a/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/mocks/MockOsgiFramework.java
+++ b/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/mocks/MockOsgiFramework.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.boot.mocks;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.security.cert.X509Certificate;
+import java.util.Dictionary;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleException;
+import org.osgi.framework.FrameworkEvent;
+import org.osgi.framework.FrameworkListener;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.Version;
+import org.osgi.framework.launch.Framework;
+
+public class MockOsgiFramework implements Framework {
+
+    private MockBundleContext bundleContext;
+
+    public MockOsgiFramework(MockBundleContext bundleContext) {
+        this.bundleContext = bundleContext;
+    }
+
+    @Override
+    public BundleContext getBundleContext() {
+        return bundleContext;
+    }
+
+    @Override
+    public int getState() {
+        throw new UnsupportedOperationException("Unimplemented method 'getState'");
+    }
+
+    @Override
+    public Dictionary<String, String> getHeaders() {
+        throw new UnsupportedOperationException("Unimplemented method 'getHeaders'");
+    }
+
+    @Override
+    public ServiceReference<?>[] getRegisteredServices() {
+        throw new UnsupportedOperationException("Unimplemented method 'getRegisteredServices'");
+    }
+
+    @Override
+    public ServiceReference<?>[] getServicesInUse() {
+        throw new UnsupportedOperationException("Unimplemented method 'getServicesInUse'");
+    }
+
+    @Override
+    public boolean hasPermission(Object permission) {
+        throw new UnsupportedOperationException("Unimplemented method 'hasPermission'");
+    }
+
+    @Override
+    public URL getResource(String name) {
+        throw new UnsupportedOperationException("Unimplemented method 'getResource'");
+    }
+
+    @Override
+    public Dictionary<String, String> getHeaders(String locale) {
+        throw new UnsupportedOperationException("Unimplemented method 'getHeaders'");
+    }
+
+    @Override
+    public Class<?> loadClass(String name) throws ClassNotFoundException {
+        throw new UnsupportedOperationException("Unimplemented method 'loadClass'");
+    }
+
+    @Override
+    public Enumeration<URL> getResources(String name) throws IOException {
+        throw new UnsupportedOperationException("Unimplemented method 'getResources'");
+    }
+
+    @Override
+    public Map<X509Certificate, List<X509Certificate>> getSignerCertificates(int signersType) {
+        throw new UnsupportedOperationException("Unimplemented method 'getSignerCertificates'");
+    }
+
+    @Override
+    public Version getVersion() {
+        throw new UnsupportedOperationException("Unimplemented method 'getVersion'");
+    }
+
+    @Override
+    public File getDataFile(String filename) {
+        throw new UnsupportedOperationException("Unimplemented method 'getDataFile'");
+    }
+
+    @Override
+    public int compareTo(Bundle o) {
+        throw new UnsupportedOperationException("Unimplemented method 'compareTo'");
+    }
+
+    @Override
+    public void init() throws BundleException {
+        throw new UnsupportedOperationException("Unimplemented method 'init'");
+    }
+
+    @Override
+    public void init(FrameworkListener... listeners) throws BundleException {
+        throw new UnsupportedOperationException("Unimplemented method 'init'");
+    }
+
+    @Override
+    public FrameworkEvent waitForStop(long timeout) throws InterruptedException {
+        throw new UnsupportedOperationException("Unimplemented method 'waitForStop'");
+    }
+
+    @Override
+    public void start() throws BundleException {
+        throw new UnsupportedOperationException("Unimplemented method 'start'");
+    }
+
+    @Override
+    public void start(int options) throws BundleException {
+        throw new UnsupportedOperationException("Unimplemented method 'start'");
+    }
+
+    @Override
+    public void stop() throws BundleException {
+        throw new UnsupportedOperationException("Unimplemented method 'stop'");
+    }
+
+    @Override
+    public void stop(int options) throws BundleException {
+        throw new UnsupportedOperationException("Unimplemented method 'stop'");
+    }
+
+    @Override
+    public void uninstall() throws BundleException {
+        throw new UnsupportedOperationException("Unimplemented method 'uninstall'");
+    }
+
+    @Override
+    public void update() throws BundleException {
+        throw new UnsupportedOperationException("Unimplemented method 'update'");
+    }
+
+    @Override
+    public void update(InputStream in) throws BundleException {
+        throw new UnsupportedOperationException("Unimplemented method 'update'");
+    }
+
+    @Override
+    public long getBundleId() {
+        throw new UnsupportedOperationException("Unimplemented method 'getBundleId'");
+    }
+
+    @Override
+    public String getLocation() {
+        throw new UnsupportedOperationException("Unimplemented method 'getLocation'");
+    }
+
+    @Override
+    public String getSymbolicName() {
+        throw new UnsupportedOperationException("Unimplemented method 'getSymbolicName'");
+    }
+
+    @Override
+    public Enumeration<String> getEntryPaths(String path) {
+        throw new UnsupportedOperationException("Unimplemented method 'getEntryPaths'");
+    }
+
+    @Override
+    public URL getEntry(String path) {
+        throw new UnsupportedOperationException("Unimplemented method 'getEntry'");
+    }
+
+    @Override
+    public long getLastModified() {
+        throw new UnsupportedOperationException("Unimplemented method 'getLastModified'");
+    }
+
+    @Override
+    public Enumeration<URL> findEntries(String path, String filePattern, boolean recurse) {
+        throw new UnsupportedOperationException("Unimplemented method 'findEntries'");
+    }
+
+    @Override
+    public <A> A adapt(Class<A> type) {
+        throw new UnsupportedOperationException("Unimplemented method 'adapt'");
+    }
+}

--- a/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/mocks/MockRepositoryAdmin.java
+++ b/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/mocks/MockRepositoryAdmin.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.boot.mocks;
+
+import java.net.URL;
+
+import org.apache.felix.bundlerepository.DataModelHelper;
+import org.apache.felix.bundlerepository.Repository;
+import org.apache.felix.bundlerepository.RepositoryAdmin;
+import org.apache.felix.bundlerepository.Requirement;
+import org.apache.felix.bundlerepository.Resolver;
+import org.apache.felix.bundlerepository.Resource;
+import org.osgi.framework.InvalidSyntaxException;
+
+public class MockRepositoryAdmin implements RepositoryAdmin {
+
+    private MockResolver resolver;
+
+    public MockRepositoryAdmin(MockResolver resolver) {
+        this.resolver = resolver;
+    }
+
+    @Override
+    public Resource[] discoverResources(String filterExpr) throws InvalidSyntaxException {
+        String resourceName = filterExpr.replace("(symbolicname=", "").replace(")", "");
+        MockResource mockResource = new MockResource(resourceName, resourceName, "uri");
+        return new Resource[] { mockResource };
+    }
+
+    @Override
+    public Resolver resolver() {
+        return resolver;
+    }
+
+    @Override
+    public Resource[] discoverResources(Requirement[] requirements) {
+        throw new UnsupportedOperationException("Unimplemented method 'discoverResources'");
+    }
+
+    @Override
+    public Resolver resolver(Repository[] repositories) {
+        throw new UnsupportedOperationException("Unimplemented method 'resolver'");
+    }
+
+    @Override
+    public Repository addRepository(String repository) throws Exception {
+        throw new UnsupportedOperationException("Unimplemented method 'addRepository'");
+    }
+
+    @Override
+    public Repository addRepository(URL repository) throws Exception {
+        throw new UnsupportedOperationException("Unimplemented method 'addRepository'");
+    }
+
+    @Override
+    public boolean removeRepository(String repository) {
+        throw new UnsupportedOperationException("Unimplemented method 'removeRepository'");
+    }
+
+    @Override
+    public Repository[] listRepositories() {
+        throw new UnsupportedOperationException("Unimplemented method 'listRepositories'");
+    }
+
+    @Override
+    public Repository getSystemRepository() {
+        throw new UnsupportedOperationException("Unimplemented method 'getSystemRepository'");
+    }
+
+    @Override
+    public Repository getLocalRepository() {
+        throw new UnsupportedOperationException("Unimplemented method 'getLocalRepository'");
+    }
+
+    @Override
+    public DataModelHelper getHelper() {
+        throw new UnsupportedOperationException("Unimplemented method 'getHelper'");
+    }
+}

--- a/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/mocks/MockResolver.java
+++ b/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/mocks/MockResolver.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.boot.mocks;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.felix.bundlerepository.Capability;
+import org.apache.felix.bundlerepository.InterruptedResolutionException;
+import org.apache.felix.bundlerepository.Reason;
+import org.apache.felix.bundlerepository.Requirement;
+import org.apache.felix.bundlerepository.Resolver;
+import org.apache.felix.bundlerepository.Resource;
+
+public class MockResolver implements Resolver {
+
+    private List<Resource> resources = new ArrayList<>();
+
+    @Override
+    public void add(Resource resource) {
+        resources.add(resource);
+    }
+
+    @Override
+    public boolean resolve() throws InterruptedResolutionException {
+        return true;
+    }
+
+    @Override
+    public Resource[] getRequiredResources() {
+        return resources.toArray(new Resource[0]);
+    }
+
+    @Override
+    public Resource[] getOptionalResources() {
+        return new Resource[0];
+    }
+
+    @Override
+    public void deploy(int flags) {
+        // Do nothing...
+    }
+
+    public List<Resource> getAllResources() {
+        return resources;
+    }
+
+    @Override
+    public Resource[] getAddedResources() {
+        throw new UnsupportedOperationException("Unimplemented method 'getAddedResources'");
+    }
+
+    @Override
+    public void add(Requirement requirement) {
+        throw new UnsupportedOperationException("Unimplemented method 'add'");
+    }
+
+    @Override
+    public Requirement[] getAddedRequirements() {
+        throw new UnsupportedOperationException("Unimplemented method 'getAddedRequirements'");
+    }
+
+    @Override
+    public void addGlobalCapability(Capability capability) {
+        throw new UnsupportedOperationException("Unimplemented method 'addGlobalCapability'");
+    }
+
+    @Override
+    public Capability[] getGlobalCapabilities() {
+        throw new UnsupportedOperationException("Unimplemented method 'getGlobalCapabilities'");
+    }
+
+    @Override
+    public boolean resolve(int flags) throws InterruptedResolutionException {
+        throw new UnsupportedOperationException("Unimplemented method 'resolve'");
+    }
+
+    @Override
+    public Reason[] getReason(Resource resource) {
+        throw new UnsupportedOperationException("Unimplemented method 'getReason'");
+    }
+
+    @Override
+    public Reason[] getUnsatisfiedRequirements() {
+        throw new UnsupportedOperationException("Unimplemented method 'getUnsatisfiedRequirements'");
+    }
+}

--- a/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/mocks/MockResource.java
+++ b/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/mocks/MockResource.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.boot.mocks;
+
+import java.util.Map;
+
+import org.apache.felix.bundlerepository.Capability;
+import org.apache.felix.bundlerepository.Requirement;
+import org.apache.felix.bundlerepository.Resource;
+import org.osgi.framework.Version;
+
+public class MockResource implements Resource {
+
+    private String id;
+    private String symbolicName;
+    private String uri;
+
+    public MockResource(String id, String symbolicName, String uri) {
+        this.id = id;
+        this.symbolicName = symbolicName;
+        this.uri = uri;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public String getSymbolicName() {
+        return symbolicName;
+    }
+
+    @Override
+    public String getURI() {
+        return uri;
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public Map getProperties() {
+        throw new UnsupportedOperationException("Unimplemented method 'getProperties'");
+    }
+
+    @Override
+    public Version getVersion() {
+        throw new UnsupportedOperationException("Unimplemented method 'getVersion'");
+    }
+
+    @Override
+    public String getPresentationName() {
+        throw new UnsupportedOperationException("Unimplemented method 'getPresentationName'");
+    }
+
+    @Override
+    public Long getSize() {
+        throw new UnsupportedOperationException("Unimplemented method 'getSize'");
+    }
+
+    @Override
+    public String[] getCategories() {
+        throw new UnsupportedOperationException("Unimplemented method 'getCategories'");
+    }
+
+    @Override
+    public Capability[] getCapabilities() {
+        throw new UnsupportedOperationException("Unimplemented method 'getCapabilities'");
+    }
+
+    @Override
+    public Requirement[] getRequirements() {
+        throw new UnsupportedOperationException("Unimplemented method 'getRequirements'");
+    }
+
+    @Override
+    public boolean isLocal() {
+        throw new UnsupportedOperationException("Unimplemented method 'isLocal'");
+    }
+}

--- a/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/mocks/MockRunnableService.java
+++ b/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/mocks/MockRunnableService.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.boot.mocks;
+
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * This is a class containing the "run" methods used by the FelixFramework to start various services
+ * like the API server and k8s controller.
+ */
+public class MockRunnableService {
+    
+    public void run(Properties bootstrapProperties, Properties overrideProperties, List<String> extraBundles) {}
+}

--- a/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/mocks/MockServiceReference.java
+++ b/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/mocks/MockServiceReference.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.boot.mocks;
+
+import java.util.Dictionary;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.ServiceReference;
+
+public class MockServiceReference<T> implements ServiceReference<T> {
+
+    private T service;
+    private Bundle bundle;
+
+    public MockServiceReference(T service, Bundle bundle) {
+        this.bundle = bundle;
+        this.service = service;
+    }
+
+    public T getService() {
+        return this.service;
+    }
+
+    @Override
+    public Bundle getBundle() {
+        return this.bundle;
+    }
+
+    @Override
+    public Object getProperty(String key) {
+        throw new UnsupportedOperationException("Unimplemented method 'getProperty'");
+    }
+
+    @Override
+    public String[] getPropertyKeys() {
+        throw new UnsupportedOperationException("Unimplemented method 'getPropertyKeys'");
+    }
+
+    @Override
+    public Bundle[] getUsingBundles() {
+        throw new UnsupportedOperationException("Unimplemented method 'getUsingBundles'");
+    }
+
+    @Override
+    public boolean isAssignableTo(Bundle bundle, String className) {
+        throw new UnsupportedOperationException("Unimplemented method 'isAssignableTo'");
+    }
+
+    @Override
+    public int compareTo(Object reference) {
+        throw new UnsupportedOperationException("Unimplemented method 'compareTo'");
+    }
+
+    @Override
+    public Dictionary<String, Object> getProperties() {
+        throw new UnsupportedOperationException("Unimplemented method 'getProperties'");
+    }
+
+    @Override
+    public <A> A adapt(Class<A> type) {
+        throw new UnsupportedOperationException("Unimplemented method 'adapt'");
+    }
+}

--- a/release.yaml
+++ b/release.yaml
@@ -75,7 +75,7 @@ framework:
 api:
   bundles:
   - artifact: dev.galasa.framework.api
-    version: 0.27.0
+    version: 0.34.0
     obr: true
     isolated: true
     codecoverage: true


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1864

## Changes
- Added `APIServerInitialisation` subclass of the `FrameworkInitialisation` class, which is responsible for initialising API server-specific stores/config.
  - Moved auth store initialisation code into this new API server initialisation class
- Added an `api.extra.bundles` bootstrap property to load bundles for use by the API server (i.e. bundles that are not loaded into the core framework)