### PR TITLE
Match request origins against a list of allowed origins via an env variable

### DIFF
--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/JwtAuthFilter.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/JwtAuthFilter.java
@@ -42,7 +42,7 @@ public class JwtAuthFilter implements Filter {
 
     private static final Map<String, List<String>> UNAUTHENTICATED_ROUTES = UnauthenticatedRoute.getRoutesAsMap();
 
-    private ResponseBuilder responseBuilder = new ResponseBuilder();
+    protected ResponseBuilder responseBuilder = new ResponseBuilder();
 
     protected Environment env = new SystemEnvironment();
 
@@ -99,7 +99,7 @@ public class JwtAuthFilter implements Filter {
             chain.doFilter(request, response);
         } else {
             // The JWT is not valid or something went wrong, so return the error response
-            responseBuilder.buildResponse(servletResponse, "application/json", errorString, httpStatusCode);
+            responseBuilder.buildResponse(servletRequest, servletResponse, "application/json", errorString, httpStatusCode);
         }
     }
 

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthCallbackRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthCallbackRoute.java
@@ -72,7 +72,7 @@ public class AuthCallbackRoute extends BaseRoute {
 
                     // Redirect the user back to the callback URL provided in the original /auth request
                     response.addHeader("Location", clientCallbackUrl);
-                    return getResponseBuilder().buildResponse(response, null, null,
+                    return getResponseBuilder().buildResponse(request, response, null, null,
                             HttpServletResponse.SC_FOUND);
                 } else {
                     logger.error("Unable to redirect back to the client application (failed to retrieve callback URL from session)");

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthClientsRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthClientsRoute.java
@@ -52,7 +52,7 @@ public class AuthClientsRoute extends BaseRoute {
 
         // Marshal into a structure to be returned as JSON
         DexClient clientToReturn = new DexClient(newDexClient.getId());
-        return getResponseBuilder().buildResponse(response, "application/json", gson.toJson(clientToReturn),
+        return getResponseBuilder().buildResponse(request, response, "application/json", gson.toJson(clientToReturn),
                 HttpServletResponse.SC_CREATED);
     }
 }

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthRoute.java
@@ -100,7 +100,7 @@ public class AuthRoute extends BaseRoute {
             throw new InternalServletException(error, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e);
         }
 
-        return getResponseBuilder().buildResponse(response, null, null, HttpServletResponse.SC_FOUND);
+        return getResponseBuilder().buildResponse(request, response, null, null, HttpServletResponse.SC_FOUND);
     }
 
     /**
@@ -154,7 +154,7 @@ public class AuthRoute extends BaseRoute {
             throw new InternalServletException(error, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e);
         }
 
-        return getResponseBuilder().buildResponse(response, "application/json", gson.toJson(responseJson), HttpServletResponse.SC_OK);
+        return getResponseBuilder().buildResponse(request, response, "application/json", gson.toJson(responseJson), HttpServletResponse.SC_OK);
     }
 
     /**

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensRoute.java
@@ -97,7 +97,7 @@ public class AuthTokensRoute extends BaseRoute {
             throw new InternalServletException(error, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e);
         }
 
-        return getResponseBuilder().buildResponse(response, "application/json", getTokensAsJsonString(tokensToReturn), HttpServletResponse.SC_OK);
+        return getResponseBuilder().buildResponse(request, response, "application/json", getTokensAsJsonString(tokensToReturn), HttpServletResponse.SC_OK);
     }
 
     /**
@@ -151,7 +151,7 @@ public class AuthTokensRoute extends BaseRoute {
             throw new InternalServletException(error, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e);
         }
 
-        return getResponseBuilder().buildResponse(response, "application/json", gson.toJson(responseJson), HttpServletResponse.SC_OK);
+        return getResponseBuilder().buildResponse(request, response, "application/json", gson.toJson(responseJson), HttpServletResponse.SC_OK);
     }
 
     /**

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/JwtAuthFilterTest.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/JwtAuthFilterTest.java
@@ -24,6 +24,7 @@ import dev.galasa.framework.api.authentication.mocks.MockOidcProvider;
 import dev.galasa.framework.api.common.BaseServletTest;
 import dev.galasa.framework.api.common.Environment;
 import dev.galasa.framework.api.common.EnvironmentVariables;
+import dev.galasa.framework.api.common.ResponseBuilder;
 import dev.galasa.framework.api.common.mocks.MockEnvironment;
 import dev.galasa.framework.api.common.mocks.MockHttpServletRequest;
 import dev.galasa.framework.api.common.mocks.MockHttpServletResponse;
@@ -35,6 +36,7 @@ public class JwtAuthFilterTest extends BaseServletTest {
         public MockJwtAuthFilter(Environment env, IOidcProvider oidcProvider) {
             super.env = env;
             super.oidcProvider = oidcProvider;
+            super.responseBuilder = new ResponseBuilder(env);
         }
     }
 

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/JwtWrapperTest.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/JwtWrapperTest.java
@@ -108,7 +108,8 @@ public class JwtWrapperTest {
         MockHttpServletRequest req = new MockHttpServletRequest("", headers);
 
         // When...
-        JwtWrapper auth = new JwtWrapper(req);
+        MockEnvironment mockEnv = new MockEnvironment();
+        JwtWrapper auth = new JwtWrapper(req, mockEnv);
         InternalServletException thrown = catchThrowableOfType(() -> auth.getUsername(), InternalServletException.class);
 
         // Then...

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/mocks/MockAuthenticationServlet.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/mocks/MockAuthenticationServlet.java
@@ -10,6 +10,7 @@ import dev.galasa.framework.api.authentication.IOidcProvider;
 import dev.galasa.framework.api.authentication.internal.DexGrpcClient;
 import dev.galasa.framework.api.common.Environment;
 import dev.galasa.framework.api.common.EnvironmentVariables;
+import dev.galasa.framework.api.common.ResponseBuilder;
 import dev.galasa.framework.api.common.mocks.MockEnvironment;
 import dev.galasa.framework.api.common.mocks.MockFramework;
 import dev.galasa.framework.spi.IFramework;
@@ -45,6 +46,7 @@ public class MockAuthenticationServlet extends AuthenticationServlet {
         this.oidcProvider = oidcProvider;
         this.dexGrpcClient = dexGrpcClient;
         this.framework = framework;
+        setResponseBuilder(new ResponseBuilder(env));
     }
 
     @Override

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthTokensRouteTest.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthTokensRouteTest.java
@@ -146,7 +146,6 @@ public class AuthTokensRouteTest extends BaseServletTest {
 
         assertThat(servletResponse.getStatus()).isEqualTo(200);
         assertThat(servletResponse.getContentType()).isEqualTo("application/json");
-        assertThat(servletResponse.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
         Map<String, String> expectedTokenFields = Map.of(
             "token_id", tokenId,
@@ -184,7 +183,6 @@ public class AuthTokensRouteTest extends BaseServletTest {
         // Then...
         assertThat(servletResponse.getStatus()).isEqualTo(500);
         assertThat(servletResponse.getContentType()).isEqualTo("application/json");
-        assertThat(servletResponse.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
         assertThat(outStream.toString()).contains("GAL5053E", "Internal server error occurred when retrieving tokens from the auth store", "The auth store could be badly configured or could be experiencing temporary issues");
     }
 
@@ -221,7 +219,6 @@ public class AuthTokensRouteTest extends BaseServletTest {
 
         assertThat(servletResponse.getStatus()).isEqualTo(200);
         assertThat(servletResponse.getContentType()).isEqualTo("application/json");
-        assertThat(servletResponse.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
         checkOrderMatches(expectedTokenOrder, getJsonArrayFromJson(output, "tokens"));
     }
 

--- a/galasa-parent/dev.galasa.framework.api.bootstrap/src/main/java/dev/galasa/framework/api/bootstrap/routes/BootstrapExternalRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.bootstrap/src/main/java/dev/galasa/framework/api/bootstrap/routes/BootstrapExternalRoute.java
@@ -33,7 +33,7 @@ public class BootstrapExternalRoute extends BaseRoute {
             throws ServletException, IOException, FrameworkException {
         Properties properties = new Properties();
         properties.store(response.getWriter(), "Galasa Bootstrap Properties");
-        response = getResponseBuilder().buildResponseHeaders(response, "text/plain", HttpServletResponse.SC_OK);
+        response = getResponseBuilder().buildResponseHeaders(request, response, "text/plain", HttpServletResponse.SC_OK);
         return response;
     }
 

--- a/galasa-parent/dev.galasa.framework.api.bootstrap/src/main/java/dev/galasa/framework/api/bootstrap/routes/BootstrapInternalRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.bootstrap/src/main/java/dev/galasa/framework/api/bootstrap/routes/BootstrapInternalRoute.java
@@ -42,7 +42,7 @@ public class BootstrapInternalRoute extends BaseRoute {
         }
 
         actualBootstrap.store(response.getWriter(), "Galasa Bootstrap Properties");
-        response = getResponseBuilder().buildResponseHeaders(response, "text/plain", HttpServletResponse.SC_OK);
+        response = getResponseBuilder().buildResponseHeaders(request, response, "text/plain", HttpServletResponse.SC_OK);
         return response;
     }
 

--- a/galasa-parent/dev.galasa.framework.api.bootstrap/src/test/java/dev/galasa/framework/api/bootstrap/BootstrapServletTest.java
+++ b/galasa-parent/dev.galasa.framework.api.bootstrap/src/test/java/dev/galasa/framework/api/bootstrap/BootstrapServletTest.java
@@ -13,6 +13,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import dev.galasa.framework.api.bootstrap.mocks.MockBootstrapServlet;
 import dev.galasa.framework.api.common.BaseServletTest;
+import dev.galasa.framework.api.common.ResponseBuilder;
+import dev.galasa.framework.api.common.mocks.MockEnvironment;
 import dev.galasa.framework.api.common.mocks.MockFramework;
 import dev.galasa.framework.api.common.mocks.MockHttpServletRequest;
 import dev.galasa.framework.api.common.mocks.MockHttpServletResponse;
@@ -31,6 +33,8 @@ public class BootstrapServletTest extends BaseServletTest {
 
 	protected void setServlet() throws ConfigurationPropertyStoreException{
 		this.servlet = new MockBootstrapServlet();
+        servlet.setResponseBuilder(new ResponseBuilder(new MockEnvironment()));
+
 		IConfigurationPropertyStoreService cpsstore;
 		cpsstore = new MockIConfigurationPropertyStoreService("bootstrap");
         cpsstore.setProperty("framework.config.store","mystore");

--- a/galasa-parent/dev.galasa.framework.api.bootstrap/src/test/java/dev/galasa/framework/api/bootstrap/routes/TestBootstrapExternalRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.bootstrap/src/test/java/dev/galasa/framework/api/bootstrap/routes/TestBootstrapExternalRoute.java
@@ -8,6 +8,7 @@ package dev.galasa.framework.api.bootstrap.routes;
 import dev.galasa.framework.api.bootstrap.BootstrapServletTest;
 import dev.galasa.framework.api.bootstrap.mocks.MockBootstrapServlet;
 import dev.galasa.framework.api.common.ResponseBuilder;
+import dev.galasa.framework.api.common.mocks.MockHttpServletRequest;
 import dev.galasa.framework.api.common.mocks.MockHttpServletResponse;
 import dev.galasa.framework.spi.FrameworkException;
 
@@ -26,13 +27,15 @@ public class TestBootstrapExternalRoute extends BootstrapServletTest {
     @Test
     public void TestBootstrapExternalRouteHandleGetRequestReturnsOK () throws ServletException, IOException, FrameworkException{
         // Given...
+        String pathInfo = "/bootstrap/external";
         ResponseBuilder responseBuilder = new ResponseBuilder();
         BootstrapExternalRoute route = new BootstrapExternalRoute(responseBuilder);
         HttpServletResponse response = (HttpServletResponse) new MockHttpServletResponse();
+        HttpServletRequest req = (HttpServletRequest) new MockHttpServletRequest(pathInfo);
         ServletOutputStream outStream = response.getOutputStream();
 
         // When...
-        response = route.handleGetRequest("/bootstrap/external",null,null,response);
+        response = route.handleGetRequest(pathInfo,null,req,response);
 
         // Then...
         String output = outStream.toString();
@@ -58,7 +61,6 @@ public class TestBootstrapExternalRoute extends BootstrapServletTest {
         String output = outStream.toString();
         assertThat(status).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("text/plain");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
         assertThat(output).contains("#Galasa Bootstrap Properties");
         assertThat(output).doesNotContain("framework.config.store=mystore\n",
             "framework.extra.bundles=more.bundles\n",

--- a/galasa-parent/dev.galasa.framework.api.bootstrap/src/test/java/dev/galasa/framework/api/bootstrap/routes/TestBootstrapInternalRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.bootstrap/src/test/java/dev/galasa/framework/api/bootstrap/routes/TestBootstrapInternalRoute.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import dev.galasa.framework.api.bootstrap.BootstrapServletTest;
 import dev.galasa.framework.api.bootstrap.mocks.MockBootstrapServlet;
 import dev.galasa.framework.api.common.ResponseBuilder;
+import dev.galasa.framework.api.common.mocks.MockHttpServletRequest;
 import dev.galasa.framework.api.common.mocks.MockHttpServletResponse;
 import dev.galasa.framework.spi.FrameworkException;
 
@@ -35,14 +36,16 @@ public class TestBootstrapInternalRoute extends BootstrapServletTest {
             "framework.testcatalog.url", "myeco.dev/testcatalog"
         );
 
+        String pathInfo = "/bootstrap";
         ResponseBuilder responseBuilder = new ResponseBuilder();
         BootstrapInternalRoute route = new BootstrapInternalRoute(responseBuilder);
+        HttpServletRequest req = (HttpServletRequest) new MockHttpServletRequest(pathInfo);
         HttpServletResponse response = (HttpServletResponse) new MockHttpServletResponse();
         ServletOutputStream outStream = response.getOutputStream();
 
         // When...
         route.onModified(properties);
-        response = route.handleGetRequest("/bootstrap",null,null,response);
+        response = route.handleGetRequest(pathInfo,null,req,response);
 
         // Then...
         String output = outStream.toString();
@@ -76,7 +79,6 @@ public class TestBootstrapInternalRoute extends BootstrapServletTest {
         String output = outStream.toString();
         assertThat(status).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("text/plain");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
         assertThat(output).contains("#Galasa Bootstrap Properties\n",
             "framework.config.store=mystore\n",
             "framework.testcatalog.url=myeco.dev/testcatalog\n");
@@ -103,7 +105,6 @@ public class TestBootstrapInternalRoute extends BootstrapServletTest {
         String output = outStream.toString();
         assertThat(status).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("text/plain");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
         assertThat(output).contains("#Galasa Bootstrap Properties");
         assertThat(output).doesNotContain("framework.", "=");
     }

--- a/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/BaseServlet.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/BaseServlet.java
@@ -45,6 +45,10 @@ public class BaseServlet extends HttpServlet {
         return this.responseBuilder;
     }
 
+    public void setResponseBuilder(ResponseBuilder responseBuilder) {
+        this.responseBuilder = responseBuilder;
+    }
+
     @Override
     public void doGet(HttpServletRequest req, HttpServletResponse res) throws ServletException, IOException {
         logger.info("BaseServlet: doGet() entered. Url: " + req.getPathInfo());
@@ -89,7 +93,7 @@ public class BaseServlet extends HttpServlet {
             logger.error(errorString, t);
         }
 
-        getResponseBuilder().buildResponse(res, "application/json", errorString, httpStatusCode);
+        getResponseBuilder().buildResponse(req, res, "application/json", errorString, httpStatusCode);
     }
 
     private void processRoutes(HttpServletRequest req, HttpServletResponse res)

--- a/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/EnvironmentVariables.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/EnvironmentVariables.java
@@ -29,4 +29,9 @@ public class EnvironmentVariables {
      * An ordered, comma-separated list of JWT claims to use when Galasa sets a username for an ecosystem user.
      */
     public static final String GALASA_USERNAME_CLAIMS = "GALASA_USERNAME_CLAIMS";
+
+    /**
+     * A comma-separated list of allowed origins that the API server is permitted to respond to.
+     */
+    public static final String GALASA_ALLOWED_ORIGINS = "GALASA_ALLOWED_ORIGINS";
 }

--- a/galasa-parent/dev.galasa.framework.api.common/src/test/java/dev/galasa/framework/api/common/TestResponseBuilder.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/test/java/dev/galasa/framework/api/common/TestResponseBuilder.java
@@ -1,0 +1,197 @@
+package dev.galasa.framework.api.common;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Map;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Test;
+
+import dev.galasa.framework.api.common.mocks.MockEnvironment;
+import dev.galasa.framework.api.common.mocks.MockHttpServletRequest;
+import dev.galasa.framework.api.common.mocks.MockHttpServletResponse;
+
+public class TestResponseBuilder {
+
+    @Test
+    public void testBuildResponseWritesResponseOK() throws Exception {
+        // Given...
+        String origin = "https://my.server.com";
+
+        MockEnvironment mockEnv = new MockEnvironment();
+        mockEnv.setenv(EnvironmentVariables.GALASA_ALLOWED_ORIGINS, origin);
+        ResponseBuilder responseBuilder = new ResponseBuilder(mockEnv);
+
+        Map<String, String> reqHeaders = Map.of("Origin", origin);
+        MockHttpServletRequest req = new MockHttpServletRequest("/", reqHeaders);
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        String contentType = "text/plain";
+        String content = "this is a response!";
+
+        // When...
+        HttpServletResponse actualResp = responseBuilder.buildResponse(req, resp, contentType, content, HttpServletResponse.SC_OK);
+
+        // Then...
+        assertThat(actualResp.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+        assertThat(actualResp.getContentType()).isEqualTo(contentType);
+        assertThat(actualResp.getOutputStream().toString()).isEqualTo(content);
+        assertThat(actualResp.getHeader("Access-Control-Allow-Origin")).isEqualTo(origin);
+    }
+
+    @Test
+    public void testBuildResponseHeadersSetsHeadersOK() throws Exception {
+        // Given...
+        String origin = "https://my.server.com";
+
+        MockEnvironment mockEnv = new MockEnvironment();
+        mockEnv.setenv(EnvironmentVariables.GALASA_ALLOWED_ORIGINS, origin);
+        ResponseBuilder responseBuilder = new ResponseBuilder(mockEnv);
+
+        Map<String, String> reqHeaders = Map.of("Origin", origin);
+        MockHttpServletRequest req = new MockHttpServletRequest("/", reqHeaders);
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        String contentType = "application/json";
+
+        // When...
+        HttpServletResponse actualResp = responseBuilder.buildResponseHeaders(req, resp, contentType, HttpServletResponse.SC_OK);
+
+        // Then...
+        assertThat(actualResp.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+        assertThat(actualResp.getContentType()).isEqualTo(contentType);
+        assertThat(actualResp.getHeader("Access-Control-Allow-Origin")).isEqualTo(origin);
+    }
+
+    @Test
+    public void testBuildResponseHeadersWithWildcardAllowedOriginSetsHeadersOK() throws Exception {
+        // Given...
+        String origin = "https://my.server.com";
+
+        MockEnvironment mockEnv = new MockEnvironment();
+        mockEnv.setenv(EnvironmentVariables.GALASA_ALLOWED_ORIGINS, "*.server.com");
+        ResponseBuilder responseBuilder = new ResponseBuilder(mockEnv);
+
+        Map<String, String> reqHeaders = Map.of("Origin", origin);
+        MockHttpServletRequest req = new MockHttpServletRequest("/", reqHeaders);
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        String contentType = "application/json";
+
+        // When...
+        HttpServletResponse actualResp = responseBuilder.buildResponseHeaders(req, resp, contentType, HttpServletResponse.SC_OK);
+
+        // Then...
+        assertThat(actualResp.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+        assertThat(actualResp.getContentType()).isEqualTo(contentType);
+        assertThat(actualResp.getHeader("Access-Control-Allow-Origin")).isEqualTo(origin);
+    }
+
+    @Test
+    public void testBuildResponseHeadersWithAllAllowedOriginSetsHeadersOK() throws Exception {
+        // Given...
+        String origin = "https://my.server.com";
+
+        MockEnvironment mockEnv = new MockEnvironment();
+        mockEnv.setenv(EnvironmentVariables.GALASA_ALLOWED_ORIGINS, "*");
+        ResponseBuilder responseBuilder = new ResponseBuilder(mockEnv);
+
+        Map<String, String> reqHeaders = Map.of("Origin", origin);
+        MockHttpServletRequest req = new MockHttpServletRequest("/", reqHeaders);
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        String contentType = "application/json";
+
+        // When...
+        HttpServletResponse actualResp = responseBuilder.buildResponseHeaders(req, resp, contentType, HttpServletResponse.SC_OK);
+
+        // Then...
+        assertThat(actualResp.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+        assertThat(actualResp.getContentType()).isEqualTo(contentType);
+        assertThat(actualResp.getHeader("Access-Control-Allow-Origin")).isEqualTo(origin);
+    }
+
+    @Test
+    public void testBuildResponseHeadersWithMultipleAllowedOriginSetsHeadersOK() throws Exception {
+        // Given...
+        String origin = "https://my.server2.com";
+
+        MockEnvironment mockEnv = new MockEnvironment();
+        mockEnv.setenv(EnvironmentVariables.GALASA_ALLOWED_ORIGINS, "https://server1.com,*.server2.com,*.server.com");
+        ResponseBuilder responseBuilder = new ResponseBuilder(mockEnv);
+
+        Map<String, String> reqHeaders = Map.of("Origin", origin);
+        MockHttpServletRequest req = new MockHttpServletRequest("/", reqHeaders);
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        String contentType = "application/json";
+
+        // When...
+        HttpServletResponse actualResp = responseBuilder.buildResponseHeaders(req, resp, contentType, HttpServletResponse.SC_OK);
+
+        // Then...
+        assertThat(actualResp.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+        assertThat(actualResp.getContentType()).isEqualTo(contentType);
+        assertThat(actualResp.getHeader("Access-Control-Allow-Origin")).isEqualTo(origin);
+    }
+
+    @Test
+    public void testBuildResponseHeadersWithNoMatchingAllowedOriginDoesNotSetCorsHeader() throws Exception {
+        // Given...
+        String origin = "https://my.server2.com";
+
+        MockEnvironment mockEnv = new MockEnvironment();
+        mockEnv.setenv(EnvironmentVariables.GALASA_ALLOWED_ORIGINS, "https://server1.com,another.server2.com,*.server.com");
+        ResponseBuilder responseBuilder = new ResponseBuilder(mockEnv);
+
+        Map<String, String> reqHeaders = Map.of("Origin", origin);
+        MockHttpServletRequest req = new MockHttpServletRequest("/", reqHeaders);
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        String contentType = "application/json";
+
+        // When...
+        HttpServletResponse actualResp = responseBuilder.buildResponseHeaders(req, resp, contentType, HttpServletResponse.SC_OK);
+
+        // Then...
+        assertThat(actualResp.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+        assertThat(actualResp.getContentType()).isEqualTo(contentType);
+        assertThat(actualResp.getHeader("Access-Control-Allow-Origin")).isNull();
+    }
+
+    @Test
+    public void testBuildResponseHeadersWithNoAllowedOriginsDoesNotSetCorsHeader() throws Exception {
+        // Given...
+        String origin = "https://my.server2.com";
+
+        MockEnvironment mockEnv = new MockEnvironment();
+        ResponseBuilder responseBuilder = new ResponseBuilder(mockEnv);
+
+        Map<String, String> reqHeaders = Map.of("Origin", origin);
+        MockHttpServletRequest req = new MockHttpServletRequest("/", reqHeaders);
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        String contentType = "application/json";
+
+        // When...
+        HttpServletResponse actualResp = responseBuilder.buildResponseHeaders(req, resp, contentType, HttpServletResponse.SC_OK);
+
+        // Then...
+        assertThat(actualResp.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+        assertThat(actualResp.getContentType()).isEqualTo(contentType);
+        assertThat(actualResp.getHeader("Access-Control-Allow-Origin")).isNull();
+    }
+
+    @Test
+    public void testBuildResponseHeadersWithNullOriginDoesNotSetCorsHeader() throws Exception {
+        // Given...
+        MockEnvironment mockEnv = new MockEnvironment();
+        ResponseBuilder responseBuilder = new ResponseBuilder(mockEnv);
+
+        MockHttpServletRequest req = new MockHttpServletRequest("/");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        String contentType = "application/json";
+
+        // When...
+        HttpServletResponse actualResp = responseBuilder.buildResponseHeaders(req, resp, contentType, HttpServletResponse.SC_OK);
+
+        // Then...
+        assertThat(actualResp.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+        assertThat(actualResp.getContentType()).isEqualTo(contentType);
+        assertThat(actualResp.getHeader("Access-Control-Allow-Origin")).isNull();
+    }
+}

--- a/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/routes/NamespacesRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/routes/NamespacesRoute.java
@@ -49,7 +49,7 @@ public class NamespacesRoute extends CPSRoute {
     @Override
     public HttpServletResponse handleGetRequest(String pathInfo, QueryParameters queryParams,HttpServletRequest req, HttpServletResponse response) throws ServletException, IOException, FrameworkException {
         String namespaces = getNamespaces(req.getRequestURI());
-		return getResponseBuilder().buildResponse(response, "application/json", namespaces, HttpServletResponse.SC_OK); 
+		return getResponseBuilder().buildResponse(req, response, "application/json", namespaces, HttpServletResponse.SC_OK); 
     }
 
     private String getNamespaces(String url) throws InternalServletException {

--- a/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/routes/PropertyRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/routes/PropertyRoute.java
@@ -50,7 +50,7 @@ public class PropertyRoute extends CPSRoute{
         String namespace = getNamespaceFromURL(pathInfo);
         String properties = getNamespaceProperties(namespace, queryParams);
         checkNamespaceExists(namespace);
-        return getResponseBuilder().buildResponse(response, "application/json", properties, HttpServletResponse.SC_OK); 
+        return getResponseBuilder().buildResponse(req, response, "application/json", properties, HttpServletResponse.SC_OK); 
     }
 
     private String getNamespaceProperties(String namespaceName, QueryParameters queryParams) throws InternalServletException{
@@ -176,7 +176,7 @@ public class PropertyRoute extends CPSRoute{
         body.close();
         CPSProperty property = applyPropertyToStore(jsonString, namespaceName, false);
         String responseBody = String.format("Successfully created property %s in %s",property.getName(), property.getNamespace());
-        return getResponseBuilder().buildResponse(response, "text/plain", responseBody, HttpServletResponse.SC_CREATED); 
+        return getResponseBuilder().buildResponse(request, response, "text/plain", responseBody, HttpServletResponse.SC_CREATED); 
     }
 
 }

--- a/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/routes/PropertyUpdateRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/routes/PropertyUpdateRoute.java
@@ -48,7 +48,7 @@ public class PropertyUpdateRoute extends CPSRoute {
         String propertyName = getPropertyNameFromURL(pathInfo);
         checkNamespaceExists(namespace);
         String property = retrieveProperty(namespace,propertyName);
-		return getResponseBuilder().buildResponse(response, "application/json", property, HttpServletResponse.SC_OK); 
+		return getResponseBuilder().buildResponse(req, response, "application/json", property, HttpServletResponse.SC_OK); 
     }
 
     private String retrieveProperty (String namespaceName, String propertyName) throws FrameworkException {
@@ -90,7 +90,7 @@ public class PropertyUpdateRoute extends CPSRoute {
         checkNamespaceExists(namespaceName);
         CPSProperty property = applyPropertyToStore(jsonString, namespaceName, true);
         String responseBody = String.format("Successfully updated property %s in %s",property.getName(), property.getNamespace());
-        return getResponseBuilder().buildResponse(response, "text/plain", responseBody, HttpServletResponse.SC_OK); 
+        return getResponseBuilder().buildResponse(request, response, "text/plain", responseBody, HttpServletResponse.SC_OK); 
     }
 
 
@@ -104,7 +104,7 @@ public class PropertyUpdateRoute extends CPSRoute {
         String property = getPropertyNameFromURL(pathInfo);
         deleteProperty(namespace, property);
         String responseBody = String.format("Successfully deleted property %s in %s",property, namespace);
-        return getResponseBuilder().buildResponse(response, "text/plain", responseBody, HttpServletResponse.SC_OK);
+        return getResponseBuilder().buildResponse(request, response, "text/plain", responseBody, HttpServletResponse.SC_OK);
     }
 
 

--- a/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/CpsServletTest.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/CpsServletTest.java
@@ -12,6 +12,8 @@ import com.google.gson.JsonParser;
 import dev.galasa.framework.api.cps.internal.mocks.MockCpsServlet;
 import dev.galasa.framework.api.beans.GalasaProperty;
 import dev.galasa.framework.api.common.BaseServletTest;
+import dev.galasa.framework.api.common.ResponseBuilder;
+import dev.galasa.framework.api.common.mocks.MockEnvironment;
 import dev.galasa.framework.api.common.mocks.MockFramework;
 import dev.galasa.framework.api.common.mocks.MockHttpServletRequest;
 import dev.galasa.framework.api.common.mocks.MockHttpServletResponse;
@@ -44,6 +46,8 @@ public class CpsServletTest extends BaseServletTest {
 
 	protected void setServlet(String namespace){
 		this.servlet = new MockCpsServlet();
+        servlet.setResponseBuilder(new ResponseBuilder(new MockEnvironment()));
+
 		if (namespace != null){
 			IConfigurationPropertyStoreService cpsstore = new MockIConfigurationPropertyStoreService(namespace);
 			IFramework framework = new MockFramework(cpsstore);

--- a/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestNamespacesRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestNamespacesRoute.java
@@ -163,7 +163,6 @@ public class TestNamespacesRoute extends CpsServletTest{
 		// We expect an error back, because the API server couldn't find any Etcd store to query
 		assertThat(resp.getStatus()).isEqualTo(500);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -189,7 +188,6 @@ public class TestNamespacesRoute extends CpsServletTest{
 		// Then...
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 		assertThat(outStream.toString()).isEqualTo("[\n"+
 		"  {\n    \"name\": \"framework\",\n    \"propertiesUrl\": \"/framework/properties\",\n    \"type\": \"NORMAL\"\n  },\n"+
 		"  {\n    \"name\": \"secure\",\n    \"propertiesUrl\": \"/secure/properties\",\n    \"type\": \"SECURE\"\n  }"+
@@ -211,7 +209,6 @@ public class TestNamespacesRoute extends CpsServletTest{
 		// Then...
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 		assertThat(outStream.toString()).isEqualTo("[\n"+
 		"  {\n    \"name\": \"framework\",\n    \"propertiesUrl\": \"/framework/properties\",\n    \"type\": \"NORMAL\"\n  },\n"+
 		"  {\n    \"name\": \"secure\",\n    \"propertiesUrl\": \"/secure/properties\",\n    \"type\": \"SECURE\"\n  }"+
@@ -234,7 +231,6 @@ public class TestNamespacesRoute extends CpsServletTest{
 		// Then...
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 		assertThat(outStream.toString()).isEqualTo("[\n"+
 		"  {\n    \"name\": \"framework\",\n    \"propertiesUrl\": \"/framework/properties\",\n    \"type\": \"NORMAL\"\n  },\n"+
 		"  {\n    \"name\": \"secure\",\n    \"propertiesUrl\": \"/secure/properties\",\n    \"type\": \"SECURE\"\n  }"+
@@ -258,7 +254,6 @@ public class TestNamespacesRoute extends CpsServletTest{
 		// We expect an error back, because the API server has thrown a ConfigurationPropertyStoreException
 		assertThat(resp.getStatus()).isEqualTo(500);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -285,7 +280,6 @@ public class TestNamespacesRoute extends CpsServletTest{
 		// We expect an error back, because the API server has thrown a ConfigurationPropertyStoreException
 		assertThat(resp.getStatus()).isEqualTo(404);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -311,7 +305,6 @@ public class TestNamespacesRoute extends CpsServletTest{
 		// We expect an error back, because the API server has thrown a ConfigurationPropertyStoreException
 		assertThat(resp.getStatus()).isEqualTo(404);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -340,7 +333,6 @@ public class TestNamespacesRoute extends CpsServletTest{
 		// We expect an error back, because the API server has thrown a ConfigurationPropertyStoreException
 		assertThat(resp.getStatus()).isEqualTo(405);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -369,7 +361,6 @@ public class TestNamespacesRoute extends CpsServletTest{
 		// We expect an error back, because the API server has thrown a ConfigurationPropertyStoreException
 		assertThat(resp.getStatus()).isEqualTo(405);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -398,7 +389,6 @@ public class TestNamespacesRoute extends CpsServletTest{
 		// We expect an error back, because the API server has thrown a ConfigurationPropertyStoreException
 		assertThat(resp.getStatus()).isEqualTo(405);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),

--- a/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestPropertyRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestPropertyRoute.java
@@ -279,7 +279,6 @@ public class TestPropertyRoute extends CpsServletTest{
 		// We expect an error back, because the API server couldn't find any Etcd store to query
 		assertThat(resp.getStatus()).isEqualTo(500);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -307,7 +306,6 @@ public class TestPropertyRoute extends CpsServletTest{
 		// We expect an error back, because the API server couldn't find any Etcd store to query
 		assertThat(resp.getStatus()).isEqualTo(404);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -341,7 +339,6 @@ public class TestPropertyRoute extends CpsServletTest{
         String output = outStream.toString();
         assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 		checkJsonArrayStructure(output,properties);
         
     }
@@ -371,7 +368,6 @@ public class TestPropertyRoute extends CpsServletTest{
         String output = outStream.toString();
         assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 		checkJsonArrayStructure(output,properties);
         
     }
@@ -393,7 +389,6 @@ public class TestPropertyRoute extends CpsServletTest{
 		// We expect an error back, because the API server could find the namespace, but it was hidden
 		assertThat(resp.getStatus()==500);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -420,7 +415,6 @@ public class TestPropertyRoute extends CpsServletTest{
 		// We expect an error back, because the API server could find the namespace
 		assertThat(resp.getStatus()==500);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -599,7 +593,6 @@ public class TestPropertyRoute extends CpsServletTest{
         String output = outStream.toString();
         assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 		checkJsonArrayStructure(output,properties);
     }
 
@@ -624,7 +617,6 @@ public class TestPropertyRoute extends CpsServletTest{
         String output = outStream.toString();
         assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 		assertThat(output).isEqualTo("[]");
     }
 
@@ -652,7 +644,6 @@ public class TestPropertyRoute extends CpsServletTest{
         String output = outStream.toString();
         assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 		checkJsonArrayStructure(output,properties);
     }
 
@@ -679,7 +670,6 @@ public class TestPropertyRoute extends CpsServletTest{
         String output = outStream.toString();
         assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 		checkJsonArrayStructure(output,properties);
     }
 
@@ -704,7 +694,6 @@ public class TestPropertyRoute extends CpsServletTest{
         String output = outStream.toString();
         assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 		assertThat(output).isEqualTo("[]");
     }
 
@@ -733,7 +722,6 @@ public class TestPropertyRoute extends CpsServletTest{
         String output = outStream.toString();
         assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 		checkJsonArrayStructure(output,properties);
     }
 
@@ -761,7 +749,6 @@ public class TestPropertyRoute extends CpsServletTest{
         String output = outStream.toString();
         assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 		checkJsonArrayStructure(output,properties);
     }
 
@@ -787,7 +774,6 @@ public class TestPropertyRoute extends CpsServletTest{
         String output = outStream.toString();
         assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 		assertThat(output).isEqualTo("[]");
     }
 
@@ -816,7 +802,6 @@ public class TestPropertyRoute extends CpsServletTest{
         String output = outStream.toString();
         assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 		checkJsonArrayStructure(output,properties);
 	}
 
@@ -846,7 +831,6 @@ public class TestPropertyRoute extends CpsServletTest{
         String output = outStream.toString();
         assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 		checkJsonArrayStructure(output,properties);
     }
 
@@ -876,7 +860,6 @@ public class TestPropertyRoute extends CpsServletTest{
         String output = outStream.toString();
         assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 		checkJsonArrayStructure(output,properties);
     }
 
@@ -908,7 +891,6 @@ public class TestPropertyRoute extends CpsServletTest{
         String output = outStream.toString();
         assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 		checkJsonArrayStructure(output,properties);
     }
 
@@ -938,7 +920,6 @@ public class TestPropertyRoute extends CpsServletTest{
         String output = outStream.toString();
         assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 		checkJsonArrayStructure(output,properties);
     }
 
@@ -965,7 +946,6 @@ public class TestPropertyRoute extends CpsServletTest{
         String output = outStream.toString();
         assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 		assertThat(output).isEqualTo("[]");
     }
 
@@ -989,7 +969,6 @@ public class TestPropertyRoute extends CpsServletTest{
 		// We expect an error back, because the API server has thrown a ConfigurationPropertyStoreException
 		assertThat(resp.getStatus()).isEqualTo(405);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -1018,7 +997,6 @@ public class TestPropertyRoute extends CpsServletTest{
 		// We expect an error back, because the API server has thrown a ConfigurationPropertyStoreException
 		assertThat(resp.getStatus()).isEqualTo(405);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -1051,7 +1029,6 @@ public class TestPropertyRoute extends CpsServletTest{
 		// We expect an error back, because the API server couldn't find any Etcd store to Route
 		assertThat(resp.getStatus()).isEqualTo(500);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -1081,7 +1058,6 @@ public class TestPropertyRoute extends CpsServletTest{
 		// We expect an error back, because the API server couldn't find any Etcd store to Route
 		assertThat(resp.getStatus()).isEqualTo(500);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -1112,7 +1088,6 @@ public class TestPropertyRoute extends CpsServletTest{
         String output = outStream.toString();
         assertThat(status).isEqualTo(201);
 		assertThat(resp.getContentType()).isEqualTo("text/plain");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
         assertThat(output).isEqualTo("Successfully created property property.6 in framework");
         assertThat(checkNewPropertyInNamespace(namespace, propertyName, value)).isTrue();       
     }
@@ -1137,7 +1112,6 @@ public class TestPropertyRoute extends CpsServletTest{
         // Then...
         assertThat(resp.getStatus()).isEqualTo(404);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -1167,7 +1141,6 @@ public class TestPropertyRoute extends CpsServletTest{
         // Then...
         assertThat(resp.getStatus()).isEqualTo(404);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -1197,7 +1170,6 @@ public class TestPropertyRoute extends CpsServletTest{
         // Then...
         assertThat(resp.getStatus()).isEqualTo(404);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -1227,7 +1199,6 @@ public class TestPropertyRoute extends CpsServletTest{
         // Then...
         assertThat(resp.getStatus()).isEqualTo(404);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -1257,7 +1228,6 @@ public class TestPropertyRoute extends CpsServletTest{
         // Then...
         assertThat(resp.getStatus()).isEqualTo(404);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -1291,7 +1261,6 @@ public class TestPropertyRoute extends CpsServletTest{
         String output = outStream.toString();
         assertThat(status).isEqualTo(201);
 		assertThat(resp.getContentType()).isEqualTo("text/plain");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
         assertThat(output).isEqualTo("Successfully created property property.newproperty in c4ame6lcas5e8");
         assertThat(checkNewPropertyInNamespace(namespace, propertyName, value)).isTrue();       
     }
@@ -1320,7 +1289,6 @@ public class TestPropertyRoute extends CpsServletTest{
         String output = outStream.toString();
         assertThat(status).isEqualTo(201);
 		assertThat(resp.getContentType()).isEqualTo("text/plain");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
         assertThat(output).isEqualTo("Successfully created property property.newproperty in newnamespace");
         assertThat(checkNewPropertyInNamespace(namespace, propertyName, value)).isTrue();       
     }
@@ -1349,7 +1317,6 @@ public class TestPropertyRoute extends CpsServletTest{
         String output = outStream.toString();
         assertThat(status).isEqualTo(201);
 		assertThat(resp.getContentType()).isEqualTo("text/plain");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
         assertThat(output).isEqualTo("Successfully created property property.6 in secure");
         assertThat(checkNewPropertyInNamespace(namespace, propertyName, value)).isTrue();       
     }
@@ -1373,7 +1340,6 @@ public class TestPropertyRoute extends CpsServletTest{
         // Then...
         assertThat(resp.getStatus()).isEqualTo(404);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -1402,7 +1368,6 @@ public class TestPropertyRoute extends CpsServletTest{
         Integer status = resp.getStatus();
         assertThat(status).isEqualTo(404);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
        checkErrorStructure(
 			outStream.toString(),
 			5018,
@@ -1430,7 +1395,6 @@ public class TestPropertyRoute extends CpsServletTest{
         // Then...
         assertThat(resp.getStatus()).isEqualTo(400);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -1458,7 +1422,6 @@ public class TestPropertyRoute extends CpsServletTest{
         // Then...
         assertThat(resp.getStatus()).isEqualTo(400);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -1484,7 +1447,6 @@ public class TestPropertyRoute extends CpsServletTest{
         // Then...
         assertThat(resp.getStatus()).isEqualTo(411);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -1511,7 +1473,6 @@ public class TestPropertyRoute extends CpsServletTest{
         // Then...
         assertThat(resp.getStatus()).isEqualTo(411);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),

--- a/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestPropertyUpdateRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestPropertyUpdateRoute.java
@@ -214,7 +214,6 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
 		// We expect an error back, because the API server couldn't find any Etcd store to Route
 		assertThat(resp.getStatus()).isEqualTo(404);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -240,7 +239,6 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
 		// We expect an error back, because the API server couldn't find any Etcd store to Route
 		assertThat(resp.getStatus()).isEqualTo(404);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -268,7 +266,6 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
         String output = outStream.toString();
         assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 		assertThat(output).isEqualTo(expectedJson);
     }
 
@@ -291,7 +288,6 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
         String output = outStream.toString();
         assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 		assertThat(output).isEqualTo(expectedJson);
     }
 
@@ -312,7 +308,6 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
         // We expect data back
         assertThat(resp.getStatus()).isEqualTo(404);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -341,7 +336,6 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
         String output = outStream.toString();
         assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 		assertThat(output).isEqualTo(expectedJson);
     }
 
@@ -362,7 +356,6 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
         String output = outStream.toString();
         assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 		assertThat(output).isEqualTo("[]");
     }
 
@@ -383,7 +376,6 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
         String output = outStream.toString();
         assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 		assertThat(output).isEqualTo("[]");
     }
 
@@ -404,7 +396,6 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
         // We expect data back
         assertThat(resp.getStatus()).isEqualTo(400);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -431,7 +422,6 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
         // We expect data back
         assertThat(resp.getStatus()).isEqualTo(404);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -458,7 +448,6 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
         // We expect data back
         assertThat(resp.getStatus()).isEqualTo(400);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -490,7 +479,6 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
 		// We expect an error back, because the API server couldn't find any Etcd store to Route
 		assertThat(resp.getStatus()).isEqualTo(404);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -517,7 +505,6 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
 		// We expect an error back, because the API server couldn't find any Etcd store to Route
 		assertThat(resp.getStatus()).isEqualTo(404);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -548,7 +535,6 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
         String output = outStream.toString();
         assertThat(status).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("text/plain");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
         assertThat(output).isEqualTo("Successfully updated property property.5 in framework");
         assertThat(checkNewPropertyInNamespace(namespace, propertyName, value)).isTrue();       
     }
@@ -575,7 +561,6 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
         String output = outStream.toString();
         assertThat(status).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("text/plain");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
         assertThat(output).isEqualTo("Successfully updated property property.5 in secure");
         assertThat(checkNewPropertyInNamespace(namespace, propertyName, value)).isTrue();
     }
@@ -601,7 +586,6 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
         // We expect data back
         assertThat(resp.getStatus()==500);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -632,7 +616,6 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
         Integer status = resp.getStatus();
         assertThat(status).isEqualTo(404);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
        checkErrorStructure(
 			outStream.toString(),
 			5017,
@@ -660,7 +643,6 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
         // Then...
         assertThat(resp.getStatus()).isEqualTo(400);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -687,7 +669,6 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
         // Then...
         assertThat(resp.getStatus()).isEqualTo(411);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -715,7 +696,6 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
         // Then...
         assertThat(resp.getStatus()).isEqualTo(411);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -746,7 +726,6 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
 		// We expect an error back, because the API server couldn't find any Etcd store to Route
 		assertThat(resp.getStatus()).isEqualTo(500);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
         
 		checkErrorStructure(
 			outStream.toString(),
@@ -773,7 +752,6 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
         // We expect data back
         assertThat(resp.getStatus()==500);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -800,7 +778,6 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
 		// We expect an error back, because the API server couldn't find any Etcd store to Route
 		assertThat(resp.getStatus()).isEqualTo(500);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
         
 		checkErrorStructure(
 			outStream.toString(),
@@ -827,7 +804,6 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
 		String output = outStream.toString();
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("text/plain");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 		assertThat(output).isEqualTo("Successfully deleted property bad.property in framework");
         
     }
@@ -853,7 +829,6 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
         String output = outStream.toString();
         assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("text/plain");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
         assertThat(output).isEqualTo("Successfully deleted property property.1 in framework");
         assertThat(checkNewPropertyInNamespace(namespace, propertyName, value)).isFalse(); 
     }
@@ -878,7 +853,6 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
 		String output = outStream.toString();
         assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("text/plain");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 		assertThat(output).isEqualTo("Successfully deleted property property.1 in secure");
 		assertThat(checkNewPropertyInNamespace(namespace, propertyName, value)).isFalse(); 
     }
@@ -907,7 +881,6 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
 		// We expect an error back, because the API server has thrown a ConfigurationPropertyStoreException
 		assertThat(resp.getStatus()).isEqualTo(405);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),

--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RequestorRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RequestorRoute.java
@@ -45,7 +45,7 @@ public class RequestorRoute extends RunsRoute {
     throws ServletException, IOException, FrameworkException {
         this.sortQueryParameterChecker = new RasQueryParameters(queryParams);
         String outputString = retrieveRequestors(queryParams);
-        return getResponseBuilder().buildResponse(response, "application/json", outputString, HttpServletResponse.SC_OK); 
+        return getResponseBuilder().buildResponse(req, response, "application/json", outputString, HttpServletResponse.SC_OK); 
     }
     
     private String retrieveRequestors(QueryParameters params) throws InternalServletException, ResultArchiveStoreException{

--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/ResultNamesRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/ResultNamesRoute.java
@@ -46,7 +46,7 @@ public class ResultNamesRoute extends RunsRoute {
     public HttpServletResponse handleGetRequest(String pathInfo, QueryParameters queryParams,HttpServletRequest req, HttpServletResponse response) 
 	throws ServletException, IOException, FrameworkException {
         String outputString = retrieveResults(new RasQueryParameters(queryParams));
-		return getResponseBuilder().buildResponse(response, "application/json", outputString, HttpServletResponse.SC_OK);
+		return getResponseBuilder().buildResponse(req, response, "application/json", outputString, HttpServletResponse.SC_OK);
     }
 
     public String retrieveResults (RasQueryParameters queryParams) throws ServletException, InternalServletException{

--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunArtifactsListRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunArtifactsListRoute.java
@@ -67,7 +67,7 @@ public class RunArtifactsListRoute extends RunArtifactsRoute {
         Matcher matcher = Pattern.compile(this.getPath()).matcher(pathInfo);
         matcher.matches();
         String runId = matcher.group(1);
-        return getResponseBuilder().buildResponse(res, "application/json", retrieveResults(runId), HttpServletResponse.SC_OK);
+        return getResponseBuilder().buildResponse(req, res, "application/json", retrieveResults(runId), HttpServletResponse.SC_OK);
     }
 
     private String retrieveResults(String runId) throws InternalServletException {

--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunDetailsRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunDetailsRoute.java
@@ -55,7 +55,7 @@ public class RunDetailsRoute extends RunsRoute {
       try{
          RasRunResult run = getRunFromFramework(runId);
          String outputString = gson.toJson(run);
-         return getResponseBuilder().buildResponse(res, "application/json", outputString, HttpServletResponse.SC_OK );
+         return getResponseBuilder().buildResponse(req, res, "application/json", outputString, HttpServletResponse.SC_OK );
       }catch(ResultArchiveStoreException ex){
          ServletError error = new ServletError(GAL5002_INVALID_RUN_ID,runId);
          throw new InternalServletException(error, HttpServletResponse.SC_NOT_FOUND, ex);
@@ -70,7 +70,7 @@ public class RunDetailsRoute extends RunsRoute {
       checkRequestHasContent(request);
       RunActionJson runAction = getUpdatedRunActionFromRequestBody(request);
       
-      return getResponseBuilder().buildResponse(response, "text/plain", updateRunStatus(runName, runAction), HttpServletResponse.SC_ACCEPTED);
+      return getResponseBuilder().buildResponse(request, response, "text/plain", updateRunStatus(runName, runAction), HttpServletResponse.SC_ACCEPTED);
    } 
 
 

--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunLogRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunLogRoute.java
@@ -44,7 +44,7 @@ public class RunLogRoute extends RunsRoute {
         String runId = matcher.group(1);
         String runLog = getRunlog(runId);
         if (runLog != null) {
-            return getResponseBuilder().buildResponse(res, "text/plain", runLog, HttpServletResponse.SC_OK);
+            return getResponseBuilder().buildResponse(req, res, "text/plain", runLog, HttpServletResponse.SC_OK);
         } else {
             ServletError error = new ServletError(GAL5002_INVALID_RUN_ID, runId);
             throw new InternalServletException(error, HttpServletResponse.SC_NOT_FOUND);

--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunQueryRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunQueryRoute.java
@@ -68,7 +68,7 @@ public class RunQueryRoute extends RunsRoute {
 	public HttpServletResponse handleGetRequest(String pathInfo, QueryParameters generalQueryParams, HttpServletRequest req, HttpServletResponse res) throws ServletException, IOException, FrameworkException {
 		RasQueryParameters queryParams = new RasQueryParameters(generalQueryParams);
 		String outputString = retrieveResults(queryParams);
-		return getResponseBuilder().buildResponse(res, "application/json", outputString, HttpServletResponse.SC_OK);
+		return getResponseBuilder().buildResponse(req, res, "application/json", outputString, HttpServletResponse.SC_OK);
 	}
 
 	protected String retrieveResults(

--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/TestClassesRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/TestClassesRoute.java
@@ -49,7 +49,7 @@ public class TestClassesRoute extends RunsRoute {
     throws ServletException, IOException, FrameworkException {
         this.sortQueryParameterChecker = new RasQueryParameters(queryParams);
         String outputString = TestClasses();
-        return getResponseBuilder().buildResponse(response, "application/json", outputString, HttpServletResponse.SC_OK); 
+        return getResponseBuilder().buildResponse(req, response, "application/json", outputString, HttpServletResponse.SC_OK); 
     }
     
     private String TestClasses () throws ResultArchiveStoreException, ServletException, InternalServletException {

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/mocks/MockServletBaseEnvironment.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/mocks/MockServletBaseEnvironment.java
@@ -10,7 +10,9 @@ import dev.galasa.framework.spi.IRunResult;
 
 import java.io.PrintWriter;
 
+import dev.galasa.framework.api.common.ResponseBuilder;
 import dev.galasa.framework.api.common.mocks.IServletUnderTest;
+import dev.galasa.framework.api.common.mocks.MockEnvironment;
 import dev.galasa.framework.api.common.mocks.MockFramework;
 import dev.galasa.framework.api.common.mocks.MockHttpServletRequest;
 import dev.galasa.framework.api.common.mocks.MockHttpServletResponse;
@@ -87,7 +89,9 @@ public abstract class MockServletBaseEnvironment {
     }
 
     public RasServlet getRasServlet() {
-        return (RasServlet)this.servlet;
+        RasServlet rasServlet = (RasServlet)this.servlet;
+        rasServlet.setResponseBuilder(new ResponseBuilder(new MockEnvironment()));
+        return rasServlet;
     }
 
     public void setMockInputs(List<IRunResult> mockInpResults) {

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRequestorsRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRequestorsRoute.java
@@ -283,7 +283,6 @@ public class TestRequestorsRoute extends RasServletTest{
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat( outStream.toString() ).isEqualTo(expectedJson);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
     @Test
@@ -311,7 +310,6 @@ public class TestRequestorsRoute extends RasServletTest{
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat( outStream.toString() ).isEqualTo(expectedJson);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
     @Test
@@ -339,7 +337,6 @@ public class TestRequestorsRoute extends RasServletTest{
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat( outStream.toString() ).isEqualTo(expectedJson);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
     @Test
@@ -368,7 +365,6 @@ public class TestRequestorsRoute extends RasServletTest{
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat( outStream.toString() ).isEqualTo(expectedJson);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
     @Test
@@ -397,7 +393,6 @@ public class TestRequestorsRoute extends RasServletTest{
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat( outStream.toString() ).isEqualTo(expectedJson);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
     @Test
@@ -426,7 +421,6 @@ public class TestRequestorsRoute extends RasServletTest{
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat( outStream.toString() ).isEqualTo(expectedJson);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
     @Test
@@ -455,6 +449,5 @@ public class TestRequestorsRoute extends RasServletTest{
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat( outStream.toString() ).isEqualTo(expectedJson);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 }

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestResultNamesRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestResultNamesRoute.java
@@ -267,7 +267,6 @@ public class TestResultNamesRoute extends RasServletTest{
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat( outStream.toString() ).isEqualTo(expectedJson);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
     @Test
@@ -299,7 +298,6 @@ public class TestResultNamesRoute extends RasServletTest{
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat( outStream.toString() ).isEqualTo(expectedJson);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
     @Test
@@ -334,7 +332,6 @@ public class TestResultNamesRoute extends RasServletTest{
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat( outStream.toString() ).isEqualTo(expectedJson);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
     @Test
@@ -370,7 +367,6 @@ public class TestResultNamesRoute extends RasServletTest{
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat( outStream.toString() ).isEqualTo(expectedJson);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
     @Test
@@ -406,7 +402,6 @@ public class TestResultNamesRoute extends RasServletTest{
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat( outStream.toString() ).isEqualTo(expectedJson);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
     @Test
@@ -524,6 +519,5 @@ public class TestResultNamesRoute extends RasServletTest{
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat( outStream.toString() ).isEqualTo(expectedJson);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 }

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunArtifactsDownloadServlet.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunArtifactsDownloadServlet.java
@@ -240,7 +240,6 @@ public class TestRunArtifactsDownloadServlet extends RasServletTest {
 		checkErrorStructure(outStream.toString(), 5008, "GAL5008E", artifactPath, runName);
 
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
     @Test
@@ -274,7 +273,6 @@ public class TestRunArtifactsDownloadServlet extends RasServletTest {
 		checkErrorStructure(outStream.toString(), 5009, "GAL5009E", artifactPath, runName);
 
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
     @Test
@@ -308,7 +306,6 @@ public class TestRunArtifactsDownloadServlet extends RasServletTest {
 		checkErrorStructure(outStream.toString(), 5009, "GAL5009E", artifactPath, runName);
 
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -341,7 +338,6 @@ public class TestRunArtifactsDownloadServlet extends RasServletTest {
 		checkErrorStructure(outStream.toString() , 5002 , "GAL5002E", "badRunId" );
 
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
     @Test
@@ -402,7 +398,6 @@ public class TestRunArtifactsDownloadServlet extends RasServletTest {
 		checkErrorStructure(outStream.toString(), 5009, "GAL5009E", artifactPath, runName);
 
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
     @Test

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunArtifactsListServlet.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunArtifactsListServlet.java
@@ -385,7 +385,6 @@ public class TestRunArtifactsListServlet extends RasServletTest {
 		assertThat(jsonString).contains(expectedJson);
 
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -461,7 +460,6 @@ public class TestRunArtifactsListServlet extends RasServletTest {
         checkRootArtifactsJson(jsonString);
 
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
     @Test
@@ -527,7 +525,6 @@ public class TestRunArtifactsListServlet extends RasServletTest {
 		assertThat(jsonString).contains(expectedJson);
 
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -559,6 +556,5 @@ public class TestRunArtifactsListServlet extends RasServletTest {
 		checkErrorStructure(outStream.toString() , 5002 , "GAL5002E", "badRunId" );
 
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 }

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunDetailsRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunDetailsRoute.java
@@ -260,7 +260,6 @@ public class TestRunDetailsRoute extends RasServletTest {
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat( outStream.toString() ).isEqualTo(expectedJson);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
     @Test
@@ -289,7 +288,6 @@ public class TestRunDetailsRoute extends RasServletTest {
         assertThat(resp.getStatus()).isEqualTo(404);
         checkErrorStructure(outStream.toString() , 5002 , "GAL5002E", runId );
         assertThat( resp.getContentType()).isEqualTo("application/json");
-        assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
     @Test
@@ -318,7 +316,6 @@ public class TestRunDetailsRoute extends RasServletTest {
         assertThat(resp.getStatus()).isEqualTo(500);
         checkErrorStructure(outStream.toString() , 5000 , "GAL5000E" );
         assertThat( resp.getContentType()).isEqualTo("application/json");
-        assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	/*

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunLogRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunLogRoute.java
@@ -237,7 +237,6 @@ public class TestRunLogRoute extends RasServletTest {
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(outStream.toString()).isEqualTo(runLog);
 		assertThat(resp.getContentType()).isEqualTo("text/plain");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -261,7 +260,6 @@ public class TestRunLogRoute extends RasServletTest {
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(outStream.toString()).isEmpty();
 		assertThat(resp.getContentType()).isEqualTo("text/plain");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -290,7 +288,6 @@ public class TestRunLogRoute extends RasServletTest {
 		assertThat(resp.getStatus()).isEqualTo(404);
 		checkErrorStructure(outStream.toString() , 5002 , "GAL5002E", "runA");
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -320,6 +317,5 @@ public class TestRunLogRoute extends RasServletTest {
 		assertThat(resp.getStatus()).isEqualTo(404);
 		checkErrorStructure(outStream.toString() , 5002 , "GAL5002E", "badRunId" );
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 }

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunQuery.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunQuery.java
@@ -207,7 +207,6 @@ public class TestRunQuery extends RasServletTest {
 		);
 
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	private boolean checkIfSameOrder(String[] sortedList, String expectedResultString, String sortedElement){
@@ -419,7 +418,6 @@ public class TestRunQuery extends RasServletTest {
 		// We expect an error back, because the API server couldn't find any RAS database to query
 		assertThat(resp.getStatus()==500);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -448,7 +446,6 @@ public class TestRunQuery extends RasServletTest {
 		// We expect an error back, because the API server couldn't find any RAS database to query
 		assertThat(resp.getStatus()==500);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -486,7 +483,6 @@ public class TestRunQuery extends RasServletTest {
 		assertThat(resp.getStatus()==200);
 		assertThat( outStream.toString() ).isEqualTo(expectedJson);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -524,7 +520,6 @@ public class TestRunQuery extends RasServletTest {
 		assertThat(resp.getStatus()==200);
 		assertThat( outStream.toString() ).isEqualTo(expectedJson);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -569,7 +564,6 @@ public class TestRunQuery extends RasServletTest {
 		assertThat(resp.getStatus()==200);
 		assertThat( outStream.toString() ).isEqualTo(expectedJson);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -623,7 +617,6 @@ public class TestRunQuery extends RasServletTest {
 		String[] sortedList = (expectedRunNames).toArray(new String[expectedRunNames.size()]);
 		assertThat(checkIfSameOrder(sortedList, outStream.toString(), "runName"));
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -668,7 +661,6 @@ public class TestRunQuery extends RasServletTest {
 		assertThat(resp.getStatus()==200);
 		assertThat( outStream.toString() ).isEqualTo(expectedJson);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -697,7 +689,6 @@ public class TestRunQuery extends RasServletTest {
 		assertThat(resp.getStatus()==400);
 		assertThat( outStream.toString() ).contains("GAL5010E: Error parsing the query parameters. from time is a mandatory field if no runname is supplied.");
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -731,7 +722,6 @@ public class TestRunQuery extends RasServletTest {
 		String[] sortedList = (expectedRunNames).toArray(new String[expectedRunNames.size()]);
 		assertThat(checkIfSameOrder(sortedList, outStream.toString(), "runName"));
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -769,7 +759,6 @@ public class TestRunQuery extends RasServletTest {
 		assertThat(resp.getStatus()==200);
 		assertThat( outStream.toString() ).isEqualTo(expectedJson);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -807,7 +796,6 @@ public class TestRunQuery extends RasServletTest {
 		assertThat(resp.getStatus()==200);
 		assertThat( outStream.toString() ).isEqualTo(expectedJson);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -844,7 +832,6 @@ public class TestRunQuery extends RasServletTest {
 		assertThat(resp.getStatus()==200);
 		assertThat( outStream.toString() ).isEqualTo(expectedJson);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -901,7 +888,6 @@ public class TestRunQuery extends RasServletTest {
 		String[] sortedList = (expectedRunNames).toArray(new String[expectedRunNames.size()]);
 		assertThat(checkIfSameOrder(sortedList, outStream.toString(), "runName"));
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -960,7 +946,6 @@ public class TestRunQuery extends RasServletTest {
 		String[] sortedList = (expectedRunNames).toArray(new String[expectedRunNames.size()]);
 		assertThat(checkIfSameOrder(sortedList, outStream.toString(), "runName"));
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -1010,7 +995,6 @@ public class TestRunQuery extends RasServletTest {
 		assertThat(resp.getStatus()==200);
 		assertThat( outStream.toString() ).isEqualTo(expectedJson);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -1039,7 +1023,6 @@ public class TestRunQuery extends RasServletTest {
 		checkErrorStructure(outStream.toString(), 5004, "GAL5004E: ", "Error retrieving page.");
 
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -1074,7 +1057,6 @@ public class TestRunQuery extends RasServletTest {
 		);
 
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -1109,7 +1091,6 @@ public class TestRunQuery extends RasServletTest {
 		);
 
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -1145,7 +1126,6 @@ public class TestRunQuery extends RasServletTest {
 		//Then...
 		assertThat(resp.getStatus()==404);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -1251,7 +1231,6 @@ public class TestRunQuery extends RasServletTest {
 		String expectedJson = generateExpectedJson(mockInputRunResults,pageSize, pageNo);
 		assertThat(resp.getStatus()==200);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
  		assertThat( outStream.toString() ).isEqualTo(expectedJson);
 	}
 
@@ -1286,7 +1265,6 @@ public class TestRunQuery extends RasServletTest {
 		String expectedJson = generateExpectedJson(mockInputRunResults,pageSize, pageNo);
 		assertThat(resp.getStatus()==200);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
  		assertThat( outStream.toString() ).isEqualTo(expectedJson);
 	}
 
@@ -1395,7 +1373,6 @@ public class TestRunQuery extends RasServletTest {
 		assertThat( outStream.toString() ).contains(expectedRunNames);
 		assertThat( outStream.toString() ).doesNotContain(excludedRunNames);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -1440,7 +1417,6 @@ public class TestRunQuery extends RasServletTest {
 		String[] sortedList = (expectedRunNames).toArray(new String[expectedRunNames.size()]);
 		assertThat(checkIfSameOrder(sortedList, outStream.toString(), "runName"));
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -1485,7 +1461,6 @@ public class TestRunQuery extends RasServletTest {
 		String[] sortedList = (expectedRunNames).toArray(new String[expectedRunNames.size()]);
 		assertThat(checkIfSameOrder(sortedList, outStream.toString(), "runName"));
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -1530,7 +1505,6 @@ public class TestRunQuery extends RasServletTest {
 		String[] sortedList = (expectedRunNames).toArray(new String[expectedRunNames.size()]);
 		assertThat(checkIfSameOrder(sortedList, outStream.toString(), "runName"));
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -1575,7 +1549,6 @@ public class TestRunQuery extends RasServletTest {
 		String[] sortedList = (expectedRunNames).toArray(new String[expectedRunNames.size()]);
 		assertThat(checkIfSameOrder(sortedList, outStream.toString(), "runName"));
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -1616,7 +1589,6 @@ public class TestRunQuery extends RasServletTest {
 		String[] sortedList = (expectedRunNames).toArray(new String[expectedRunNames.size()]);
 		assertThat(checkIfSameOrder(sortedList, outStream.toString(), "runName"));
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -1661,7 +1633,6 @@ public class TestRunQuery extends RasServletTest {
 		String[] sortedList = (expectedRunNames).toArray(new String[expectedRunNames.size()]);
 		assertThat(checkIfSameOrder(sortedList, outStream.toString(), "runName"));
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -1696,7 +1667,6 @@ public class TestRunQuery extends RasServletTest {
 		assertThat(resp.getStatus()==500);
 		assertThat( outStream.toString() ).contains("GAL5011E:","badsort");
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -1731,7 +1701,6 @@ public class TestRunQuery extends RasServletTest {
 		assertThat(resp.getStatus()==500);
 		assertThat( outStream.toString() ).contains("GAL5011E:","to:erroneoussort");
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -1771,7 +1740,6 @@ public class TestRunQuery extends RasServletTest {
 		String[] sortedList = (expectedRunNames).toArray(new String[expectedRunNames.size()]);
 		assertThat(checkIfSameOrder(sortedList, outStream.toString(), "runName"));
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -1813,7 +1781,6 @@ public class TestRunQuery extends RasServletTest {
 		assertThat( outStream.toString() ).contains(expectedRunNames);
 		assertThat( outStream.toString() ).doesNotContain(excludedRunNames);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -1857,7 +1824,6 @@ public class TestRunQuery extends RasServletTest {
 		assertThat( outStream.toString() ).contains(expectedRunNames);
 		assertThat( outStream.toString() ).doesNotContain(excludedRunNames);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -1901,7 +1867,6 @@ public class TestRunQuery extends RasServletTest {
 		assertThat( outStream.toString() ).contains(expectedRunNames);
 		assertThat( outStream.toString() ).doesNotContain(excludedRunNames);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -1941,7 +1906,6 @@ public class TestRunQuery extends RasServletTest {
 		assertThat(resp.getStatus()==200);
 		assertThat( outStream.toString() ).isEqualTo(expectedRunNames);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -1983,7 +1947,6 @@ public class TestRunQuery extends RasServletTest {
 		assertThat(resp.getStatus()==200);
 		assertThat( outStream.toString() ).isEqualTo(expectedRunNames);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test
@@ -2025,7 +1988,6 @@ public class TestRunQuery extends RasServletTest {
 		assertThat(resp.getStatus()==200);
 		assertThat( outStream.toString() ).isEqualTo(expectedRunNames);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	@Test

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestTestClassesRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestTestClassesRoute.java
@@ -298,7 +298,6 @@ public class TestTestClassesRoute extends RasServletTest{
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat( outStream.toString() ).isEqualTo(expectedJson);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
 	    @Test
@@ -326,7 +325,6 @@ public class TestTestClassesRoute extends RasServletTest{
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat( outStream.toString() ).isEqualTo(expectedJson);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
     @Test
@@ -354,7 +352,6 @@ public class TestTestClassesRoute extends RasServletTest{
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat( outStream.toString() ).isEqualTo(expectedJson);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
     @Test
@@ -382,7 +379,6 @@ public class TestTestClassesRoute extends RasServletTest{
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat( outStream.toString() ).isEqualTo(expectedJson);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 
     @Test
@@ -490,6 +486,5 @@ public class TestTestClassesRoute extends RasServletTest{
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat( outStream.toString() ).isEqualTo(expectedJson);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
-		assertThat( resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 	}
 }

--- a/galasa-parent/dev.galasa.framework.api.resources/src/main/java/dev/galasa/framework/api/resources/routes/ResourcesRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.resources/src/main/java/dev/galasa/framework/api/resources/routes/ResourcesRoute.java
@@ -66,9 +66,9 @@ public class ResourcesRoute  extends BaseRoute{
         body.close();
         List<String> errorsList = processRequest(jsonBody);
         if (errorsList.size() >0){
-            response = getResponseBuilder().buildResponse(response, "application/json", gson.toJson(errorsList), HttpServletResponse.SC_BAD_REQUEST);
+            response = getResponseBuilder().buildResponse(request, response, "application/json", gson.toJson(errorsList), HttpServletResponse.SC_BAD_REQUEST);
         } else {
-            response = getResponseBuilder().buildResponse(response, "application/json", "", HttpServletResponse.SC_OK);
+            response = getResponseBuilder().buildResponse(request, response, "application/json", "", HttpServletResponse.SC_OK);
         }
         errors.clear();
         return response;

--- a/galasa-parent/dev.galasa.framework.api.resources/src/test/java/dev/galasa/framework/api/resources/ResourcesServletTest.java
+++ b/galasa-parent/dev.galasa.framework.api.resources/src/test/java/dev/galasa/framework/api/resources/ResourcesServletTest.java
@@ -18,6 +18,8 @@ import javax.servlet.http.HttpServletResponse;
 import javax.validation.constraints.NotNull;
 
 import dev.galasa.framework.api.common.BaseServletTest;
+import dev.galasa.framework.api.common.ResponseBuilder;
+import dev.galasa.framework.api.common.mocks.MockEnvironment;
 import dev.galasa.framework.api.common.mocks.MockFramework;
 import dev.galasa.framework.api.common.mocks.MockHttpServletRequest;
 import dev.galasa.framework.api.common.mocks.MockHttpServletResponse;
@@ -51,6 +53,8 @@ public class ResourcesServletTest extends BaseServletTest {
 
 	protected void setServlet(String namespace){
 		this.servlet = new MockResourcesServlet();
+        servlet.setResponseBuilder(new ResponseBuilder(new MockEnvironment()));
+
 		IConfigurationPropertyStoreService cpsstore;
 		if (namespace != null){
 			cpsstore = new MockIConfigurationPropertyStoreService(namespace);

--- a/galasa-parent/dev.galasa.framework.api.resources/src/test/java/dev/galasa/framework/api/resources/routes/TestResourcesRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.resources/src/test/java/dev/galasa/framework/api/resources/routes/TestResourcesRoute.java
@@ -823,7 +823,6 @@ public class TestResourcesRoute extends ResourcesServletTest{
         Integer status = resp.getStatus();
         assertThat(status).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
         checkPropertyInNamespace(namespace, propertyname, value);
     }
 
@@ -848,7 +847,6 @@ public class TestResourcesRoute extends ResourcesServletTest{
         Integer status = resp.getStatus();
         assertThat(status).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
         checkPropertyInNamespace(namespace, propertyname, value);
     }
 
@@ -875,7 +873,6 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String output = outStream.toString();
         assertThat(status).isEqualTo(400);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
         assertThat(output).contains("GAL5017E: Error occured when trying to access property 'property.name'. The property does not exist.");
         checkPropertyNotInNamespace(namespace, propertyname, value);
     }
@@ -906,7 +903,6 @@ public class TestResourcesRoute extends ResourcesServletTest{
         Integer status = resp.getStatus();
         assertThat(status).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
         checkPropertyInNamespace(namespace, propertyname, value);
         checkPropertyInNamespace(namespace, propertynametwo, valuetwo);
     }
@@ -932,7 +928,6 @@ public class TestResourcesRoute extends ResourcesServletTest{
         Integer status = resp.getStatus();
         assertThat(status).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
         checkPropertyInNamespace(namespace, propertyname, value);
     }
 
@@ -959,7 +954,6 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String output = outStream.toString();
         assertThat(status).isEqualTo(400);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
         assertThat(output).contains("The property name provided already exists");
         checkPropertyNotInNamespace(namespace, propertyname, value);
     }
@@ -985,7 +979,6 @@ public class TestResourcesRoute extends ResourcesServletTest{
         Integer status = resp.getStatus();
         assertThat(status).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
         checkPropertyInNamespace(namespace, propertyname, value);
     }
 
@@ -1015,7 +1008,6 @@ public class TestResourcesRoute extends ResourcesServletTest{
         Integer status = resp.getStatus();
         assertThat(status).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
         checkPropertyInNamespace(namespace, propertyname, value);
         checkPropertyInNamespace(namespace, propertynametwo, valuetwo);
     }
@@ -1046,7 +1038,6 @@ public class TestResourcesRoute extends ResourcesServletTest{
         Integer status = resp.getStatus();
         assertThat(status).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
         checkPropertyInNamespace(namespace, propertyname, value);
         checkPropertyInNamespace(namespace, propertynametwo, valuetwo);
     }
@@ -1072,7 +1063,6 @@ public class TestResourcesRoute extends ResourcesServletTest{
         Integer status = resp.getStatus();
         assertThat(status).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
         checkPropertyNotInNamespace(namespace, propertyname, value);
     }
 
@@ -1102,7 +1092,6 @@ public class TestResourcesRoute extends ResourcesServletTest{
         Integer status = resp.getStatus();
         assertThat(status).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
         checkPropertyNotInNamespace(namespace, propertyname, value);
         checkPropertyNotInNamespace(namespace, propertynametwo, valuetwo);
     }
@@ -1128,7 +1117,6 @@ public class TestResourcesRoute extends ResourcesServletTest{
         Integer status = resp.getStatus();
         assertThat(status).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
         checkPropertyNotInNamespace(namespace, propertyname, value);
     }
 
@@ -1158,7 +1146,6 @@ public class TestResourcesRoute extends ResourcesServletTest{
         Integer status = resp.getStatus();
         assertThat(status).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
         checkPropertyNotInNamespace(namespace, propertyname, value);
         checkPropertyNotInNamespace(namespace, propertynametwo, valuetwo);
     }
@@ -1189,7 +1176,6 @@ public class TestResourcesRoute extends ResourcesServletTest{
         Integer status = resp.getStatus();
         assertThat(status).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
         checkPropertyNotInNamespace(namespace, propertyname, value);
         checkPropertyNotInNamespace(namespace, propertynametwo, valuetwo);
     }
@@ -1217,7 +1203,6 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String output = outStream.toString();
         assertThat(status).isEqualTo(400);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
         assertThat(output).contains("GAL5030E: Error occured when trying to delete Property 'property.1'. Report the problem to your Galasa Ecosystem owner.");
         checkPropertyNotInNamespace(namespace, propertyname, value);
     }
@@ -1249,8 +1234,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         Integer status = resp.getStatus();
         String output = outStream.toString();
         assertThat(status).isEqualTo(400);
-		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*"); 
+		assertThat(resp.getContentType()).isEqualTo("application/json"); 
         assertThat(output).contains("GAL5030E: Error occured when trying to delete Property 'property.1'. Report the problem to your Galasa Ecosystem owner.");
         assertThat(output).contains("GAL5030E: Error occured when trying to delete Property 'property.5'. Report the problem to your Galasa Ecosystem owner.");
         checkPropertyNotInNamespace(namespace, propertyname, value);

--- a/galasa-parent/dev.galasa.framework.api.runs/src/main/java/dev/galasa/framework/api/runs/routes/GroupRunsRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.runs/src/main/java/dev/galasa/framework/api/runs/routes/GroupRunsRoute.java
@@ -47,7 +47,7 @@ public class GroupRunsRoute extends GroupRuns{
         List<IRun> runs = getRuns(groupName.substring(1));
         if (runs != null){
             ScheduleStatus serializedRuns = serializeRuns(runs);
-            return getResponseBuilder().buildResponse(response, "application/json", gson.toJson(serializedRuns), HttpServletResponse.SC_OK);
+            return getResponseBuilder().buildResponse(request, response, "application/json", gson.toJson(serializedRuns), HttpServletResponse.SC_OK);
         }else{
             ServletError error = new ServletError(GAL5019_UNABLE_TO_RETRIEVE_RUNS, groupName);
             throw new InternalServletException(error, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
@@ -68,7 +68,7 @@ public class GroupRunsRoute extends GroupRuns{
             requestor = null;
         }
         ScheduleStatus scheduleStatus = scheduleRun(scheduleRequest, groupName.substring(1), requestor);
-        return getResponseBuilder().buildResponse(response, "application/json", gson.toJson(scheduleStatus), HttpServletResponse.SC_CREATED);
+        return getResponseBuilder().buildResponse(request, response, "application/json", gson.toJson(scheduleStatus), HttpServletResponse.SC_CREATED);
     }
 
 }

--- a/galasa-parent/dev.galasa.framework.api.runs/src/test/java/dev/galasa/framework/api/runs/RunsServletTest.java
+++ b/galasa-parent/dev.galasa.framework.api.runs/src/test/java/dev/galasa/framework/api/runs/RunsServletTest.java
@@ -16,6 +16,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import dev.galasa.framework.api.common.BaseServletTest;
 import dev.galasa.framework.api.common.EnvironmentVariables;
+import dev.galasa.framework.api.common.ResponseBuilder;
 import dev.galasa.framework.api.common.mocks.MockEnvironment;
 import dev.galasa.framework.api.common.mocks.MockFramework;
 import dev.galasa.framework.api.common.mocks.MockHttpServletRequest;
@@ -44,6 +45,8 @@ public class RunsServletTest extends BaseServletTest {
         mockEnv.setenv(EnvironmentVariables.GALASA_USERNAME_CLAIMS, "preferred_username,name,sub");
 
         this.servlet = new MockRunsServlet(mockEnv);
+        servlet.setResponseBuilder(new ResponseBuilder(mockEnv));
+
         ServletOutputStream outStream = new MockServletOutputStream();
         PrintWriter writer = new PrintWriter(outStream);
         this.resp = new MockHttpServletResponse(writer, outStream);

--- a/galasa-parent/dev.galasa.framework.api.runs/src/test/java/dev/galasa/framework/api/runs/routes/TestGroupRunsRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.runs/src/test/java/dev/galasa/framework/api/runs/routes/TestGroupRunsRoute.java
@@ -171,7 +171,6 @@ public class TestGroupRunsRoute extends RunsServletTest {
         //Then...
         assertThat(resp.getStatus()).isEqualTo(500);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),
@@ -384,7 +383,6 @@ public class TestGroupRunsRoute extends RunsServletTest {
         //Then...
         assertThat(resp.getStatus()).isEqualTo(500);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(resp.getHeader("Access-Control-Allow-Origin")).isEqualTo("*");
 
 		checkErrorStructure(
 			outStream.toString(),


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1895

## Changes
- Added a `GALASA_ALLOWED_ORIGINS` env variable that is used to check request origins against before setting the `Access-Control-Allow-Origin` header
  - If a request's origin matches an allowed origin, then that origin will be used as the value for the `Access-Control-Allow-Origin` header
  - If a request's origin doesn't match or if a request doesn't have an origin, then the `Access-Control-Allow-Origin` header will not be added to the response
- Updated unit tests to mock out the environment used to retrieve the `GALASA_ALLOWED_ORIGINS` variable