### PR TITLE
Validate auth request payloads before sending requests to Dex

### DIFF
--- a/galasa-parent/dev.galasa.framework.api.authentication/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api.authentication/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 description = 'Galasa Authentication API'
 
-version = '0.34.0'
+version = '0.35.0'
 
 dependencies {
     implementation project(':dev.galasa.framework')

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/OidcProvider.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/OidcProvider.java
@@ -181,9 +181,9 @@ public class OidcProvider implements IOidcProvider {
         // Convert the request's JSON object to the application/x-www-form-urlencoded content type
         // as required by the /token endpoint.
         sbRequestBody.append("grant_type=refresh_token");
-        sbRequestBody.append("&client_id=" + URLEncoder.encode(clientId, StandardCharsets.UTF_8));
-        sbRequestBody.append("&client_secret=" + URLEncoder.encode(clientSecret, StandardCharsets.UTF_8));
-        sbRequestBody.append("&refresh_token=" + URLEncoder.encode(refreshToken, StandardCharsets.UTF_8));
+        sbRequestBody.append("&client_id=" + clientId);
+        sbRequestBody.append("&client_secret=" + clientSecret);
+        sbRequestBody.append("&refresh_token=" + refreshToken);
 
         logger.info("Sending POST request to '" + tokenEndpoint + "' for client with ID '" + clientId + "'");
 
@@ -201,9 +201,9 @@ public class OidcProvider implements IOidcProvider {
         // Convert the request's JSON object to the application/x-www-form-urlencoded content type
         // as required by the /token endpoint.
         sbRequestBody.append("grant_type=authorization_code");
-        sbRequestBody.append("&code=" + URLEncoder.encode(authCode, StandardCharsets.UTF_8));
-        sbRequestBody.append("&client_id=" + URLEncoder.encode(clientId, StandardCharsets.UTF_8));
-        sbRequestBody.append("&client_secret=" + URLEncoder.encode(clientSecret, StandardCharsets.UTF_8));
+        sbRequestBody.append("&code=" + authCode);
+        sbRequestBody.append("&client_id=" + clientId);
+        sbRequestBody.append("&client_secret=" + clientSecret);
         sbRequestBody.append("&redirect_uri=" + URLEncoder.encode(redirectUri, StandardCharsets.UTF_8));
 
         logger.info("Sending POST request to '" + tokenEndpoint + "' for client with ID '" + clientId + "'");

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/TokenPayloadValidator.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/TokenPayloadValidator.java
@@ -16,12 +16,6 @@ import javax.servlet.http.HttpServletResponse;
 
 public class TokenPayloadValidator implements IBeanValidator<TokenPayload> {
 
-    // Regex to match a non-empty string that can contain only:
-    // - Alphanumeric characters
-    // - '-' (dashes)
-    // - '_' (underscores)
-    private static final String ALPHANUM_DASHES_PATTERN = "^[a-zA-Z0-9\\-_]+$";
-
     @Override
     public void validate(TokenPayload tokenPayload) throws InternalServletException {
         boolean isValid = false;
@@ -30,10 +24,10 @@ public class TokenPayloadValidator implements IBeanValidator<TokenPayload> {
             String refreshToken = tokenPayload.getRefreshToken();
             String authCode = tokenPayload.getCode();
     
-            if (clientId != null && clientId.matches(ALPHANUM_DASHES_PATTERN)) {
+            if (clientId != null && isAlphanumWithDashes(clientId)) {
                 // The refresh token and authorization code parameters are mutually exclusive
-                isValid = ((refreshToken != null && refreshToken.matches(ALPHANUM_DASHES_PATTERN) && authCode == null)
-                    || (authCode != null && authCode.matches(ALPHANUM_DASHES_PATTERN) && refreshToken == null));
+                isValid = ((refreshToken != null && isAlphanumWithDashes(refreshToken) && authCode == null)
+                    || (authCode != null && isAlphanumWithDashes(authCode) && refreshToken == null));
             }
         }
 
@@ -41,5 +35,22 @@ public class TokenPayloadValidator implements IBeanValidator<TokenPayload> {
             ServletError error = new ServletError(GAL5062_INVALID_TOKEN_REQUEST_BODY);
             throw new InternalServletException(error, HttpServletResponse.SC_BAD_REQUEST);
         }
+    }
+
+    /**
+     * Checks whether a given string contains only alphanumeric characters, '-', and '_'
+     * 
+     * @param str the string to validate
+     * @return true if the string contains only alphanumeric characters, '-', and '_', or false otherwise
+     */
+    private boolean isAlphanumWithDashes(String str) {
+        boolean isValid = true;
+        for (char c : str.toCharArray()) {
+            if (!Character.isLetterOrDigit(c) && c != '-' && c != '_') {
+                isValid = false;
+                break;
+            }
+        }
+        return isValid;
     }
 }

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/TokenPayloadValidator.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/TokenPayloadValidator.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.api.authentication.internal;
+
+import dev.galasa.framework.api.beans.TokenPayload;
+import dev.galasa.framework.api.common.IBeanValidator;
+import dev.galasa.framework.api.common.InternalServletException;
+import dev.galasa.framework.api.common.ServletError;
+
+import static dev.galasa.framework.api.common.ServletErrorMessage.*;
+
+import javax.servlet.http.HttpServletResponse;
+
+public class TokenPayloadValidator implements IBeanValidator<TokenPayload> {
+
+    // Regex to match a non-empty string that can contain only:
+    // - Alphanumeric characters
+    // - '-' (dashes)
+    // - '_' (underscores)
+    private static final String ALPHANUM_DASHES_PATTERN = "^[a-zA-Z0-9\\-_]+$";
+
+    @Override
+    public void validate(TokenPayload tokenPayload) throws InternalServletException {
+        boolean isValid = false;
+        if (tokenPayload != null) {
+            String clientId = tokenPayload.getClientId();
+            String refreshToken = tokenPayload.getRefreshToken();
+            String authCode = tokenPayload.getCode();
+    
+            if (clientId != null && clientId.matches(ALPHANUM_DASHES_PATTERN)) {
+                // The refresh token and authorization code parameters are mutually exclusive
+                isValid = ((refreshToken != null && refreshToken.matches(ALPHANUM_DASHES_PATTERN) && authCode == null)
+                    || (authCode != null && authCode.matches(ALPHANUM_DASHES_PATTERN) && refreshToken == null));
+            }
+        }
+
+        if (!isValid) {
+            ServletError error = new ServletError(GAL5062_INVALID_TOKEN_REQUEST_BODY);
+            throw new InternalServletException(error, HttpServletResponse.SC_BAD_REQUEST);
+        }
+    }
+}

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthRoute.java
@@ -1,6 +1,5 @@
 package dev.galasa.framework.api.authentication.internal.routes;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
@@ -19,9 +18,11 @@ import com.google.gson.JsonObject;
 import dev.galasa.framework.api.authentication.IOidcProvider;
 import dev.galasa.framework.api.authentication.JwtWrapper;
 import dev.galasa.framework.api.authentication.internal.DexGrpcClient;
+import dev.galasa.framework.api.authentication.internal.TokenPayloadValidator;
 import dev.galasa.framework.api.beans.TokenPayload;
 import dev.galasa.framework.api.common.BaseRoute;
 import dev.galasa.framework.api.common.Environment;
+import dev.galasa.framework.api.common.IBeanValidator;
 import dev.galasa.framework.api.common.InternalServletException;
 import dev.galasa.framework.api.common.QueryParameters;
 import dev.galasa.framework.api.common.ResponseBuilder;
@@ -42,6 +43,8 @@ public class AuthRoute extends BaseRoute {
 
     private static final String ID_TOKEN_KEY      = "id_token";
     private static final String REFRESH_TOKEN_KEY = "refresh_token";
+
+    private static final IBeanValidator<TokenPayload> validator = new TokenPayloadValidator();
 
     public AuthRoute(
         ResponseBuilder responseBuilder,
@@ -114,16 +117,13 @@ public class AuthRoute extends BaseRoute {
         logger.info("AuthRoute: handlePostRequest() entered.");
 
         // Check that the request body contains the required payload
-        TokenPayload requestPayload = getRequestBodyAsJson(request);
-        if (requestPayload == null || !isTokenPayloadValid(requestPayload)) {
-            ServletError error = new ServletError(GAL5400_BAD_REQUEST, request.getServletPath());
-            throw new InternalServletException(error, HttpServletResponse.SC_BAD_REQUEST);
-        }
+        TokenPayload requestPayload = parseRequestBody(request, TokenPayload.class);
+        validator.validate(requestPayload);
 
         JsonObject responseJson = new JsonObject();
         try {
             // Send a POST request to Dex's /token endpoint
-            JsonObject tokenResponseBodyJson = sendTokenPost(request, requestPayload);
+            JsonObject tokenResponseBodyJson = sendTokenPost(requestPayload);
 
             // Return the JWT and refresh token as the servlet's response
             if (tokenResponseBodyJson != null && tokenResponseBodyJson.has(ID_TOKEN_KEY) && tokenResponseBodyJson.has(REFRESH_TOKEN_KEY)) {
@@ -158,29 +158,13 @@ public class AuthRoute extends BaseRoute {
     }
 
     /**
-     * Gets a given HTTP request's body as a JSON object.
-     */
-    private TokenPayload getRequestBodyAsJson(HttpServletRequest request) throws IOException {
-        StringBuilder sbRequestBody = new StringBuilder();
-        BufferedReader bodyReader = request.getReader();
-
-        String line = bodyReader.readLine();
-        while (line != null) {
-            sbRequestBody.append(line);
-            line = bodyReader.readLine();
-        }
-
-        return gson.fromJson(sbRequestBody.toString(), TokenPayload.class);
-    }
-
-    /**
      * Sends a POST request to the JWT issuer's /token endpoint and returns the
      * response's body as a JSON object.
      *
      * @param requestBodyJson the request payload containing the required parameters
      *                        for the /token endpoint
      */
-    private JsonObject sendTokenPost(HttpServletRequest request, TokenPayload requestBodyJson)
+    private JsonObject sendTokenPost(TokenPayload requestBodyJson)
             throws IOException, InterruptedException, InternalServletException {
         String refreshToken = requestBodyJson.getRefreshToken();
         String clientId = requestBodyJson.getClientId();
@@ -220,14 +204,6 @@ public class AuthRoute extends BaseRoute {
             logger.error("Invalid URL provided: '" + url + "'");
         }
         return isValid;
-    }
-
-    /**
-     * Checks if the POST request payload to pass to Dex's /token endpoint contains a client ID and either
-     * a refresh token or an authorization code.
-     */
-    private boolean isTokenPayloadValid(TokenPayload requestPayload) {
-        return (requestPayload.getClientId() != null) && (requestPayload.getRefreshToken() != null || requestPayload.getCode() != null);
     }
 
     /**

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthRouteTest.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthRouteTest.java
@@ -95,13 +95,11 @@ public class AuthRouteTest extends BaseServletTest {
         // Then...
         // Expecting this json:
         // {
-        // "error_code" : 5400,
-        // "error_message" : "GAL5400E: Error occured when trying to execute request
-        // '/auth'. Please check your request parameters or report the problem to your
-        // Galasa Ecosystem owner."
+        // "error_code" : 5062,
+        // "error_message" : "GAL5411E: ... The request body is empty."
         // }
-        assertThat(servletResponse.getStatus()).isEqualTo(400);
-        checkErrorStructure(outStream.toString(), 5400, "GAL5400E");
+        assertThat(servletResponse.getStatus()).isEqualTo(411);
+        checkErrorStructure(outStream.toString(), 5411, "GAL5411E");
     }
 
     @Test
@@ -122,13 +120,11 @@ public class AuthRouteTest extends BaseServletTest {
         // Then...
         // Expecting this json:
         // {
-        // "error_code" : 5400,
-        // "error_message" : "GAL5400E: Error occured when trying to execute request
-        // '/auth'. Please check your request parameters or report the problem to your
-        // Galasa Ecosystem owner."
+        // "error_code" : 5062,
+        // "error_message" : "GAL5062E: Invalid request body provided. ..."
         // }
         assertThat(servletResponse.getStatus()).isEqualTo(400);
-        checkErrorStructure(outStream.toString(), 5400, "GAL5400E");
+        checkErrorStructure(outStream.toString(), 5062, "GAL5062E");
     }
 
     @Test

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthTokensRouteTest.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthTokensRouteTest.java
@@ -227,7 +227,7 @@ public class AuthTokensRouteTest extends BaseServletTest {
         // Given...
         MockAuthenticationServlet servlet = new MockAuthenticationServlet();
 
-        MockHttpServletRequest mockRequest = new MockHttpServletRequest(null, "", "POST");
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest("/tokens", "", "POST");
         MockHttpServletResponse servletResponse = new MockHttpServletResponse();
         ServletOutputStream outStream = servletResponse.getOutputStream();
 
@@ -238,13 +238,112 @@ public class AuthTokensRouteTest extends BaseServletTest {
         // Then...
         // Expecting this json:
         // {
-        // "error_code" : 5400,
-        // "error_message" : "GAL5400E: Error occured when trying to execute request
-        // '/auth'. Please check your request parameters or report the problem to your
-        // Galasa Ecosystem owner."
+        // "error_code" : 5411,
+        // "error_message" : "GAL5411E: ... The request body is empty."
+        // }
+        assertThat(servletResponse.getStatus()).isEqualTo(411);
+        checkErrorStructure(outStream.toString(), 5411, "GAL5411E");
+    }
+
+    @Test
+    public void testAuthPostRequestWithBadlyFormattedClientIdReturnsBadRequestError() throws Exception {
+        // Given...
+        MockAuthenticationServlet servlet = new MockAuthenticationServlet();
+
+        // Payload with a non-alphanumeric clientID
+        String payload = buildRequestPayload("&%[not a valid client ID]", "refreshtoken", null);
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest("/tokens", payload, "POST");
+        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
+        ServletOutputStream outStream = servletResponse.getOutputStream();
+
+        // When...
+        servlet.init();
+        servlet.doPost(mockRequest, servletResponse);
+
+        // Then...
+        // Expecting this json:
+        // {
+        // "error_code" : 5062,
+        // "error_message" : "GAL5062E: Invalid request body provided. ..."
         // }
         assertThat(servletResponse.getStatus()).isEqualTo(400);
-        checkErrorStructure(outStream.toString(), 5400, "GAL5400E");
+        checkErrorStructure(outStream.toString(), 5062, "GAL5062E");
+    }
+
+    @Test
+    public void testAuthPostRequestWithBadlyFormattedRefreshTokenReturnsBadRequestError() throws Exception {
+        // Given...
+        MockAuthenticationServlet servlet = new MockAuthenticationServlet();
+
+        // Payload with a non-alphanumeric refresh token
+        String payload = buildRequestPayload("dummy-id", "(not a valid refresh token)", null);
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest("/tokens", payload, "POST");
+        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
+        ServletOutputStream outStream = servletResponse.getOutputStream();
+
+        // When...
+        servlet.init();
+        servlet.doPost(mockRequest, servletResponse);
+
+        // Then...
+        // Expecting this json:
+        // {
+        // "error_code" : 5062,
+        // "error_message" : "GAL5062E: Invalid request body provided. ..."
+        // }
+        assertThat(servletResponse.getStatus()).isEqualTo(400);
+        checkErrorStructure(outStream.toString(), 5062, "GAL5062E");
+    }
+
+    @Test
+    public void testAuthPostRequestWithBadlyFormattedAuthCodeReturnsBadRequestError() throws Exception {
+        // Given...
+        MockAuthenticationServlet servlet = new MockAuthenticationServlet();
+
+        // Payload with a non-alphanumeric auth code
+        String payload = buildRequestPayload("dummy_id", "refresh-token", "$** not a valid auth code **@");
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest("/tokens", payload, "POST");
+        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
+        ServletOutputStream outStream = servletResponse.getOutputStream();
+
+        // When...
+        servlet.init();
+        servlet.doPost(mockRequest, servletResponse);
+
+        // Then...
+        // Expecting this json:
+        // {
+        // "error_code" : 5062,
+        // "error_message" : "GAL5062E: Invalid request body provided. ..."
+        // }
+        assertThat(servletResponse.getStatus()).isEqualTo(400);
+        checkErrorStructure(outStream.toString(), 5062, "GAL5062E");
+    }
+
+    @Test
+    public void testAuthPostRequestWithBothRefreshTokenAndAuthCodeReturnsBadRequestError() throws Exception {
+        // Given...
+        MockAuthenticationServlet servlet = new MockAuthenticationServlet();
+
+        // The refresh token and auth code are mutually exclusive, so a bad request should be thrown when both are
+        // provided
+        String payload = buildRequestPayload("dummy-id", "refresh-token", "auth-code");
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest("/tokens", payload, "POST");
+        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
+        ServletOutputStream outStream = servletResponse.getOutputStream();
+
+        // When...
+        servlet.init();
+        servlet.doPost(mockRequest, servletResponse);
+
+        // Then...
+        // Expecting this json:
+        // {
+        // "error_code" : 5062,
+        // "error_message" : "GAL5062E: Invalid request body provided. ..."
+        // }
+        assertThat(servletResponse.getStatus()).isEqualTo(400);
+        checkErrorStructure(outStream.toString(), 5062, "GAL5062E");
     }
 
     @Test
@@ -265,13 +364,11 @@ public class AuthTokensRouteTest extends BaseServletTest {
         // Then...
         // Expecting this json:
         // {
-        // "error_code" : 5400,
-        // "error_message" : "GAL5400E: Error occured when trying to execute request
-        // '/auth'. Please check your request parameters or report the problem to your
-        // Galasa Ecosystem owner."
+        // "error_code" : 5062,
+        // "error_message" : "GAL5062E: Invalid request body provided. ..."
         // }
         assertThat(servletResponse.getStatus()).isEqualTo(400);
-        checkErrorStructure(outStream.toString(), 5400, "GAL5400E");
+        checkErrorStructure(outStream.toString(), 5062, "GAL5062E");
     }
 
     @Test

--- a/galasa-parent/dev.galasa.framework.api.common/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api.common/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 description = 'Framework API - Common Packages'
 
-version = '0.34.0'
+version = '0.35.0'
 
 dependencies {
     implementation project(':dev.galasa.framework')

--- a/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/BaseRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/BaseRoute.java
@@ -17,6 +17,7 @@ import dev.galasa.framework.spi.utils.GalasaGson;
 
 import static dev.galasa.framework.api.common.ServletErrorMessage.*;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 
 public abstract class BaseRoute implements IRoute {
@@ -89,5 +90,28 @@ public abstract class BaseRoute implements IRoute {
             throw new InternalServletException(error, HttpServletResponse.SC_LENGTH_REQUIRED);
         }
         return valid;
+    }
+
+    /**
+     * Parses a given HTTP request's body into a bean object
+     * 
+     * @param request the HTTP request to be parsed
+     * @param clazz the bean class to parse the request body into
+     * @return the parsed HTTP request body
+     * @throws IOException if there is an issue reading the request body
+     * @throws InternalServletException if the request does not contain a body
+     */
+    protected <T> T parseRequestBody(HttpServletRequest request, Class<T> clazz) throws IOException, InternalServletException {
+        StringBuilder sbRequestBody = new StringBuilder();
+        checkRequestHasContent(request);
+
+        try (BufferedReader bodyReader = request.getReader()) {
+            String line = bodyReader.readLine();
+            while (line != null) {
+                sbRequestBody.append(line);
+                line = bodyReader.readLine();
+            }
+        }
+        return gson.fromJson(sbRequestBody.toString(), clazz);
     }
 }

--- a/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/IBeanValidator.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/IBeanValidator.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.api.common;
+
+public interface IBeanValidator<T> {
+
+    /**
+     * Checks that the provided bean is valid according to its validation rules. The provided bean should come from the
+     * body of a request that has been serialised into an object according to the OpenAPI specification.
+     * 
+     * @param bean an instance of the API bean to validate
+     * @throws InternalServletException if the bean is not valid
+     */
+    void validate(T bean) throws InternalServletException;
+}

--- a/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
@@ -94,6 +94,7 @@ public enum ServletErrorMessage {
     GAL5059_INVALID_ISSUER_URI_PROVIDED               (5059, "E: Invalid Galasa Dex server URL provided. This could be because the Galasa Ecosystem is badly configured. Report the problem to your Galasa Ecosystem owner."),
     GAL5060_INVALID_OIDC_URI_RECEIVED                 (5060, "E: Internal server error. Invalid OpenID Connect URL received from the Galasa Dex server. Report the problem to your Galasa Ecosystem owner."),
     GAL5061_MISMATCHED_OIDC_URI_RECEIVED              (5061, "E: Internal server error. OpenID Connect URL received from the Galasa Dex server does not match the expected Dex server scheme or host. Report the problem to your Galasa Ecosystem owner."),
+    GAL5062_INVALID_TOKEN_REQUEST_BODY                (5062, "E: Invalid request body provided. Please ensure that you have provided a client ID and either a refresh token or a authorization code in your request. Allowable characters for these parameters are 'a'-'z', 'A'-'Z', '0'-'9', '-' (dash), and '_' (underscore)"),
     ;
 
 

--- a/release.yaml
+++ b/release.yaml
@@ -81,7 +81,7 @@ api:
     codecoverage: true
 
   - artifact: dev.galasa.framework.api.authentication
-    version: 0.34.0
+    version: 0.35.0
     obr: true
     isolated: true
     codecoverage: true
@@ -93,7 +93,7 @@ api:
     codecoverage: true
 
   - artifact: dev.galasa.framework.api.common
-    version: 0.34.0
+    version: 0.35.0
     obr: true
     isolated: true
     codecoverage: true


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1894

## Changes
- Added an initial `TokenPayloadValidator` class that implements a new `IBeanValidator` interface to handle the validation of auth request payloads
  - Eamonn: Not completely happy with this since this means every bean will end up with a corresponding validator class and constraints can't be re-used if another bean uses similar validation rules...
- Added missing URL encoding to URL values in requests to Dex (since Dex expects request content to be `application/x-www-form-urlencoded`)