### PR TITLE
Add general Event POJO to Framework to produce events

### DIFF
--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/events/Event.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/events/Event.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.spi.events;
+
+import java.util.UUID;
+
+public class Event implements IEvent {
+
+    private String id;
+    private String timestamp;
+    private String message;
+
+    public Event(String timestamp, String message){
+        this.id = UUID.randomUUID().toString();
+        this.timestamp = timestamp;
+        this.message = message;
+    }
+
+    public String getId(){
+        return this.id;
+    }
+
+    public void setId(String id){
+        this.id = id;
+    }
+
+    public String getTimestamp(){
+        return this.timestamp;
+    }
+
+    public void setTimestamp(String timestamp){
+        this.timestamp = timestamp;
+    }
+
+    public String getMessage(){
+        return this.message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    @Override
+    public String toString() {
+        return  this.getClass().getName() + "{" +
+                "id='" + id + '\'' +
+                ", timestamp=" + timestamp +
+                ", message='" + message + '\'' +
+                '}';
+    }
+
+}


### PR DESCRIPTION
## Why?

To allow the production and publishing of events to a Kafka cluster (or any other Events Service that has been registered) so the class is a general 'Event' class as opposed to a 'KafkaEvent'.

In various places throughout the framework, an Event will be instantiated, and sent via the Events Service.