### PR TITLE
Add token creation to POST /auth/tokens

### DIFF
--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/AuthenticationServlet.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/AuthenticationServlet.java
@@ -66,7 +66,7 @@ public class AuthenticationServlet extends BaseServlet {
         addRoute(new AuthRoute(getResponseBuilder(), oidcProvider, dexGrpcClient, authStoreService, env));
         addRoute(new AuthClientsRoute(getResponseBuilder(), dexGrpcClient));
         addRoute(new AuthCallbackRoute(getResponseBuilder(), externalApiServerUrl));
-        addRoute(new AuthTokensRoute(getResponseBuilder(), authStoreService));
+        addRoute(new AuthTokensRoute(getResponseBuilder(), oidcProvider, dexGrpcClient, authStoreService, env));
 
         logger.info("Galasa Authentication API initialised");
     }

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/UnauthenticatedRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/UnauthenticatedRoute.java
@@ -9,21 +9,29 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
+import dev.galasa.framework.api.common.HttpMethod;
+
+/**
+ * An enum representing the API routes that do not require a JWT in order to send
+ * requests to. Each route contains a list of allowed HTTP methods indicating the
+ * methods that will not be blocked by the JWT filter.
+ */
 public enum UnauthenticatedRoute {
 
-    AUTH("/auth", "GET", "POST"),
-    AUTH_TOKENS("/auth/tokens", "POST"),
-    AUTH_CALLBACK("/auth/callback", "GET"),
-    BOOTSTRAP("/bootstrap", "GET"),
-    BOOTSTRAP_EXTERNAL("/bootstrap/external", "GET"),
-    HEALTH("/health", "GET"),
+    AUTH("/auth", HttpMethod.GET, HttpMethod.POST),
+    AUTH_TOKENS("/auth/tokens", HttpMethod.POST),
+    AUTH_CALLBACK("/auth/callback", HttpMethod.GET),
+    BOOTSTRAP("/bootstrap", HttpMethod.GET),
+    BOOTSTRAP_EXTERNAL("/bootstrap/external", HttpMethod.GET),
+    HEALTH("/health", HttpMethod.GET),
     ;
 
     private String route;
-    private List<String> allowedMethods;
+    private List<HttpMethod> allowedMethods;
 
-    private UnauthenticatedRoute(String route, String... allowedMethods) {
+    private UnauthenticatedRoute(String route, HttpMethod... allowedMethods) {
         this.route = route;
         this.allowedMethods = Arrays.asList(allowedMethods);
     }
@@ -42,6 +50,9 @@ public enum UnauthenticatedRoute {
     }
 
     public List<String> getAllowedMethods() {
-        return this.allowedMethods;
+        return this.allowedMethods
+            .stream()
+            .map(HttpMethod::toString)
+            .collect(Collectors.toList());
     }
 }

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/UnauthenticatedRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/UnauthenticatedRoute.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.api.authentication;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public enum UnauthenticatedRoute {
+
+    AUTH("/auth", "GET", "POST"),
+    AUTH_TOKENS("/auth/tokens", "POST"),
+    AUTH_CALLBACK("/auth/callback", "GET"),
+    BOOTSTRAP("/bootstrap", "GET"),
+    BOOTSTRAP_EXTERNAL("/bootstrap/external", "GET"),
+    HEALTH("/health", "GET"),
+    ;
+
+    private String route;
+    private List<String> allowedMethods;
+
+    private UnauthenticatedRoute(String route, String... allowedMethods) {
+        this.route = route;
+        this.allowedMethods = Arrays.asList(allowedMethods);
+    }
+
+    public static Map<String, List<String>> getRoutesAsMap() {
+        Map<String, List<String>> routeMap = new HashMap<>();
+        for (UnauthenticatedRoute route : values()) {
+            routeMap.put(route.toString(), route.getAllowedMethods());
+        }
+        return routeMap;
+    }
+
+    @Override
+    public String toString() {
+        return this.route;
+    }
+
+    public List<String> getAllowedMethods() {
+        return this.allowedMethods;
+    }
+}

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensRoute.java
@@ -7,7 +7,9 @@ package dev.galasa.framework.api.authentication.internal.routes;
 
 import static dev.galasa.framework.api.common.ServletErrorMessage.*;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.net.http.HttpResponse;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -17,12 +19,18 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.coreos.dex.api.DexOuterClass.Client;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
+import dev.galasa.framework.api.authentication.IOidcProvider;
+import dev.galasa.framework.api.authentication.JwtWrapper;
+import dev.galasa.framework.api.authentication.internal.DexGrpcClient;
+import dev.galasa.framework.api.beans.TokenPayload;
 import dev.galasa.framework.api.common.AuthToken;
 import dev.galasa.framework.api.common.BaseRoute;
+import dev.galasa.framework.api.common.Environment;
 import dev.galasa.framework.api.common.InternalServletException;
 import dev.galasa.framework.api.common.QueryParameters;
 import dev.galasa.framework.api.common.ResponseBuilder;
@@ -30,16 +38,32 @@ import dev.galasa.framework.api.common.ServletError;
 import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.auth.IAuthStoreService;
 import dev.galasa.framework.spi.auth.IAuthToken;
+import dev.galasa.framework.spi.auth.User;
 import dev.galasa.framework.spi.auth.AuthStoreException;
 
 public class AuthTokensRoute extends BaseRoute {
 
     private IAuthStoreService authStoreService;
+    private IOidcProvider oidcProvider;
+    private DexGrpcClient dexGrpcClient;
+    private Environment env;
 
-    public AuthTokensRoute(ResponseBuilder responseBuilder, IAuthStoreService authStoreService) {
+    private static final String ID_TOKEN_KEY      = "id_token";
+    private static final String REFRESH_TOKEN_KEY = "refresh_token";
+
+    public AuthTokensRoute(
+        ResponseBuilder responseBuilder,
+        IOidcProvider oidcProvider,
+        DexGrpcClient dexGrpcClient,
+        IAuthStoreService authStoreService,
+        Environment env
+    ) {
         // Regex to match /auth/tokens only
         super(responseBuilder, "\\/tokens\\/?");
+        this.oidcProvider = oidcProvider;
+        this.dexGrpcClient = dexGrpcClient;
         this.authStoreService = authStoreService;
+        this.env = env;
     }
 
     /**
@@ -77,6 +101,60 @@ public class AuthTokensRoute extends BaseRoute {
     }
 
     /**
+     * Sending a POST request to /auth/tokens issues a new bearer token using a
+     * client ID, client secret, and refresh token.
+     */
+    @Override
+    public HttpServletResponse handlePostRequest(String pathInfo, QueryParameters queryParameters,
+            HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException, FrameworkException {
+
+        logger.info("AuthRoute: handlePostRequest() entered.");
+
+        // Check that the request body contains the required payload
+        TokenPayload requestPayload = getRequestBodyAsJson(request);
+        if (requestPayload == null || !isTokenPayloadValid(requestPayload)) {
+            ServletError error = new ServletError(GAL5400_BAD_REQUEST, request.getServletPath());
+            throw new InternalServletException(error, HttpServletResponse.SC_BAD_REQUEST);
+        }
+
+        JsonObject responseJson = new JsonObject();
+        try {
+            // Send a POST request to Dex's /token endpoint
+            JsonObject tokenResponseBodyJson = sendTokenPost(request, requestPayload);
+
+            // Return the JWT and refresh token as the servlet's response
+            if (tokenResponseBodyJson != null && tokenResponseBodyJson.has(ID_TOKEN_KEY) && tokenResponseBodyJson.has(REFRESH_TOKEN_KEY)) {
+                logger.info("Bearer and refresh tokens successfully received from issuer.");
+
+                String jwt = tokenResponseBodyJson.get(ID_TOKEN_KEY).getAsString();
+                responseJson.addProperty("jwt", jwt);
+                responseJson.addProperty(REFRESH_TOKEN_KEY, tokenResponseBodyJson.get(REFRESH_TOKEN_KEY).getAsString());
+
+                // If we're refreshing an existing token, then we don't want to create a new entry in the tokens database.
+                // We only want to store tokens in the tokens database when they are created.
+                String tokenDescription = requestPayload.getDescription();
+                if (requestPayload.getRefreshToken() == null && tokenDescription != null) {
+                    addTokenToAuthStore(requestPayload.getClientId(), jwt, tokenDescription);
+                }
+
+            } else {
+                logger.info("Unable to get new bearer and refresh tokens from issuer.");
+
+                ServletError error = new ServletError(GAL5055_FAILED_TO_GET_TOKENS_FROM_ISSUER);
+                throw new InternalServletException(error, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            }
+
+        } catch (InterruptedException e) {
+            logger.error("POST request to the OpenID Connect provider's token endpoint was interrupted.", e);
+
+            ServletError error = new ServletError(GAL5000_GENERIC_API_ERROR);
+            throw new InternalServletException(error, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e);
+        }
+
+        return getResponseBuilder().buildResponse(response, "application/json", gson.toJson(responseJson), HttpServletResponse.SC_OK);
+    }
+
+    /**
      * Converts a list of authentication tokens into a JSON string
      *
      * @param tokens the tokens to convert
@@ -93,5 +171,85 @@ public class AuthTokensRoute extends BaseRoute {
         tokensObj.add("tokens", tokensArray);
 
         return gson.toJson(tokensObj);
+    }
+
+    /**
+     * Gets a given HTTP request's body as a JSON object.
+     */
+    private TokenPayload getRequestBodyAsJson(HttpServletRequest request) throws IOException {
+        StringBuilder sbRequestBody = new StringBuilder();
+        BufferedReader bodyReader = request.getReader();
+
+        String line = bodyReader.readLine();
+        while (line != null) {
+            sbRequestBody.append(line);
+            line = bodyReader.readLine();
+        }
+
+        return gson.fromJson(sbRequestBody.toString(), TokenPayload.class);
+    }
+
+    /**
+     * Sends a POST request to the JWT issuer's /token endpoint and returns the
+     * response's body as a JSON object.
+     *
+     * @param requestBodyJson the request payload containing the required parameters
+     *                        for the /token endpoint
+     */
+    private JsonObject sendTokenPost(HttpServletRequest request, TokenPayload requestBodyJson)
+            throws IOException, InterruptedException, InternalServletException {
+        String refreshToken = requestBodyJson.getRefreshToken();
+        String clientId = requestBodyJson.getClientId();
+        Client dexClient = dexGrpcClient.getClient(clientId);
+
+        JsonObject response = null;
+        if (dexClient != null) {
+            String clientSecret = dexClient.getSecret();
+
+            // Refresh tokens and authorization codes can be used in exchange for JWTs.
+            // At this point, we either have a refresh token or an authorization code,
+            // so perform the relevant POST request
+            HttpResponse<String> tokenResponse = null;
+            if (refreshToken != null) {
+                tokenResponse = oidcProvider.sendTokenPost(clientId, clientSecret, refreshToken);
+            } else {
+                tokenResponse = oidcProvider.sendTokenPost(clientId, clientSecret, requestBodyJson.getCode(), AuthCallbackRoute.getExternalAuthCallbackUrl());
+            }
+
+            if (tokenResponse != null) {
+                response = gson.fromJson(tokenResponse.body(), JsonObject.class);
+            }
+        }
+        return response;
+    }
+
+    /**
+     * Checks if the POST request payload to pass to Dex's /token endpoint contains a client ID and either
+     * a refresh token or an authorization code.
+     */
+    private boolean isTokenPayloadValid(TokenPayload requestPayload) {
+        return (requestPayload.getClientId() != null) && (requestPayload.getRefreshToken() != null || requestPayload.getCode() != null);
+    }
+
+    /**
+     * Records a new Galasa token in the auth store.
+     *
+     * @param clientId the ID of the client that a user has authenticated with
+     * @param jwt the JWT that was returned after authenticating with the client, identifying the user
+     * @param description the description of the Galasa token provided by the user
+     * @throws InternalServletException
+     */
+    private void addTokenToAuthStore(String clientId, String jwt, String description) throws InternalServletException {
+        logger.info("Storing new token record in the auth store");
+        JwtWrapper jwtWrapper = new JwtWrapper(jwt, env);
+        User user = new User(jwtWrapper.getUsername());
+
+        try {
+            authStoreService.storeToken(clientId, description, user);
+        } catch (AuthStoreException e) {
+            ServletError error = new ServletError(GAL5056_FAILED_TO_STORE_TOKEN_IN_AUTH_STORE, description);
+            throw new InternalServletException(error, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e);
+        }
+        logger.info("Stored token record in the auth store OK");
     }
 }

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/JwtAuthFilterTest.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/JwtAuthFilterTest.java
@@ -193,6 +193,29 @@ public class JwtAuthFilterTest extends BaseServletTest {
     }
 
     @Test
+    public void testGetRequestWithoutJwtToAuthTokensIsBlockedByFilter() throws Exception {
+        // Given...
+        MockEnvironment mockEnv = new MockEnvironment();
+        String mockIssuerUrl = "http://dummy-issuer/dex";
+        mockEnv.setenv(EnvironmentVariables.GALASA_DEX_ISSUER, mockIssuerUrl);
+
+        MockOidcProvider mockOidcProvider = new MockOidcProvider();
+
+        JwtAuthFilter authFilter = new MockJwtAuthFilter(mockEnv, mockOidcProvider);
+        HttpServletRequest mockRequest = new MockHttpServletRequest("/auth/tokens", "", "GET");
+        HttpServletResponse mockResponse = new MockHttpServletResponse();
+
+        FilterChain mockChain = new MockFilterChain();
+
+        // When...
+        authFilter.init(null);
+        authFilter.doFilter(mockRequest, mockResponse, mockChain);
+
+        // Then...
+        assertThat(mockResponse.getStatus()).isEqualTo(401);
+    }
+
+    @Test
     public void testRequestToProtectedAuthRouteIsProcessedInFilter() throws Exception {
         // Given...
         MockEnvironment mockEnv = new MockEnvironment();

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/JwtAuthFilterTest.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/JwtAuthFilterTest.java
@@ -169,6 +169,28 @@ public class JwtAuthFilterTest extends BaseServletTest {
         assertThat(mockResponse.getStatus()).isEqualTo(200);
     }
 
+    @Test
+    public void testPostRequestToAuthTokensPassesThroughFilterAndReturnsOk() throws Exception {
+        // Given...
+        MockEnvironment mockEnv = new MockEnvironment();
+        String mockIssuerUrl = "http://dummy-issuer/dex";
+        mockEnv.setenv(EnvironmentVariables.GALASA_DEX_ISSUER, mockIssuerUrl);
+
+        MockOidcProvider mockOidcProvider = new MockOidcProvider();
+
+        JwtAuthFilter authFilter = new MockJwtAuthFilter(mockEnv, mockOidcProvider);
+        HttpServletRequest mockRequest = new MockHttpServletRequest("/auth/tokens", "", "POST");
+        HttpServletResponse mockResponse = new MockHttpServletResponse();
+
+        FilterChain mockChain = new MockFilterChain();
+
+        // When...
+        authFilter.init(null);
+        authFilter.doFilter(mockRequest, mockResponse, mockChain);
+
+        // Then...
+        assertThat(mockResponse.getStatus()).isEqualTo(200);
+    }
 
     @Test
     public void testRequestToProtectedAuthRouteIsProcessedInFilter() throws Exception {

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthTokensRouteTest.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthTokensRouteTest.java
@@ -7,8 +7,8 @@ package dev.galasa.framework.api.authentication.routes;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.net.http.HttpResponse;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -17,24 +17,66 @@ import javax.servlet.ServletOutputStream;
 
 import org.junit.Test;
 
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
+import dev.galasa.framework.api.authentication.internal.DexGrpcClient;
 import dev.galasa.framework.api.authentication.internal.routes.AuthTokensRoute;
 import dev.galasa.framework.api.authentication.mocks.MockAuthenticationServlet;
+import dev.galasa.framework.api.authentication.mocks.MockDexGrpcClient;
+import dev.galasa.framework.api.authentication.mocks.MockOidcProvider;
 import dev.galasa.framework.api.common.AuthToken;
 import dev.galasa.framework.api.common.BaseServletTest;
 import dev.galasa.framework.api.common.mocks.MockHttpServletRequest;
 import dev.galasa.framework.api.common.mocks.MockHttpServletResponse;
+import dev.galasa.framework.api.common.mocks.MockTimeService;
 import dev.galasa.framework.api.common.mocks.MockAuthStoreService;
 import dev.galasa.framework.spi.auth.IAuthToken;
 import dev.galasa.framework.spi.auth.User;
 import dev.galasa.framework.spi.utils.GalasaGson;
 import dev.galasa.framework.api.common.mocks.MockFramework;
+import dev.galasa.framework.api.common.mocks.MockHttpResponse;
 
 public class AuthTokensRouteTest extends BaseServletTest {
 
     private static final GalasaGson gson = new GalasaGson();
+
+    private String buildRequestPayload(String clientId, String refreshToken, String authCode) {
+        return buildRequestPayload(clientId, refreshToken, authCode, null);
+    }
+
+    private String buildRequestPayload(String clientId, String refreshToken, String authCode, String description) {
+        JsonObject requestPayload = new JsonObject();
+        if (clientId != null) {
+            requestPayload.addProperty("client_id", clientId);
+        }
+
+        if (refreshToken != null) {
+            requestPayload.addProperty("refresh_token", refreshToken);
+        }
+
+        if (authCode != null) {
+            requestPayload.addProperty("code", authCode);
+        }
+
+        if (description != null) {
+            requestPayload.addProperty("description", description);
+        }
+
+        String requestPayloadStr = gson.toJson(requestPayload);
+        return requestPayloadStr;
+    }
+
+    private String buildTokenResponse(String jwt, String refreshToken) {
+        JsonObject responseJson = new JsonObject();
+
+        responseJson.addProperty("id_token", jwt);
+        responseJson.addProperty("refresh_token", refreshToken);
+
+        return gson.toJson(responseJson);
+    }
 
     /**
      * Compares a list of expected authentication tokens against a JSON array
@@ -58,8 +100,7 @@ public class AuthTokensRouteTest extends BaseServletTest {
     @Test
     public void testAuthTokensRouteRegexMatchesOnlyTokens(){
         //Given...
-        MockAuthStoreService authStoreService = new MockAuthStoreService(new ArrayList<>());
-        String tokensRoutePath = new AuthTokensRoute(null, authStoreService).getPath();
+        String tokensRoutePath = new AuthTokensRoute(null, null, null, null, null).getPath();
 
         //When...
         Pattern tokensRoutePattern = Pattern.compile(tokensRoutePath);
@@ -183,4 +224,340 @@ public class AuthTokensRouteTest extends BaseServletTest {
         assertThat(servletResponse.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
         checkOrderMatches(expectedTokenOrder, getJsonArrayFromJson(output, "tokens"));
     }
+
+    @Test
+    public void testAuthPostRequestWithEmptyRequestPayloadReturnsBadRequestError() throws Exception {
+        // Given...
+        MockAuthenticationServlet servlet = new MockAuthenticationServlet();
+
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest(null, "", "POST");
+        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
+        ServletOutputStream outStream = servletResponse.getOutputStream();
+
+        // When...
+        servlet.init();
+        servlet.doPost(mockRequest, servletResponse);
+
+        // Then...
+        // Expecting this json:
+        // {
+        // "error_code" : 5400,
+        // "error_message" : "GAL5400E: Error occured when trying to execute request
+        // '/auth'. Please check your request parameters or report the problem to your
+        // Galasa Ecosystem owner."
+        // }
+        assertThat(servletResponse.getStatus()).isEqualTo(400);
+        checkErrorStructure(outStream.toString(), 5400, "GAL5400E");
+    }
+
+    @Test
+    public void testAuthPostRequestWithInvalidRequestPayloadReturnsBadRequestError() throws Exception {
+        // Given...
+        MockAuthenticationServlet servlet = new MockAuthenticationServlet();
+
+        // Payload with a missing "refresh_token" field
+        String payload = buildRequestPayload("dummy-id", null, null);
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest("/tokens", payload, "POST");
+        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
+        ServletOutputStream outStream = servletResponse.getOutputStream();
+
+        // When...
+        servlet.init();
+        servlet.doPost(mockRequest, servletResponse);
+
+        // Then...
+        // Expecting this json:
+        // {
+        // "error_code" : 5400,
+        // "error_message" : "GAL5400E: Error occured when trying to execute request
+        // '/auth'. Please check your request parameters or report the problem to your
+        // Galasa Ecosystem owner."
+        // }
+        assertThat(servletResponse.getStatus()).isEqualTo(400);
+        checkErrorStructure(outStream.toString(), 5400, "GAL5400E");
+    }
+
+    @Test
+    public void testAuthPostRequestWithValidRefreshTokenRequestPayloadReturnsJWT() throws Exception {
+        // Given...
+        String dummyJwt = "this-is-a-jwt";
+        String dummyRefreshToken = "this-is-a-refresh-token";
+        String mockResponseJson = buildTokenResponse(dummyJwt, dummyRefreshToken);
+
+        HttpResponse<String> mockResponse = new MockHttpResponse<String>(mockResponseJson);
+
+        String clientId = "dummy-id";
+        String clientSecret = "asecret";
+        String refreshToken = "here-is-a-token";
+
+        MockOidcProvider mockOidcProvider = new MockOidcProvider(mockResponse);
+
+        DexGrpcClient mockDexGrpcClient = new MockDexGrpcClient("http://issuer", clientId, clientSecret, "http://callback");
+
+        MockTimeService mockTimeService = new MockTimeService(Instant.now());
+        MockAuthStoreService mockAuthStoreService = new MockAuthStoreService(mockTimeService);
+        MockFramework mockFramework = new MockFramework(mockAuthStoreService);
+
+        MockAuthenticationServlet servlet = new MockAuthenticationServlet(mockOidcProvider, mockDexGrpcClient, mockFramework);
+
+        String payload = buildRequestPayload(clientId, refreshToken, null);
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest("/tokens", payload, "POST");
+        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
+        ServletOutputStream outStream = servletResponse.getOutputStream();
+
+        // When...
+        servlet.init();
+        servlet.doPost(mockRequest, servletResponse);
+
+        // Then...
+        // Expecting this json:
+        // {
+        //   "jwt": "this-is-a-jwt",
+        //   "refresh_token": "this-is-a-refresh-token",
+        // }
+        JsonObject expectedJsonObject = new JsonObject();
+        expectedJsonObject.addProperty("jwt", dummyJwt);
+        expectedJsonObject.addProperty("refresh_token", dummyRefreshToken);
+
+        assertThat(servletResponse.getStatus()).isEqualTo(200);
+        assertThat(outStream.toString()).isEqualTo(gson.toJson(expectedJsonObject));
+        assertThat(mockAuthStoreService.getTokens()).isEmpty();
+    }
+
+    @Test
+    public void testAuthPostRequestWithDescriptionInRequestReturnsJWTAndStoresTokenInAuthStore() throws Exception {
+        // Given...
+        String tokenDescription = "my new galasactl token for my macOS laptop";
+        String userName = "JohnDoe";
+
+        Algorithm mockJwtSigningAlgorithm = Algorithm.HMAC256("dummysecret");
+        String dummyJwt = JWT.create()
+            .withSubject("validUserId")
+            .withIssuedAt(Instant.EPOCH)
+            .withClaim("name", userName)
+            .sign(mockJwtSigningAlgorithm);
+
+        String dummyRefreshToken = "this-is-a-refresh-token";
+        String mockResponseJson = buildTokenResponse(dummyJwt, dummyRefreshToken);
+
+        HttpResponse<String> mockResponse = new MockHttpResponse<String>(mockResponseJson);
+
+        String clientId = "dummy-id";
+        String clientSecret = "asecret";
+        String authCode = "thisisacode";
+
+        String callbackUri = "http://api.host/auth/callback";
+        String issuerUrl = "http://dummy.host";
+
+        MockOidcProvider mockOidcProvider = new MockOidcProvider(mockResponse);
+        DexGrpcClient mockDexGrpcClient = new MockDexGrpcClient(issuerUrl, clientId, clientSecret, callbackUri);
+
+        Instant tokenCreationTime = Instant.now();
+        MockTimeService mockTimeService = new MockTimeService(tokenCreationTime);
+        MockAuthStoreService mockAuthStoreService = new MockAuthStoreService(mockTimeService);
+        MockFramework mockFramework = new MockFramework(mockAuthStoreService);
+
+        MockAuthenticationServlet servlet = new MockAuthenticationServlet(mockOidcProvider, mockDexGrpcClient, mockFramework);
+
+        String payload = buildRequestPayload(clientId, null, authCode, tokenDescription);
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest("/tokens", payload, "POST");
+        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
+        ServletOutputStream outStream = servletResponse.getOutputStream();
+
+        // When...
+        servlet.init();
+        servlet.doPost(mockRequest, servletResponse);
+
+        // Then...
+        // Expecting this json:
+        // {
+        //   "jwt": "ey....",
+        //   "refresh_token": "this-is-a-refresh-token",
+        // }
+        JsonObject expectedJsonObject = new JsonObject();
+        expectedJsonObject.addProperty("jwt", dummyJwt);
+        expectedJsonObject.addProperty("refresh_token", dummyRefreshToken);
+
+        assertThat(servletResponse.getStatus()).isEqualTo(200);
+        assertThat(outStream.toString()).isEqualTo(gson.toJson(expectedJsonObject));
+
+        // A record of the newly-created token should have been added to the auth store
+        List<IAuthToken> tokens = mockAuthStoreService.getTokens();
+        assertThat(tokens).hasSize(1);
+
+        IAuthToken newToken = tokens.get(0);
+        assertThat(newToken.getDescription()).isEqualTo(tokenDescription);
+        assertThat(newToken.getCreationTime()).isEqualTo(tokenCreationTime);
+        assertThat(newToken.getOwner().getLoginId()).isEqualTo(userName);
+    }
+
+    @Test
+    public void testAuthPostRequestWithValidAuthCodeRequestPayloadReturnsJWT() throws Exception {
+        // Given...
+        String dummyJwt = "this-is-a-jwt";
+        String dummyRefreshToken = "this-is-a-refresh-token";
+        String mockResponseJson = buildTokenResponse(dummyJwt, dummyRefreshToken);
+
+        HttpResponse<String> mockResponse = new MockHttpResponse<String>(mockResponseJson);
+
+        String clientId = "dummy-id";
+        String clientSecret = "asecret";
+        String authCode = "thisisacode";
+
+        String callbackUri = "http://api.host/auth/callback";
+        String issuerUrl = "http://dummy.host";
+
+        MockOidcProvider mockOidcProvider = new MockOidcProvider(mockResponse);
+
+        DexGrpcClient mockDexGrpcClient = new MockDexGrpcClient(issuerUrl, clientId, clientSecret, callbackUri);
+
+        Instant tokenCreationTime = Instant.now();
+        MockTimeService mockTimeService = new MockTimeService(tokenCreationTime);
+        MockAuthStoreService mockAuthStoreService = new MockAuthStoreService(mockTimeService);
+        MockFramework mockFramework = new MockFramework(mockAuthStoreService);
+
+        MockAuthenticationServlet servlet = new MockAuthenticationServlet(mockOidcProvider, mockDexGrpcClient, mockFramework);
+
+        String payload = buildRequestPayload(clientId, null, authCode);
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest("/tokens", payload, "POST");
+        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
+        ServletOutputStream outStream = servletResponse.getOutputStream();
+
+        // When...
+        servlet.init();
+        servlet.doPost(mockRequest, servletResponse);
+
+        // Then...
+        // Expecting this json:
+        // {
+        //   "jwt": "this-is-a-jwt",
+        //   "refresh_token": "this-is-a-refresh-token",
+        // }
+        JsonObject expectedJsonObject = new JsonObject();
+        expectedJsonObject.addProperty("jwt", dummyJwt);
+        expectedJsonObject.addProperty("refresh_token", dummyRefreshToken);
+
+        assertThat(servletResponse.getStatus()).isEqualTo(200);
+        assertThat(outStream.toString()).isEqualTo(gson.toJson(expectedJsonObject));
+
+        // No new token records should have been added to the auth store since no token description was provided
+        assertThat(mockAuthStoreService.getTokens()).isEmpty();
+    }
+
+    @Test
+    public void testAuthPostRequestWithFailingAuthStoreReturnsError() throws Exception {
+        // Given...
+        String tokenDescription = "my new galasactl token for my macOS laptop";
+        String userName = "JohnDoe";
+
+        Algorithm mockJwtSigningAlgorithm = Algorithm.HMAC256("dummysecret");
+        String dummyJwt = JWT.create()
+            .withSubject("validUserId")
+            .withIssuedAt(Instant.EPOCH)
+            .withClaim("name", userName)
+            .sign(mockJwtSigningAlgorithm);
+
+        String dummyRefreshToken = "this-is-a-refresh-token";
+        String mockResponseJson = buildTokenResponse(dummyJwt, dummyRefreshToken);
+
+        HttpResponse<String> mockResponse = new MockHttpResponse<String>(mockResponseJson);
+
+        String clientId = "dummy-id";
+        String clientSecret = "asecret";
+        String authCode = "thisisacode";
+
+        String callbackUri = "http://api.host/auth/callback";
+        String issuerUrl = "http://dummy.host";
+
+        MockOidcProvider mockOidcProvider = new MockOidcProvider(mockResponse);
+
+        DexGrpcClient mockDexGrpcClient = new MockDexGrpcClient(issuerUrl, clientId, clientSecret, callbackUri);
+
+        Instant tokenCreationTime = Instant.now();
+        MockTimeService mockTimeService = new MockTimeService(tokenCreationTime);
+        MockAuthStoreService mockAuthStoreService = new MockAuthStoreService(mockTimeService);
+        mockAuthStoreService.setThrowException(true);
+
+        MockFramework mockFramework = new MockFramework(mockAuthStoreService);
+
+        MockAuthenticationServlet servlet = new MockAuthenticationServlet(mockOidcProvider, mockDexGrpcClient, mockFramework);
+
+        String payload = buildRequestPayload(clientId, null, authCode, tokenDescription);
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest("/tokens", payload, "POST");
+        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
+        ServletOutputStream outStream = servletResponse.getOutputStream();
+
+        // When...
+        servlet.init();
+        servlet.doPost(mockRequest, servletResponse);
+
+        // Then...
+        assertThat(servletResponse.getStatus()).isEqualTo(500);
+        checkErrorStructure(outStream.toString(), 5056, "GAL5056E", "Internal server error occurred when storing the new Galasa token with description", tokenDescription);
+    }
+
+    @Test
+    public void testAuthPostRequestThrowsUnexpectedErrorReturnsServerError() throws Exception {
+        // Given...
+        MockOidcProvider mockOidcProvider = new MockOidcProvider();
+        mockOidcProvider.setThrowException(true);
+
+        String clientId = "myclient";
+        MockDexGrpcClient mockDexGrpcClient = new MockDexGrpcClient("http://issuer", clientId, "secret", "http://callback");
+
+        MockAuthenticationServlet servlet = new MockAuthenticationServlet(mockOidcProvider, mockDexGrpcClient);
+
+        String payload = buildRequestPayload("dummy-id", "here-is-a-token", null);
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest("/tokens", payload, "POST");
+        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
+        ServletOutputStream outStream = servletResponse.getOutputStream();
+
+        // When...
+        servlet.init();
+        servlet.doPost(mockRequest, servletResponse);
+
+        // Then...
+        // Expecting this json:
+        // {
+        // "error_code" : 5000,
+        // "error_message" : "GAL5000E: Error occured when trying to access the
+        // endpoint. Report the problem to your Galasa Ecosystem owner."
+        // }
+        assertThat(servletResponse.getStatus()).isEqualTo(500);
+        checkErrorStructure(outStream.toString(), 5000, "GAL5000E", "Error occured when trying to access the endpoint");
+    }
+
+    @Test
+    public void testAuthPostRequestWithTokenErrorResponseReturnsServerError() throws Exception {
+        // Given...
+        JsonObject dummyErrorJson = new JsonObject();
+        dummyErrorJson.addProperty("error", "oh no, something went wrong!");
+        HttpResponse<String> mockResponse = new MockHttpResponse<String>(gson.toJson(dummyErrorJson));
+
+        MockOidcProvider mockOidcProvider = new MockOidcProvider(mockResponse);
+
+        String clientId = "myclient";
+        MockDexGrpcClient mockDexGrpcClient = new MockDexGrpcClient("http://issuer", clientId, "secret", "http://callback");
+
+        MockAuthenticationServlet servlet = new MockAuthenticationServlet(mockOidcProvider, mockDexGrpcClient);
+
+        String payload = buildRequestPayload("dummy-id", "here-is-a-token", null);
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest("/tokens", payload, "POST");
+        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
+        ServletOutputStream outStream = servletResponse.getOutputStream();
+
+        // When...
+        servlet.init();
+        servlet.doPost(mockRequest, servletResponse);
+
+        // Then...
+        // Expecting this json:
+        // {
+        //   "error_code": 5055,
+        //   "error_message": "GAL5055E: ..."
+        // }
+        assertThat(servletResponse.getStatus()).isEqualTo(500);
+        checkErrorStructure(outStream.toString(), 5055, "GAL5055E", "Failed to get a JWT and a refresh token from the Galasa Dex server", "The Dex server did not respond with a JWT and refresh token");
+    }
+
 }

--- a/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/HttpMethod.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/HttpMethod.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.api.common;
+
+/**
+ * A simple enum consisting of all possible HTTP request methods.
+ */
+public enum HttpMethod {
+    GET,
+    POST,
+    PUT,
+    DELETE,
+    HEAD,
+    PATCH,
+    TRACE,
+    OPTIONS,
+    CONNECT,
+}

--- a/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -81,8 +81,11 @@ paths:
                     error_code: 5000
                     error_message: "GAL5000E: Error occured when trying to access the endpoint. Report the problem to your Galasa Ecosystem owner."
                   summary: An error occured when trying to access the endpoint
+    
+    # POST /auth is deprecated in favour of POST /auth/tokens and will be removed in a future release
     post:
       operationId: postAuthenticate
+      deprecated: true
       summary: Provide a refresh token and get back a JWT for authenticating to a Galasa ecosystem.
       tags:
       - Authentication API
@@ -249,7 +252,50 @@ paths:
                     error_code: 5000
                     error_message: "GAL5000E: Error occured when trying to access the endpoint. Report the problem to your Galasa Ecosystem owner."
                   summary: An error occured when trying to access the endpoint
-  /auth/tokens/{tokenId}:    
+    post:
+      operationId: createToken
+      summary: Provide a refresh token and get back a JWT for authenticating to a Galasa ecosystem.
+      tags:
+      - Authentication API
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthProperties'
+      responses:
+        '200':
+          description: Returns a JSON Object containing a JWT and refresh token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+              examples:
+                missingparametererror:
+                  value:
+                    error_code: 5400
+                    error_message: "E: Error occured when trying to execute request '/auth/tokens'. Please check your request parameters or report the problem to your Galasa Ecosystem owner."
+                  summary: One or more required body properties are missing
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsonError'
+              examples:
+                genericerror:
+                  value:
+                    error_code: 5000
+                    error_message: "GAL5000E: Error occured when trying to access the endpoint. Report the problem to your Galasa Ecosystem owner."
+                  summary: An error occured when trying to access the endpoint
+  /auth/tokens/{tokenId}:
     delete:
       operationId: deleteToken
       summary: Deletes a token which is used for authenticating with the Galasa API server.

--- a/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -128,6 +128,8 @@ paths:
                     error_message: "GAL5000E: Error occured when trying to access the endpoint. Report the problem to your Galasa Ecosystem owner."
                   summary: An error occured when trying to access the endpoint
   /auth/callback:
+    parameters:
+      - $ref: '#/components/parameters/ClientApiVersion'
     get:
       operationId: getAuthenticateCallback
       summary: Callback endpoint used as part of an OAuth 2.0 authorization code flow, redirects to a callback URL with an authorization code as a query parameter.
@@ -168,6 +170,8 @@ paths:
                     error_message: "E: Error occured when trying to execute request '/auth/callback'. Please check your request parameters or report the problem to your Galasa Ecosystem owner."
                   summary: One or more required query parameters are missing
   /auth/clients:
+    parameters:
+      - $ref: '#/components/parameters/ClientApiVersion'
     post:
       operationId: postClients
       summary: Create a new Dex client to authenticate with.
@@ -210,6 +214,8 @@ paths:
                     error_message: "GAL5000E: Error occured when trying to access the endpoint. Report the problem to your Galasa Ecosystem owner."
                   summary: An error occured when trying to access the endpoint
   /auth/tokens:
+    parameters:
+      - $ref: '#/components/parameters/ClientApiVersion'
     get:
       operationId: getTokens
       summary: Get a list of tokens used for authenticating with the Galasa API server.
@@ -296,6 +302,8 @@ paths:
                     error_message: "GAL5000E: Error occured when trying to access the endpoint. Report the problem to your Galasa Ecosystem owner."
                   summary: An error occured when trying to access the endpoint
   /auth/tokens/{tokenId}:
+    parameters:
+      - $ref: '#/components/parameters/ClientApiVersion'
     delete:
       operationId: deleteToken
       summary: Deletes a token which is used for authenticating with the Galasa API server.


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1865

## Changes
- Added JWT and auth token creation code from `POST /auth` into `POST /auth/tokens`
  - The existing code for `POST /auth` will be removed in a future release (see https://github.com/galasa-dev/projectmanagement/issues/1873)
- Added `POST /auth/tokens` through JWT filter to maintain existing functionality
  - Changed the unauthenticated routes list into an enum
- Updated the OpenAPI specification, marking `POST /auth` as deprecated.