### PR TITLE
Validate OpenID Connect endpoints on discovery

### DIFF
--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/AuthenticationServlet.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/AuthenticationServlet.java
@@ -74,8 +74,9 @@ public class AuthenticationServlet extends BaseServlet {
     /**
      * Initialises the OpenID Connect Provider and Dex gRPC client fields to allow
      * the authentication servlet to communicate with Dex.
+     * @throws ServletException if there was an issue contacting Dex
      */
-    protected void initialiseDexClients(String dexIssuerUrl, String dexGrpcHostname, String externalWebUiUrl) {
+    protected void initialiseDexClients(String dexIssuerUrl, String dexGrpcHostname, String externalWebUiUrl) throws ServletException {
         this.oidcProvider = new OidcProvider(dexIssuerUrl, HttpClient.newHttpClient());
         this.dexGrpcClient = new DexGrpcClient(dexGrpcHostname, externalWebUiUrl);
     }

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/OidcProvider.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/OidcProvider.java
@@ -99,7 +99,8 @@ public class OidcProvider implements IOidcProvider {
         } catch (IOException | InterruptedException | JsonSyntaxException e) {
             logger.error("Unable to obtain issuer's OpenID configuration, using defaults");
         } catch (URISyntaxException e) {
-            ServletError error = new ServletError(GAL5059_INVALID_ISSUER_URI_PROVIDED, issuerUrl);
+            logger.error("Invalid Galasa Dex URL provided '" + issuerUrl + "'", e);
+            ServletError error = new ServletError(GAL5059_INVALID_ISSUER_URI_PROVIDED);
             throw new ServletException(error.getMessage(), e);
         }
 
@@ -384,13 +385,15 @@ public class OidcProvider implements IOidcProvider {
             URI uri = new URI(urlToValidate);
             if (!uri.getScheme().equals(issuerUrl.getScheme())
                 || !uri.getHost().equals(issuerUrl.getHost())) {
-                ServletError error = new ServletError(GAL5061_MISMATCHED_OIDC_URI_RECEIVED, urlToValidate, issuerUrl.toString());
+                logger.error("URL '" + urlToValidate + "' does not match issuer scheme or hostname '" + issuerUrl + "'");
+                ServletError error = new ServletError(GAL5061_MISMATCHED_OIDC_URI_RECEIVED);
                 throw new ServletException(error.getMessage());
             }
 
             return uri.toString();
         } catch (URISyntaxException e) {
-            ServletError error = new ServletError(GAL5060_INVALID_OIDC_URI_RECEIVED, urlToValidate);
+            logger.error("Invalid URL received '" + urlToValidate + "'", e);
+            ServletError error = new ServletError(GAL5060_INVALID_OIDC_URI_RECEIVED);
             throw new ServletException(error.getMessage(), e);
         }
     }

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/OidcProvider.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/OidcProvider.java
@@ -99,9 +99,9 @@ public class OidcProvider implements IOidcProvider {
         } catch (IOException | InterruptedException | JsonSyntaxException e) {
             logger.error("Unable to obtain issuer's OpenID configuration, using defaults");
         } catch (URISyntaxException e) {
-            logger.error("Invalid Galasa Dex URL provided '" + issuerUrl + "'", e);
+            logger.error("Invalid Galasa Dex URL provided '" + issuerUrl + "'");
             ServletError error = new ServletError(GAL5059_INVALID_ISSUER_URI_PROVIDED);
-            throw new ServletException(error.getMessage(), e);
+            throw new ServletException(error.getMessage());
         }
 
         logger.info("Authorization endpoint is: " + this.authorizationEndpoint);
@@ -392,9 +392,9 @@ public class OidcProvider implements IOidcProvider {
 
             return uri.toString();
         } catch (URISyntaxException e) {
-            logger.error("Invalid URL received '" + urlToValidate + "'", e);
+            logger.error("Invalid URL received '" + urlToValidate + "'");
             ServletError error = new ServletError(GAL5060_INVALID_OIDC_URI_RECEIVED);
-            throw new ServletException(error.getMessage(), e);
+            throw new ServletException(error.getMessage());
         }
     }
 }

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/OidcProvider.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/OidcProvider.java
@@ -8,6 +8,7 @@ package dev.galasa.framework.api.authentication.internal;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpHeaders;
@@ -27,6 +28,7 @@ import java.util.Base64;
 import java.util.Base64.Decoder;
 import java.util.Optional;
 
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
@@ -46,9 +48,12 @@ import com.google.gson.JsonSyntaxException;
 
 import dev.galasa.framework.api.authentication.IOidcProvider;
 import dev.galasa.framework.api.authentication.internal.beans.JsonWebKey;
+import dev.galasa.framework.api.common.ServletError;
 import dev.galasa.framework.spi.utils.GalasaGson;
 import dev.galasa.framework.spi.utils.ITimeService;
 import dev.galasa.framework.spi.utils.SystemTimeService;
+
+import static dev.galasa.framework.api.common.ServletErrorMessage.*;
 
 /**
  * A class that handles communications with an OpenID Connect (OIDC) Provider.
@@ -66,39 +71,44 @@ public class OidcProvider implements IOidcProvider {
     private Instant nextJwkRefresh = Instant.EPOCH;
     private ITimeService timeService;
 
-    private String issuerUrl;
+    private URI issuerUrl;
     private String authorizationEndpoint;
     private String tokenEndpoint;
     private String jwksUri;
 
     private HttpClient httpClient = HttpClient.newHttpClient();
 
-    public OidcProvider(String issuerUrl, HttpClient httpClient, ITimeService timeService) {
-        this.issuerUrl = issuerUrl;
-        this.httpClient = httpClient;
-        this.timeService = timeService;
-
-        this.authorizationEndpoint = issuerUrl + "/auth";
-        this.tokenEndpoint = issuerUrl + "/token";
-        this.jwksUri = issuerUrl + "/keys";
-
+    public OidcProvider(String issuerUrl, HttpClient httpClient, ITimeService timeService) throws ServletException {
         try {
+            this.issuerUrl = new URI(issuerUrl);
+            this.httpClient = httpClient;
+            this.timeService = timeService;
+
+            this.authorizationEndpoint = issuerUrl + "/auth";
+            this.tokenEndpoint = issuerUrl + "/token";
+            this.jwksUri = issuerUrl + "/keys";
+
             JsonObject openIdConfiguration = getOpenIdConfiguration();
             if (openIdConfiguration != null) {
                 // The following endpoints are mandatory in OpenID configurations
-                this.authorizationEndpoint = openIdConfiguration.get("authorization_endpoint").getAsString();
-                this.tokenEndpoint = openIdConfiguration.get("token_endpoint").getAsString();
-                this.jwksUri = openIdConfiguration.get("jwks_uri").getAsString();
+                this.authorizationEndpoint = getValidatedUrl(openIdConfiguration.get("authorization_endpoint").getAsString());
+                this.tokenEndpoint = getValidatedUrl(openIdConfiguration.get("token_endpoint").getAsString());
+                this.jwksUri = getValidatedUrl(openIdConfiguration.get("jwks_uri").getAsString());
             }
+
         } catch (IOException | InterruptedException | JsonSyntaxException e) {
             logger.error("Unable to obtain issuer's OpenID configuration, using defaults");
+        } catch (URISyntaxException e) {
+            ServletError error = new ServletError(GAL5059_INVALID_ISSUER_URI_PROVIDED, issuerUrl);
+            throw new ServletException(error.getMessage(), e);
         }
+
         logger.info("Authorization endpoint is: " + this.authorizationEndpoint);
         logger.info("Token endpoint is: " + this.tokenEndpoint);
         logger.info("JWKs endpoint is: " + this.jwksUri);
     }
 
-    public OidcProvider(String issuerUrl, HttpClient httpClient) {
+    public OidcProvider(String issuerUrl, HttpClient httpClient) throws ServletException {
         this(issuerUrl, httpClient, new SystemTimeService());
     }
 
@@ -260,7 +270,7 @@ public class OidcProvider implements IOidcProvider {
             RSAPublicKey publicKey = getRSAPublicKeyFromIssuer(decodedJwt.getKeyId());
             if (publicKey != null) {
                 Algorithm algorithm = Algorithm.RSA256(publicKey, null);
-                JWTVerifier verifier = JWT.require(algorithm).withIssuer(issuerUrl).build();
+                JWTVerifier verifier = JWT.require(algorithm).withIssuer(issuerUrl.toString()).build();
 
                 decodedJwt = verifier.verify(jwt);
                 isValid = (decodedJwt != null);
@@ -358,5 +368,30 @@ public class OidcProvider implements IOidcProvider {
 
         // Update the next refresh time by the refresh interval
         nextJwkRefresh = Instant.now().plus(JWK_REFRESH_INTERVAL_MINUTES, ChronoUnit.MINUTES);
+    }
+
+    /**
+     * Validates and returns the validated URL as a string. The validation checks that
+     * the given URL is a valid URL and its scheme and host matches the OpenID Connect
+     * issuer's scheme and host.
+     * 
+     * @param urlToValidate the URL to validate
+     * @return the validated URL
+     * @throws ServletException if the URL is not valid
+     */
+    private String getValidatedUrl(String urlToValidate) throws ServletException {
+        try {
+            URI uri = new URI(urlToValidate);
+            if (!uri.getScheme().equals(issuerUrl.getScheme())
+                || !uri.getHost().equals(issuerUrl.getHost())) {
+                ServletError error = new ServletError(GAL5061_MISMATCHED_OIDC_URI_RECEIVED, urlToValidate, issuerUrl.toString());
+                throw new ServletException(error.getMessage());
+            }
+
+            return uri.toString();
+        } catch (URISyntaxException e) {
+            ServletError error = new ServletError(GAL5060_INVALID_OIDC_URI_RECEIVED, urlToValidate, issuerUrl.toString());
+            throw new ServletException(error.getMessage(), e);
+        }
     }
 }

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/OidcProvider.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/OidcProvider.java
@@ -390,7 +390,7 @@ public class OidcProvider implements IOidcProvider {
 
             return uri.toString();
         } catch (URISyntaxException e) {
-            ServletError error = new ServletError(GAL5060_INVALID_OIDC_URI_RECEIVED, urlToValidate, issuerUrl.toString());
+            ServletError error = new ServletError(GAL5060_INVALID_OIDC_URI_RECEIVED, urlToValidate);
             throw new ServletException(error.getMessage(), e);
         }
     }

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/OidcProviderTest.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/OidcProviderTest.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import java.util.Base64.Encoder;
 import java.util.function.BiPredicate;
 
+import javax.servlet.ServletException;
+
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.google.gson.JsonArray;
@@ -139,6 +141,109 @@ public class OidcProviderTest {
     //-------------------------------------------------------------------------
     // Test methods
     //-------------------------------------------------------------------------
+    @Test
+    public void testCreateOidcProviderWithInvalidIssuerUrlThrowsError() throws Exception {
+        // When...
+        ServletException thrown = catchThrowableOfType(() -> new OidcProvider("not a valid issuer url", null), ServletException.class);
+
+        // Then...
+        assertThat(thrown).isNotNull();
+        assertThat(thrown.getMessage()).contains("GAL5059", "Invalid Galasa Dex server URI provided");
+    }
+
+    @Test
+    public void testCreateOidcProviderWithInvalidAuthEndpointThrowsError() throws Exception {
+        // Given...
+        JsonObject mockOpenIdConfig = new JsonObject();
+        mockOpenIdConfig.addProperty("authorization_endpoint", "not a valid url");
+
+        HttpResponse<Object> mockResponse = new MockHttpResponse<Object>(gson.toJson(mockOpenIdConfig), 200);
+
+        MockHttpClient mockHttpClient = new MockHttpClient(mockResponse);
+
+        // When...
+        ServletException thrown = catchThrowableOfType(() -> new OidcProvider("http://my.server", mockHttpClient), ServletException.class);
+
+        // Then...
+        assertThat(thrown).isNotNull();
+        assertThat(thrown.getMessage()).contains("GAL5060E", "Invalid OpenID Connect URL");
+    }
+
+    @Test
+    public void testCreateOidcProviderWithAuthEndpointDifferentSchemeThrowsError() throws Exception {
+        // Given...
+        JsonObject mockOpenIdConfig = new JsonObject();
+        mockOpenIdConfig.addProperty("authorization_endpoint", "nothttp://my.server/auth");
+
+        HttpResponse<Object> mockResponse = new MockHttpResponse<Object>(gson.toJson(mockOpenIdConfig), 200);
+
+        MockHttpClient mockHttpClient = new MockHttpClient(mockResponse);
+
+        // When...
+        ServletException thrown = catchThrowableOfType(() -> new OidcProvider("http://my.server", mockHttpClient), ServletException.class);
+
+        // Then...
+        assertThat(thrown).isNotNull();
+        assertThat(thrown.getMessage()).contains("GAL5061E", "does not match the expected Dex server scheme or host");
+    }
+
+    @Test
+    public void testCreateOidcProviderWithAuthEndpointOnDifferentHostThrowsError() throws Exception {
+        // Given...
+        JsonObject mockOpenIdConfig = new JsonObject();
+        mockOpenIdConfig.addProperty("authorization_endpoint", "http://my-malicious-server/auth");
+
+        HttpResponse<Object> mockResponse = new MockHttpResponse<Object>(gson.toJson(mockOpenIdConfig), 200);
+
+        MockHttpClient mockHttpClient = new MockHttpClient(mockResponse);
+
+        // When...
+        ServletException thrown = catchThrowableOfType(() -> new OidcProvider("http://my.server", mockHttpClient), ServletException.class);
+
+        // Then...
+        assertThat(thrown).isNotNull();
+        assertThat(thrown.getMessage()).contains("GAL5061E", "does not match the expected Dex server scheme or host");
+    }
+
+    @Test
+    public void testCreateOidcProviderWithTokensEndpointOnDifferentHostThrowsError() throws Exception {
+        // Given...
+        JsonObject mockOpenIdConfig = new JsonObject();
+        mockOpenIdConfig.addProperty("authorization_endpoint", "http://my.server/auth");
+        mockOpenIdConfig.addProperty("token_endpoint", "http://my-malicious-server/tokens");
+
+        HttpResponse<Object> mockResponse = new MockHttpResponse<Object>(gson.toJson(mockOpenIdConfig), 200);
+
+        MockHttpClient mockHttpClient = new MockHttpClient(mockResponse);
+
+        // When...
+        ServletException thrown = catchThrowableOfType(() -> new OidcProvider("http://my.server", mockHttpClient), ServletException.class);
+
+        // Then...
+        assertThat(thrown).isNotNull();
+        assertThat(thrown.getMessage()).contains("GAL5061E", "does not match the expected Dex server scheme or host");
+    }
+
+    @Test
+    public void testCreateOidcProviderWithJwksEndpointOnDifferentHostThrowsError() throws Exception {
+        // Given...
+        JsonObject mockOpenIdConfig = new JsonObject();
+        mockOpenIdConfig.addProperty("authorization_endpoint", "http://my.server/auth");
+        mockOpenIdConfig.addProperty("token_endpoint", "http://my.server/tokens");
+        mockOpenIdConfig.addProperty("jwks_uri", "http://my-malicious-server/keys");
+
+        HttpResponse<Object> mockResponse = new MockHttpResponse<Object>(gson.toJson(mockOpenIdConfig), 200);
+
+        MockHttpClient mockHttpClient = new MockHttpClient(mockResponse);
+
+        // When...
+        ServletException thrown = catchThrowableOfType(() -> new OidcProvider("http://my.server", mockHttpClient), ServletException.class);
+
+        // Then...
+        assertThat(thrown).isNotNull();
+        assertThat(thrown.getMessage()).contains("GAL5061E", "does not match the expected Dex server scheme or host");
+    }
+
     @Test
     public void testTokenPostWithRefreshTokenValidRequestReturnsValidResponse() throws Exception {
         // Given...
@@ -451,7 +556,7 @@ public class OidcProviderTest {
 
         MockHttpClient mockHttpClient = new MockHttpClient(mockResponse);
 
-        OidcProvider oidcProvider = new OidcProvider("http://dummy-issuer", mockHttpClient);
+        OidcProvider oidcProvider = new OidcProvider("http://my.server", mockHttpClient);
 
         // When...
         JsonObject openIdConfig = oidcProvider.getOpenIdConfiguration();
@@ -460,6 +565,7 @@ public class OidcProviderTest {
         assertThat(openIdConfig).isNotNull();
         assertThat(openIdConfig).isEqualTo(mockOpenIdConfig);
     }
+
 
     @Test
     public void testGetOpenIdConfigurationWithErrorResponseReturnsNull() throws Exception {

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/OidcProviderTest.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/OidcProviderTest.java
@@ -148,7 +148,7 @@ public class OidcProviderTest {
 
         // Then...
         assertThat(thrown).isNotNull();
-        assertThat(thrown.getMessage()).contains("GAL5059", "Invalid Galasa Dex server URI provided");
+        assertThat(thrown.getMessage()).contains("GAL5059", "Invalid Galasa Dex server URL provided");
     }
 
     @Test

--- a/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
@@ -91,9 +91,9 @@ public enum ServletErrorMessage {
     GAL5056_FAILED_TO_STORE_TOKEN_IN_AUTH_STORE       (5056, "E: Internal server error occurred when storing the new Galasa token with description ''{0}'' in the auth store. The auth store could be badly configured, or could be experiencing a temporary issue. Report the problem to your Galasa Ecosystem owner."),
     GAL5057_FAILED_TO_RETRIEVE_USERNAME_FROM_JWT      (5057, "E: Unable to retrieve a username from the given JWT. No JWT claim exists in the given JWT that matches the supplied claims: ''{0}''. This could be because the Galasa Ecosystem is badly configured and the chosen authentication provider does not include the expected claims in JWTs. Report the problem to your Galasa Ecosystem owner."),
     GAL5058_NO_USERNAME_JWT_CLAIMS_PROVIDED           (5058, "E: Unable to retrieve a username from the given JWT. No JWT claims to retrieve a username from were provided. This could be because the Galasa Ecosystem is badly configured. Report the problem to your Galasa Ecosystem owner."),
-    GAL5059_INVALID_ISSUER_URI_PROVIDED               (5059, "E: Invalid Galasa Dex server URI provided ''{0}''. This could be because the Galasa Ecosystem is badly configured. Report the problem to your Galasa Ecosystem owner."),
-    GAL5060_INVALID_OIDC_URI_RECEIVED                 (5060, "E: Internal server error. Invalid OpenID Connect URL ''{0}'' received from the Galasa Dex server. Report the problem to your Galasa Ecosystem owner."),
-    GAL5061_MISMATCHED_OIDC_URI_RECEIVED              (5061, "E: Internal server error. OpenID Connect URL ''{0}'' received from the Galasa Dex server does not match the expected Dex server scheme or host ''{1}''. Report the problem to your Galasa Ecosystem owner."),
+    GAL5059_INVALID_ISSUER_URI_PROVIDED               (5059, "E: Invalid Galasa Dex server URL provided. This could be because the Galasa Ecosystem is badly configured. Report the problem to your Galasa Ecosystem owner."),
+    GAL5060_INVALID_OIDC_URI_RECEIVED                 (5060, "E: Internal server error. Invalid OpenID Connect URL received from the Galasa Dex server. Report the problem to your Galasa Ecosystem owner."),
+    GAL5061_MISMATCHED_OIDC_URI_RECEIVED              (5061, "E: Internal server error. OpenID Connect URL received from the Galasa Dex server does not match the expected Dex server scheme or host. Report the problem to your Galasa Ecosystem owner."),
     ;
 
 

--- a/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
@@ -91,6 +91,9 @@ public enum ServletErrorMessage {
     GAL5056_FAILED_TO_STORE_TOKEN_IN_AUTH_STORE       (5056, "E: Internal server error occurred when storing the new Galasa token with description ''{0}'' in the auth store. The auth store could be badly configured, or could be experiencing a temporary issue. Report the problem to your Galasa Ecosystem owner."),
     GAL5057_FAILED_TO_RETRIEVE_USERNAME_FROM_JWT      (5057, "E: Unable to retrieve a username from the given JWT. No JWT claim exists in the given JWT that matches the supplied claims: ''{0}''. This could be because the Galasa Ecosystem is badly configured and the chosen authentication provider does not include the expected claims in JWTs. Report the problem to your Galasa Ecosystem owner."),
     GAL5058_NO_USERNAME_JWT_CLAIMS_PROVIDED           (5058, "E: Unable to retrieve a username from the given JWT. No JWT claims to retrieve a username from were provided. This could be because the Galasa Ecosystem is badly configured. Report the problem to your Galasa Ecosystem owner."),
+    GAL5059_INVALID_ISSUER_URI_PROVIDED               (5059, "E: Invalid Galasa Dex server URI provided ''{0}''. This could be because the Galasa Ecosystem is badly configured. Report the problem to your Galasa Ecosystem owner."),
+    GAL5060_INVALID_OIDC_URI_RECEIVED                 (5060, "E: Internal server error. Invalid OpenID Connect URL ''{0}'' received from the Galasa Dex server. Report the problem to your Galasa Ecosystem owner."),
+    GAL5061_MISMATCHED_OIDC_URI_RECEIVED              (5061, "E: Internal server error. OpenID Connect URL ''{0}'' received from the Galasa Dex server does not match the expected Dex server scheme or host ''{1}''. Report the problem to your Galasa Ecosystem owner."),
     ;
 
 


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1894

## Changes
- Added validation to check if the OpenID Connect endpoints returned by Dex are valid URLs and that their schemes and hostnames match the Dex server's scheme and hostname
- Added unit tests around validation logic