### PR TITLE
Add more validation to origin matcher

### DIFF
--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensRoute.java
@@ -120,7 +120,7 @@ public class AuthTokensRoute extends BaseRoute {
         JsonObject responseJson = new JsonObject();
         try {
             // Send a POST request to Dex's /token endpoint
-            JsonObject tokenResponseBodyJson = sendTokenPost(request, requestPayload);
+            JsonObject tokenResponseBodyJson = sendTokenPost(requestPayload);
 
             // Return the JWT and refresh token as the servlet's response
             if (tokenResponseBodyJson != null && tokenResponseBodyJson.has(ID_TOKEN_KEY) && tokenResponseBodyJson.has(REFRESH_TOKEN_KEY)) {
@@ -196,7 +196,7 @@ public class AuthTokensRoute extends BaseRoute {
      * @param requestBodyJson the request payload containing the required parameters
      *                        for the /token endpoint
      */
-    private JsonObject sendTokenPost(HttpServletRequest request, TokenPayload requestBodyJson)
+    private JsonObject sendTokenPost(TokenPayload requestBodyJson)
             throws IOException, InterruptedException, InternalServletException {
         String refreshToken = requestBodyJson.getRefreshToken();
         String clientId = requestBodyJson.getClientId();

--- a/galasa-parent/dev.galasa.framework.api.common/src/test/java/dev/galasa/framework/api/common/TestResponseBuilder.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/test/java/dev/galasa/framework/api/common/TestResponseBuilder.java
@@ -178,6 +178,29 @@ public class TestResponseBuilder {
     }
 
     @Test
+    public void testBuildResponseHeadersWithHttpSplittingDoesNotSetCorsHeader() throws Exception {
+        // Given...
+        String origin = "http://my-server.com\n\rContent-Type: text/plain";
+
+        MockEnvironment mockEnv = new MockEnvironment();
+        mockEnv.setenv(EnvironmentVariables.GALASA_ALLOWED_ORIGINS, "*");
+        ResponseBuilder responseBuilder = new ResponseBuilder(mockEnv);
+
+        Map<String, String> reqHeaders = Map.of("Origin", origin);
+        MockHttpServletRequest req = new MockHttpServletRequest("/", reqHeaders);
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        String contentType = "application/json";
+
+        // When...
+        HttpServletResponse actualResp = responseBuilder.buildResponseHeaders(req, resp, contentType, HttpServletResponse.SC_OK);
+
+        // Then...
+        assertThat(actualResp.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+        assertThat(actualResp.getContentType()).isEqualTo(contentType);
+        assertThat(actualResp.getHeader("Access-Control-Allow-Origin")).isNull();
+    }
+
+    @Test
     public void testBuildResponseHeadersWithNoAllowedOriginsDoesNotSetCorsHeader() throws Exception {
         // Given...
         String origin = "https://my.server2.com";

--- a/galasa-parent/dev.galasa.framework.api.common/src/test/java/dev/galasa/framework/api/common/TestResponseBuilder.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/test/java/dev/galasa/framework/api/common/TestResponseBuilder.java
@@ -155,6 +155,29 @@ public class TestResponseBuilder {
     }
 
     @Test
+    public void testBuildResponseHeadersWithInvalidOriginDoesNotSetCorsHeader() throws Exception {
+        // Given...
+        String origin = "not a valid origin";
+
+        MockEnvironment mockEnv = new MockEnvironment();
+        mockEnv.setenv(EnvironmentVariables.GALASA_ALLOWED_ORIGINS, "*");
+        ResponseBuilder responseBuilder = new ResponseBuilder(mockEnv);
+
+        Map<String, String> reqHeaders = Map.of("Origin", origin);
+        MockHttpServletRequest req = new MockHttpServletRequest("/", reqHeaders);
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        String contentType = "application/json";
+
+        // When...
+        HttpServletResponse actualResp = responseBuilder.buildResponseHeaders(req, resp, contentType, HttpServletResponse.SC_OK);
+
+        // Then...
+        assertThat(actualResp.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+        assertThat(actualResp.getContentType()).isEqualTo(contentType);
+        assertThat(actualResp.getHeader("Access-Control-Allow-Origin")).isNull();
+    }
+
+    @Test
     public void testBuildResponseHeadersWithNoAllowedOriginsDoesNotSetCorsHeader() throws Exception {
         // Given...
         String origin = "https://my.server2.com";


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1895

## Changes
- Add validation to check if the value of the "Origin" header in a request is a valid URI
- Added tests around invalid URI and attempted HTTP splitting to set other HTTP headers
- Removed unused `request` parameter in `sendTokenPost` methods