### PR TITLE
Upgrade api.openapi bundle to 0.34.1 - missing from set version script

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -111,7 +111,7 @@ api:
     codecoverage: true
 
   - artifact: dev.galasa.framework.api.openapi
-    version: 0.34.0
+    version: 0.34.1
     obr: true
     isolated: true
     mvp: true
@@ -146,3 +146,4 @@ api:
     obr: true
     bom: true
     mvp: true
+    isolated: true


### PR DESCRIPTION
### Why?

For patch release 0.34.1. api.openapi upgrade seems to be missing from the set-version script (will fix). Also the last line was accidentally deleted by another PR in the history.