### PR TITLE
Add FrameworkEventsService back but only initialise for local

### DIFF
--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkInitialisation.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkInitialisation.java
@@ -792,11 +792,11 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
             // framework.getEventsService() returns non-null.
             eventsRegistration.initialise(this);
         }
-        if (this.framework.getEventsService() == null) {
-            throw new FrameworkException("Failed to initialise an Events Service, unable to continue");
-        }
-        logger.trace("Selected Events Service is " 
+        // The Events Service should not be mandatory so okay to not have one registered
+        if (this.framework.getEventsService() != null) {
+            logger.trace("Selected Events Service is " 
             + this.framework.getEventsService().getClass().getName());
 
+        }
     }
 }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/events/FrameworkEventsServiceRegistration.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/events/FrameworkEventsServiceRegistration.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.internal.events;
+
+import java.net.URI;
+
+import javax.validation.constraints.NotNull;
+
+import org.osgi.service.component.annotations.Component;
+
+import dev.galasa.framework.spi.EventsException;
+import dev.galasa.framework.spi.IEventsServiceRegistration;
+import dev.galasa.framework.spi.IFrameworkInitialisation;
+
+@Component(service = { IEventsServiceRegistration.class })
+public class FrameworkEventsServiceRegistration implements IEventsServiceRegistration {
+
+    /**
+     * This method intialises the service with the framework, managers can then
+     * access this service.
+     * 
+     * @param frameworkInitialisation - the framework setup.
+     * @throws EventsException 
+     */
+    public void initialise(@NotNull IFrameworkInitialisation frameworkInitialisation) throws EventsException {
+
+        try {
+            URI cps = frameworkInitialisation.getBootstrapConfigurationPropertyStore();
+
+            // If the CPS is a file, then register this version of the EventsService
+            if (cps.getScheme().equals("file")) {
+                frameworkInitialisation.registerEventsService(new FrameworkEventsService());
+            }
+        } catch (EventsException e) {
+            throw e;
+        }
+    }
+
+}


### PR DESCRIPTION
FrameworkEventsService must be present - as if a user has not specified to use the Kafka extension in the extra.bundles, FrameworkInitialisation will fail. This FrameworkEventsService will only be selected for local runs though, by seeing if the CPS URI scheme is file.