### PR TITLE
Produce test lifecycle status change events from the TestRunner

### DIFF
--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
@@ -5,6 +5,8 @@
  */
 package dev.galasa.framework;
 
+import static org.mockito.Mockito.framework;
+
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -38,6 +40,7 @@ import dev.galasa.framework.maven.repository.spi.IMavenRepository;
 import dev.galasa.framework.spi.AbstractManager;
 import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
 import dev.galasa.framework.spi.DynamicStatusStoreException;
+import dev.galasa.framework.spi.EventsException;
 import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.FrameworkResourceUnavailableException;
 import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
@@ -49,6 +52,7 @@ import dev.galasa.framework.spi.IRun;
 import dev.galasa.framework.spi.Result;
 import dev.galasa.framework.spi.ResultArchiveStoreException;
 import dev.galasa.framework.spi.SharedEnvironmentRunType;
+import dev.galasa.framework.spi.events.Event;
 import dev.galasa.framework.spi.language.GalasaTest;
 import dev.galasa.framework.spi.teststructure.TestStructure;
 import dev.galasa.framework.spi.utils.DssUtils;
@@ -651,7 +655,16 @@ public class TestRunner {
     private void updateStatus(TestRunLifecycleStatus status, String timestamp) throws TestRunException {
 
         if (this.produceEvents) {
-            logger.debug("Producing a test lifecycle status change event.");
+            logger.debug("Producing a test run lifecycle status change event.");
+
+            String message = String.format("Galasa test run %s is now in status: %s.", framework.getTestRunName(), status.toString());
+            Event testLifecycleStatusChangeEvent = new Event(Instant.now().toString(), message);
+
+            try {
+                framework.getEventsService().produceEvent("Tests.StatusChangedEvent", testLifecycleStatusChangeEvent);
+            } catch (EventsException e) {
+                throw new TestRunException("Failed to publish a test run lifecycle status change event to the Events Service", e);
+            }
         }
 
         this.testStructure.setStatus(status.toString());

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
@@ -5,8 +5,6 @@
  */
 package dev.galasa.framework;
 
-import static org.mockito.Mockito.framework;
-
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -52,7 +50,7 @@ import dev.galasa.framework.spi.IRun;
 import dev.galasa.framework.spi.Result;
 import dev.galasa.framework.spi.ResultArchiveStoreException;
 import dev.galasa.framework.spi.SharedEnvironmentRunType;
-import dev.galasa.framework.spi.events.Event;
+import dev.galasa.framework.spi.events.TestRunLifecycleStatusChangedEvent;
 import dev.galasa.framework.spi.language.GalasaTest;
 import dev.galasa.framework.spi.teststructure.TestStructure;
 import dev.galasa.framework.spi.utils.DssUtils;
@@ -658,10 +656,11 @@ public class TestRunner {
             logger.debug("Producing a test run lifecycle status change event.");
 
             String message = String.format("Galasa test run %s is now in status: %s.", framework.getTestRunName(), status.toString());
-            Event testLifecycleStatusChangeEvent = new Event(Instant.now().toString(), message);
+            TestRunLifecycleStatusChangedEvent testRunLifecycleStatusChangedEvent = new TestRunLifecycleStatusChangedEvent(Instant.now().toString(), message);
+            String topic = testRunLifecycleStatusChangedEvent.getTopic();
 
             try {
-                framework.getEventsService().produceEvent("Tests.StatusChangedEvent", testLifecycleStatusChangeEvent);
+                framework.getEventsService().produceEvent(topic, testRunLifecycleStatusChangedEvent);
             } catch (EventsException e) {
                 throw new TestRunException("Failed to publish a test run lifecycle status change event to the Events Service", e);
             }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/events/TestRunLifecycleStatusChangedEvent.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/events/TestRunLifecycleStatusChangedEvent.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.spi.events;
+
+public class TestRunLifecycleStatusChangedEvent extends Event {
+
+    private final String TOPIC = "Tests.StatusChangedEvent";
+
+    public TestRunLifecycleStatusChangedEvent(String timestamp, String message) {
+        super(timestamp, message);
+    }
+
+    public String getTopic() {
+        return this.TOPIC;
+    }
+    
+}


### PR DESCRIPTION
This is to test the new Kafka extension to close issues https://github.com/galasa-dev/projectmanagement/issues/1768 and https://github.com/galasa-dev/projectmanagement/issues/1893

Refinements to be made in future but this is just to test that we are producing events okay in remote runs, once the service has been enabled and the CPS prop for event production turned on.