### PR TITLE
Iss1768 - Update IEventsService interface

### DIFF
--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/events/FrameworkEventsService.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/events/FrameworkEventsService.java
@@ -5,14 +5,18 @@
  */
 package dev.galasa.framework.internal.events;
 
+import dev.galasa.framework.spi.events.IEvent;
 import dev.galasa.framework.spi.IEventsService;
 
 public class FrameworkEventsService implements IEventsService {
 
-    // The implementation of an Events Service would be in here, but there is no implementation for local runs...
+    // The Events Service has no implementation for local runs...
 
-    
+    @Override
+    public void produceEvent(String topic, IEvent event) {
+    }
 
+    @Override
     public void shutdown(){
         // Nothing to shut down
     }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IEventProducer.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IEventProducer.java
@@ -1,0 +1,11 @@
+package dev.galasa.framework.spi;
+
+import dev.galasa.framework.spi.events.IEvent;
+
+public interface IEventProducer {
+
+    void sendEvent(IEvent event);
+
+    void close();
+    
+}

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IEventsService.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IEventsService.java
@@ -5,7 +5,11 @@
  */
 package dev.galasa.framework.spi;
 
+import dev.galasa.framework.spi.events.IEvent;
+
 public interface IEventsService {
+
+    void produceEvent(String topic, IEvent event);
 
     void shutdown();
     

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IEventsService.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IEventsService.java
@@ -9,7 +9,7 @@ import dev.galasa.framework.spi.events.IEvent;
 
 public interface IEventsService {
 
-    void produceEvent(String topic, IEvent event);
+    void produceEvent(String topic, IEvent event) throws EventsException;
 
     void shutdown();
     

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/events/IEvent.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/events/IEvent.java
@@ -18,8 +18,5 @@ public interface IEvent {
     String getMessage();
 
     void setMessage(String message);
-
-    @Override
-    String toString();
     
 }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/events/IEvent.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/events/IEvent.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.spi.events;
+
+public interface IEvent {
+
+    String getId();
+
+    void setId(String id);
+
+    String getTimestamp();
+
+    void setTimestamp(String timestamp);
+
+    String getMessage();
+
+    void setMessage(String message);
+
+    @Override
+    String toString();
+    
+}

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockEventsService.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockEventsService.java
@@ -6,8 +6,14 @@
 package dev.galasa.framework.mocks;
 
 import dev.galasa.framework.spi.IEventsService;
+import dev.galasa.framework.spi.events.IEvent;
 
 public class MockEventsService implements IEventsService {
+
+    @Override
+    public void produceEvent(String topic, IEvent event) {
+        throw new UnsupportedOperationException("Unimplemented method 'produceEvent'");
+    }
 
     @Override
     public void shutdown() {


### PR DESCRIPTION
### Why?
The IEventsService needs all methods available in the interface as the concrete methods are not accessible to the caller. I have also updated the classes that implement the interface. 

Also moved the IEvent interface into the framework from extensions so the framework code can refer to it.