### PR TITLE
Update release.yaml using the auto-generated release.yaml during local builds

### DIFF
--- a/build-locally.sh
+++ b/build-locally.sh
@@ -319,6 +319,21 @@ function check_secrets {
     success "secrets audit complete"
 }
 
+function update_release_yaml {
+    h2 "Updating release.yaml"
+
+    # After running 'gradle build', a release.yaml file should have been automatically generated
+    generated_release_yaml="${BASEDIR}/galasa-parent/build/release.yaml"
+    current_release_yaml="${BASEDIR}/release.yaml"
+
+    if [[ -f ${generated_release_yaml} ]]; then
+        cp ${generated_release_yaml} ${current_release_yaml}
+        success "Updated release.yaml OK"
+    else
+        warn "Failed to automatically generate release.yaml, please ensure any changed bundles have had their versions updated in ${current_release_yaml}"
+    fi
+}
+
 #-----------------------------------------------------------------------------------------
 # Process parameters
 #-----------------------------------------------------------------------------------------
@@ -414,6 +429,7 @@ generate_beans
 
 build_code
 publish_to_maven
+update_release_yaml
 
 if [[ -z ${SWAGGER_CODEGEN_CLI_JAR} ]]; then
     download_dependencies

--- a/release.yaml
+++ b/release.yaml
@@ -4,6 +4,15 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
+# -----------------------------------------------------------
+#
+#                         WARNING
+#
+# This file is periodically re-generated from the contents of
+# the repository, so don't make changes here manually please.
+# -----------------------------------------------------------
+
+
 apiVersion: galasa.dev/v1alpha
 kind: Release
 metadata:
@@ -12,138 +21,224 @@ metadata:
 
 framework:
   bundles:
+
+
   - artifact: dev.galasa
     version: 0.34.0
-    obr: true
-    bom: true
-    mvp: true
-    javadoc: true
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      true
+    isolated:     false
     codecoverage: true
 
   - artifact: dev.galasa.framework
     version: 0.36.0
-    obr: true
-    bom: true
-    mvp: true
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      false
+    isolated:     false
     codecoverage: true
-
-  - artifact: galasa-boot
-    version: 0.34.0
-    mvp: true
-    codecoverage: true
-
 
   - artifact: dev.galasa.framework.docker.controller
     version: 0.34.0
-    obr: true
-    isolated: true
+    obr:          true
+    mvp:          false
+    bom:          false
+    javadoc:      false
+    isolated:     true
     codecoverage: true
 
   - artifact: dev.galasa.framework.k8s.controller
     version: 0.36.0
-    obr: true
-    isolated: true
+    obr:          true
+    mvp:          false
+    bom:          false
+    javadoc:      false
+    isolated:     true
     codecoverage: true
+
+  - artifact: dev.galasa.framework.log4j2.bridge
+    version: 0.25.0
+    obr:          false
+    mvp:          false
+    bom:          false
+    javadoc:      false
+    isolated:     false
+    codecoverage: false
 
   - artifact: dev.galasa.framework.maven.repository
     version: 0.22.0
-    obr: true
-    mvp: true
-    isolated: true
+    obr:          true
+    mvp:          true
+    bom:          false
+    javadoc:      false
+    isolated:     true
     codecoverage: true
 
   - artifact: dev.galasa.framework.maven.repository.spi
     version: 0.21.0
-    obr: true
-    mvp: true
-    isolated: true
-    codecoverage: true
-
-  - artifact: dev.galasa.framework.resource.management
-    version: 0.23.0
-    obr: true
-    isolated: true
+    obr:          true
+    mvp:          true
+    bom:          false
+    javadoc:      false
+    isolated:     true
     codecoverage: true
 
   - artifact: dev.galasa.framework.metrics
     version: 0.21.0
-    obr: true
-    isolated: true
+    obr:          true
+    mvp:          false
+    bom:          false
+    javadoc:      false
+    isolated:     true
     codecoverage: true
 
+  - artifact: dev.galasa.framework.resource.management
+    version: 0.23.0
+    obr:          true
+    mvp:          false
+    bom:          false
+    javadoc:      false
+    isolated:     true
+    codecoverage: true
+
+  - artifact: galasa-boot
+    version: 0.34.0
+    obr:          false
+    mvp:          true
+    bom:          false
+    javadoc:      false
+    isolated:     false
+    codecoverage: true
+
+  - artifact: galasa-testharness
+    version: 0.34.0
+    obr:          false
+    mvp:          false
+    bom:          false
+    javadoc:      false
+    isolated:     false
+    codecoverage: false
 
 api:
   bundles:
+
+
   - artifact: dev.galasa.framework.api
     version: 0.36.0
-    obr: true
-    isolated: true
+    obr:          true
+    mvp:          false
+    bom:          false
+    javadoc:      false
+    isolated:     true
     codecoverage: true
 
   - artifact: dev.galasa.framework.api.authentication
     version: 0.36.0
-    obr: true
-    isolated: true
-    codecoverage: true
-
-  - artifact: dev.galasa.framework.api.bootstrap
-    version: 0.34.0
-    obr: true
-    isolated: true
-    codecoverage: true
-
-  - artifact: dev.galasa.framework.api.common
-    version: 0.36.0
-    obr: true
-    isolated: true
-    codecoverage: true
-
-  - artifact: dev.galasa.framework.api.cps
-    version: 0.35.0
-    obr: true
-    isolated: true
-    codecoverage: true
-
-  - artifact: dev.galasa.framework.api.health
-    version: 0.25.0
-    obr: true
-    isolated: true
-    codecoverage: true
-
-  - artifact: dev.galasa.framework.api.openapi
-    version: 0.36.0
-    obr: true
-    isolated: true
-    mvp: true
-    codecoverage: true
-
-  - artifact: dev.galasa.framework.api.ras
-    version: 0.34.0
-    obr: true
-    isolated: true
-    codecoverage: true
-
-  - artifact: dev.galasa.framework.api.resources
-    version: 0.34.0
-    obr: true
-    isolated: true
-    codecoverage: true
-
-  - artifact: dev.galasa.framework.api.runs
-    version: 0.34.0
-    obr: true
-    isolated: true
-    codecoverage: true
-
-  - artifact: dev.galasa.framework.api.testcatalog
-    version: 0.34.0
-    obr: true
-    isolated: true
+    obr:          true
+    mvp:          false
+    bom:          false
+    javadoc:      false
+    isolated:     true
     codecoverage: true
 
   - artifact: dev.galasa.framework.api.beans
     version: 0.33.0
-    obr: true
-    bom: true
-    mvp: true
-    isolated: true
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      true
+    isolated:     true
+    codecoverage: true
+
+  - artifact: dev.galasa.framework.api.bootstrap
+    version: 0.34.0
+    obr:          true
+    mvp:          false
+    bom:          false
+    javadoc:      false
+    isolated:     true
+    codecoverage: true
+
+  - artifact: dev.galasa.framework.api.common
+    version: 0.36.0
+    obr:          true
+    mvp:          false
+    bom:          false
+    javadoc:      true
+    isolated:     true
+    codecoverage: true
+
+  - artifact: dev.galasa.framework.api.cps
+    version: 0.35.0
+    obr:          true
+    mvp:          false
+    bom:          false
+    javadoc:      false
+    isolated:     true
+    codecoverage: true
+
+  - artifact: dev.galasa.framework.api.health
+    version: 0.25.0
+    obr:          true
+    mvp:          false
+    bom:          false
+    javadoc:      false
+    isolated:     true
+    codecoverage: true
+
+  - artifact: dev.galasa.framework.api.launcher
+    version: 0.21.0
+    obr:          false
+    mvp:          false
+    bom:          false
+    javadoc:      false
+    isolated:     false
+    codecoverage: false
+
+  - artifact: dev.galasa.framework.api.openapi
+    version: 0.36.0
+    obr:          true
+    mvp:          true
+    bom:          true
+    javadoc:      false
+    isolated:     true
+    codecoverage: false
+
+  - artifact: dev.galasa.framework.api.ras
+    version: 0.34.0
+    obr:          true
+    mvp:          false
+    bom:          false
+    javadoc:      false
+    isolated:     true
+    codecoverage: true
+
+  - artifact: dev.galasa.framework.api.resources
+    version: 0.34.0
+    obr:          true
+    mvp:          false
+    bom:          false
+    javadoc:      false
+    isolated:     true
+    codecoverage: true
+
+  - artifact: dev.galasa.framework.api.runs
+    version: 0.34.0
+    obr:          true
+    mvp:          false
+    bom:          false
+    javadoc:      false
+    isolated:     true
+    codecoverage: true
+
+  - artifact: dev.galasa.framework.api.testcatalog
+    version: 0.34.0
+    obr:          true
+    mvp:          false
+    bom:          false
+    javadoc:      false
+    isolated:     true
+    codecoverage: true


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1902

## Changes
- Gradle builds generate a release.yaml based on the versions of all bundles in the framework project, so the build-locally script now copies that file into the actual release.yaml file, which removes the need to manually update bundle versions in the release.yaml.
- Updated the release.yaml based on the results from running the modified build-locally script