### PR TITLE
Add DELETE /auth/tokens/{tokenid} route to revoke auth tokens

### DIFF
--- a/galasa-parent/dev.galasa.framework.api.authentication/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api.authentication/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 description = 'Galasa Authentication API'
 
-version = '0.35.0'
+version = '0.36.0'
 
 dependencies {
     implementation project(':dev.galasa.framework')

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/AuthenticationServlet.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/AuthenticationServlet.java
@@ -21,6 +21,7 @@ import dev.galasa.framework.api.authentication.internal.OidcProvider;
 import dev.galasa.framework.api.authentication.internal.routes.AuthCallbackRoute;
 import dev.galasa.framework.api.authentication.internal.routes.AuthClientsRoute;
 import dev.galasa.framework.api.authentication.internal.routes.AuthRoute;
+import dev.galasa.framework.api.authentication.internal.routes.AuthTokensDetailsRoute;
 import dev.galasa.framework.api.authentication.internal.routes.AuthTokensRoute;
 import dev.galasa.framework.api.common.BaseServlet;
 import dev.galasa.framework.api.common.Environment;
@@ -67,6 +68,7 @@ public class AuthenticationServlet extends BaseServlet {
         addRoute(new AuthClientsRoute(getResponseBuilder(), dexGrpcClient));
         addRoute(new AuthCallbackRoute(getResponseBuilder(), externalApiServerUrl));
         addRoute(new AuthTokensRoute(getResponseBuilder(), oidcProvider, dexGrpcClient, authStoreService, env));
+        addRoute(new AuthTokensDetailsRoute(getResponseBuilder(), dexGrpcClient, authStoreService));
 
         logger.info("Galasa Authentication API initialised");
     }

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/JwtWrapper.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/JwtWrapper.java
@@ -55,6 +55,15 @@ public class JwtWrapper {
     }
 
     /**
+     * Get the value of the "sub" claim from the decoded JWT
+     * 
+     * @return the value associated with the decoded JWT's "sub" claim
+     */
+    public String getSubject() {
+        return decodedJwt.getSubject();
+    }
+
+    /**
      * Gets a JSON Web Token (JWT) from a given request's Authorization header,
      * returning null if it does not have one.
      *

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/DexGrpcClient.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/DexGrpcClient.java
@@ -121,7 +121,7 @@ public class DexGrpcClient {
      * @throws InternalServletException if there was an issue deleting the client
      */
     public void deleteClient(String clientId) throws InternalServletException {
-        logger.info("Deleting Dex client with ID: " + clientId);
+        logger.info("Deleting Dex client");
 
         // Build the DeleteClient request
         com.coreos.dex.api.DexOuterClass.DeleteClientReq.Builder deleteClientReqBuilder = DeleteClientReq.newBuilder();
@@ -136,7 +136,7 @@ public class DexGrpcClient {
         } else {
             // Something went wrong, the client with the given ID couldn't be found
             ServletError error = new ServletError(GAL5063_FAILED_TO_DELETE_CLIENT);
-            throw new InternalServletException(error, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            throw new InternalServletException(error, HttpServletResponse.SC_NOT_FOUND);
         }
     }
 
@@ -148,7 +148,7 @@ public class DexGrpcClient {
      * @throws InternalServletException if there was an issue revoking the refresh token
      */
     public void revokeRefreshToken(String userId, String clientId) throws InternalServletException {
-        logger.info("Revoking refresh token client with ID: " + clientId);
+        logger.info("Revoking refresh token");
 
         // Build the RevokeRefresh request
         com.coreos.dex.api.DexOuterClass.RevokeRefreshReq.Builder revokeRefreshReqBuilder = RevokeRefreshReq.newBuilder();
@@ -162,9 +162,9 @@ public class DexGrpcClient {
         if (!clientResp.getNotFound()) {
             logger.info("Refresh token successfully revoked");
         } else {
-            // Something went wrong, the client with the given ID couldn't be found
+            // Something went wrong, the refresh token for the given client and user couldn't be found
             ServletError error = new ServletError(GAL5064_FAILED_TO_REVOKE_TOKEN);
-            throw new InternalServletException(error, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            throw new InternalServletException(error, HttpServletResponse.SC_NOT_FOUND);
         }
     }
 

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/DexGrpcClient.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/DexGrpcClient.java
@@ -17,6 +17,8 @@ import com.coreos.dex.api.DexGrpc.DexBlockingStub;
 import com.coreos.dex.api.DexOuterClass.Client;
 import com.coreos.dex.api.DexOuterClass.CreateClientReq;
 import com.coreos.dex.api.DexOuterClass.CreateClientResp;
+import com.coreos.dex.api.DexOuterClass.DeleteClientReq;
+import com.coreos.dex.api.DexOuterClass.DeleteClientResp;
 import com.coreos.dex.api.DexOuterClass.GetClientReq;
 import com.coreos.dex.api.DexOuterClass.GetClientResp;
 import com.coreos.dex.api.DexOuterClass.CreateClientReq.Builder;
@@ -111,6 +113,32 @@ public class DexGrpcClient {
     }
 
     /**
+     * Deletes a Dex client with a given client ID.
+     *
+     * @param clientId the ID of the client to delete
+     * @throws InternalServletException if there was an issue deleting the client
+     */
+    public void deleteClient(String clientId) throws InternalServletException {
+        logger.info("Deleting Dex client with ID: " + clientId);
+
+        // Build the DeleteClient request
+        com.coreos.dex.api.DexOuterClass.DeleteClientReq.Builder deleteClientReqBuilder = DeleteClientReq.newBuilder();
+        deleteClientReqBuilder.setId(clientId);
+
+        // Send the gRPC call to delete the Dex client
+        DeleteClientReq deleteClientReq = deleteClientReqBuilder.build();
+        DeleteClientResp clientResp = sendDeleteClientRequest(deleteClientReq);
+
+        if (!clientResp.getNotFound()) {
+            logger.info("Dex client successfully deleted");
+        } else {
+            // Something went wrong, the client with the given ID couldn't be found
+            ServletError error = new ServletError(GAL5063_FAILED_TO_DELETE_CLIENT);
+            throw new InternalServletException(error, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
      * Initialises a blocking stub to be used when sending requests to Dex's gRPC
      * API.
      *
@@ -139,5 +167,15 @@ public class DexGrpcClient {
      */
     protected GetClientResp sendGetClientRequest(GetClientReq getClientReq) {
         return blockingStub.getClient(getClientReq);
+    }
+
+    /**
+     * Sends a request to delete a Dex client.
+     *
+     * @param deleteClientReq the request to send
+     * @return the response received from Dex's gRPC API
+     */
+    protected DeleteClientResp sendDeleteClientRequest(DeleteClientReq deleteClientReq) {
+        return blockingStub.deleteClient(deleteClientReq);
     }
 }

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthCallbackRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthCallbackRoute.java
@@ -26,9 +26,11 @@ public class AuthCallbackRoute extends BaseRoute {
 
     private static String externalApiServerUrl;
 
+    // Regex to match /auth/callback only
+    private static final String PATH_PATTERN = "\\/callback";
+
     public AuthCallbackRoute(ResponseBuilder responseBuilder, String externalApiServerUrl) {
-        // Regex to match /auth/callback only
-        super(responseBuilder, "\\/callback");
+        super(responseBuilder, PATH_PATTERN);
         AuthCallbackRoute.externalApiServerUrl = externalApiServerUrl;
     }
 

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthClientsRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthClientsRoute.java
@@ -28,9 +28,10 @@ public class AuthClientsRoute extends BaseRoute {
 
     private DexGrpcClient dexGrpcClient;
 
+    private static final String PATH_PATTERN = "\\/clients\\/?";
+
     public AuthClientsRoute(ResponseBuilder responseBuilder, DexGrpcClient dexGrpcClient) {
-        // Regex to match /auth/clients and /auth/clients/
-        super(responseBuilder, "\\/clients\\/?");
+        super(responseBuilder, PATH_PATTERN);
         this.dexGrpcClient = dexGrpcClient;
     }
 

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthRoute.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package dev.galasa.framework.api.authentication.internal.routes;
 
 import java.io.IOException;

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthRoute.java
@@ -49,6 +49,9 @@ public class AuthRoute extends BaseRoute {
     private static final String ID_TOKEN_KEY      = "id_token";
     private static final String REFRESH_TOKEN_KEY = "refresh_token";
 
+    // Regex to match endpoint /auth and /auth/
+    private static final String PATH_PATTERN = "\\/?";
+
     private static final IBeanValidator<TokenPayload> validator = new TokenPayloadValidator();
 
     public AuthRoute(
@@ -58,8 +61,7 @@ public class AuthRoute extends BaseRoute {
         IAuthStoreService authStoreService,
         Environment env
     ) {
-        // Regex to match endpoint /auth and /auth/
-        super(responseBuilder, "\\/?");
+        super(responseBuilder, PATH_PATTERN);
         this.oidcProvider = oidcProvider;
         this.dexGrpcClient = dexGrpcClient;
         this.authStoreService = authStoreService;

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensDetailsRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensDetailsRoute.java
@@ -7,6 +7,9 @@ package dev.galasa.framework.api.authentication.internal.routes;
 
 import static dev.galasa.framework.api.common.ServletErrorMessage.*;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -28,14 +31,14 @@ public class AuthTokensDetailsRoute extends BaseRoute {
 
     // Regex to match /auth/tokens/{tokenid} and /auth/tokens/{tokenid}/, where {tokenid}
     // is an ID that can contain only alphanumeric characters, underscores (_), and dashes (-)
-    private static final String PATH = "\\/tokens\\/[a-zA-Z0-9\\-\\_]+";
+    private static final String PATH_PATTERN = "\\/tokens\\/([a-zA-Z0-9\\-\\_]+)\\/?";
 
     public AuthTokensDetailsRoute(
         ResponseBuilder responseBuilder,
         DexGrpcClient dexGrpcClient,
         IAuthStoreService authStoreService
     ) {
-        super(responseBuilder, PATH);
+        super(responseBuilder, PATH_PATTERN);
         this.dexGrpcClient = dexGrpcClient;
         this.authStoreService = authStoreService;
     }
@@ -55,8 +58,9 @@ public class AuthTokensDetailsRoute extends BaseRoute {
     private String getTokenIdFromUrl(String pathInfo) throws InternalServletException {
         try {
             // The URL path is '/auth/tokens/{tokenid}' so we'll grab the {tokenid} part of the path
-            String[] urlParts = pathInfo.split("/");
-            return urlParts[2];
+            Matcher matcher = Pattern.compile(PATH_PATTERN).matcher(pathInfo);
+            matcher.matches();
+            return matcher.group(1);
         } catch (Exception ex) {
             // This should never happen since the URL's path will always contain a valid token ID
             // at this point, otherwise the route will not be matched

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensDetailsRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensDetailsRoute.java
@@ -31,7 +31,7 @@ public class AuthTokensDetailsRoute extends BaseRoute {
         DexGrpcClient dexGrpcClient,
         IAuthStoreService authStoreService
     ) {
-        // Regex to match /auth/tokens/{tokenid} and /auth/tokens/{tokenid}/, where {tokenid} 
+        // Regex to match /auth/tokens/{tokenid} and /auth/tokens/{tokenid}/, where {tokenid}
         // is an ID that can contain only alphanumeric characters, underscores (_), and dashes (-)
         super(responseBuilder, "\\/tokens\\/[a-zA-Z0-9\\-\\_]+");
         this.dexGrpcClient = dexGrpcClient;
@@ -66,13 +66,14 @@ public class AuthTokensDetailsRoute extends BaseRoute {
     private void revokeToken(String tokenId, String userId) throws InternalServletException {
         try {
             logger.info("Attempting to revoke token with ID '" + tokenId + "'");
-            // Delete the Dex client associated with the token
+
             IInternalAuthToken tokenToRevoke = authStoreService.getToken(tokenId);
             if (tokenToRevoke == null) {
                 ServletError error = new ServletError(GAL5066_ERROR_NO_SUCH_TOKEN_EXISTS);
                 throw new InternalServletException(error, HttpServletResponse.SC_NOT_FOUND);
             }
 
+            // Delete the Dex client associated with the token
             String dexClientId = tokenToRevoke.getDexClientId();
             dexGrpcClient.deleteClient(dexClientId);
 

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensDetailsRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensDetailsRoute.java
@@ -65,6 +65,7 @@ public class AuthTokensDetailsRoute extends BaseRoute {
 
     private void revokeToken(String tokenId, String userId) throws InternalServletException {
         try {
+            logger.info("Attempting to revoke token with ID '" + tokenId + "'");
             // Delete the Dex client associated with the token
             IInternalAuthToken tokenToRevoke = authStoreService.getToken(tokenId);
             if (tokenToRevoke == null) {
@@ -80,6 +81,8 @@ public class AuthTokensDetailsRoute extends BaseRoute {
 
             // Delete the token's record in the auth store
             authStoreService.deleteToken(tokenId);
+
+            logger.info("Revoked token with ID '" + tokenId + "' OK");
         } catch (AuthStoreException ex) {
             ServletError error = new ServletError(GAL5064_FAILED_TO_REVOKE_TOKEN);
             throw new InternalServletException(error, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, ex);

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensDetailsRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensDetailsRoute.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.api.authentication.internal.routes;
+
+import static dev.galasa.framework.api.common.ServletErrorMessage.*;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import dev.galasa.framework.api.authentication.internal.DexGrpcClient;
+import dev.galasa.framework.api.common.BaseRoute;
+import dev.galasa.framework.api.common.InternalServletException;
+import dev.galasa.framework.api.common.QueryParameters;
+import dev.galasa.framework.api.common.ResponseBuilder;
+import dev.galasa.framework.api.common.ServletError;
+import dev.galasa.framework.spi.FrameworkException;
+import dev.galasa.framework.spi.auth.AuthStoreException;
+import dev.galasa.framework.spi.auth.IAuthStoreService;
+
+public class AuthTokensDetailsRoute extends BaseRoute {
+    private IAuthStoreService authStoreService;
+    private DexGrpcClient dexGrpcClient;
+
+    public AuthTokensDetailsRoute(
+        ResponseBuilder responseBuilder,
+        DexGrpcClient dexGrpcClient,
+        IAuthStoreService authStoreService
+    ) {
+        // Regex to match /auth/tokens/{tokenid} and /auth/tokens/{tokenid}/, where {tokenid} 
+        // is an ID that can contain only alphanumeric characters, underscores (_), and dashes (-)
+        super(responseBuilder, "\\/tokens\\/[a-zA-Z0-9\\-\\_]+");
+        this.dexGrpcClient = dexGrpcClient;
+        this.authStoreService = authStoreService;
+    }
+
+    @Override
+    public HttpServletResponse handleDeleteRequest(String pathInfo, QueryParameters queryParameters,
+            HttpServletRequest request, HttpServletResponse response)
+            throws FrameworkException {
+        String tokenId = getTokenIdFromUrl(pathInfo);
+        revokeToken(tokenId);
+
+        String responseBody = "Successfully revoked token with ID '" + tokenId + "'";
+        return getResponseBuilder().buildResponse(request, response, "text/plain", responseBody, HttpServletResponse.SC_OK);
+    }
+
+    private String getTokenIdFromUrl(String pathInfo) throws InternalServletException {
+        try {
+            // The URL path is '/auth/tokens/{tokenid}' so we'll grab the {tokenid} part of the path
+            String[] urlParts = pathInfo.split("/");
+            return urlParts[2];
+        } catch (Exception ex) {
+            // This should never happen since the URL's path will always contain a valid token ID
+            // at this point, otherwise the route will not be matched
+            ServletError error = new ServletError(GAL5064_FAILED_TO_GET_TOKEN_ID_FROM_URL);
+            throw new InternalServletException(error, HttpServletResponse.SC_NOT_FOUND, ex);
+        }
+    }
+
+    private void revokeToken(String tokenId) throws InternalServletException {
+        try {
+            // Delete the token's record in the auth store
+            authStoreService.deleteToken(tokenId);
+        } catch (AuthStoreException ex) {
+            ServletError error = new ServletError(GAL5064_FAILED_TO_REVOKE_TOKEN);
+            throw new InternalServletException(error, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, ex);
+        }
+    }
+}

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensDetailsRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensDetailsRoute.java
@@ -68,7 +68,7 @@ public class AuthTokensDetailsRoute extends BaseRoute {
             // Delete the Dex client associated with the token
             IInternalAuthToken tokenToRevoke = authStoreService.getToken(tokenId);
             if (tokenToRevoke == null) {
-                ServletError error = new ServletError(GAL5064_FAILED_TO_REVOKE_TOKEN);
+                ServletError error = new ServletError(GAL5066_ERROR_NO_SUCH_TOKEN_EXISTS);
                 throw new InternalServletException(error, HttpServletResponse.SC_NOT_FOUND);
             }
 

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensDetailsRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensDetailsRoute.java
@@ -67,6 +67,11 @@ public class AuthTokensDetailsRoute extends BaseRoute {
         try {
             // Delete the Dex client associated with the token
             IInternalAuthToken tokenToRevoke = authStoreService.getToken(tokenId);
+            if (tokenToRevoke == null) {
+                ServletError error = new ServletError(GAL5064_FAILED_TO_REVOKE_TOKEN);
+                throw new InternalServletException(error, HttpServletResponse.SC_NOT_FOUND);
+            }
+
             String dexClientId = tokenToRevoke.getDexClientId();
             dexGrpcClient.deleteClient(dexClientId);
 

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensDetailsRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensDetailsRoute.java
@@ -19,6 +19,7 @@ import dev.galasa.framework.api.common.ServletError;
 import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.auth.AuthStoreException;
 import dev.galasa.framework.spi.auth.IAuthStoreService;
+import dev.galasa.framework.spi.auth.IAuthToken;
 
 public class AuthTokensDetailsRoute extends BaseRoute {
     private IAuthStoreService authStoreService;
@@ -62,6 +63,9 @@ public class AuthTokensDetailsRoute extends BaseRoute {
 
     private void revokeToken(String tokenId) throws InternalServletException {
         try {
+            // Revoke the token in Dex
+            IAuthToken tokenToRevoke = authStoreService.getToken(tokenId);
+
             // Delete the token's record in the auth store
             authStoreService.deleteToken(tokenId);
         } catch (AuthStoreException ex) {

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensDetailsRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensDetailsRoute.java
@@ -26,14 +26,16 @@ public class AuthTokensDetailsRoute extends BaseRoute {
     private IAuthStoreService authStoreService;
     private DexGrpcClient dexGrpcClient;
 
+    // Regex to match /auth/tokens/{tokenid} and /auth/tokens/{tokenid}/, where {tokenid}
+    // is an ID that can contain only alphanumeric characters, underscores (_), and dashes (-)
+    private static final String PATH = "\\/tokens\\/[a-zA-Z0-9\\-\\_]+";
+
     public AuthTokensDetailsRoute(
         ResponseBuilder responseBuilder,
         DexGrpcClient dexGrpcClient,
         IAuthStoreService authStoreService
     ) {
-        // Regex to match /auth/tokens/{tokenid} and /auth/tokens/{tokenid}/, where {tokenid}
-        // is an ID that can contain only alphanumeric characters, underscores (_), and dashes (-)
-        super(responseBuilder, "\\/tokens\\/[a-zA-Z0-9\\-\\_]+");
+        super(responseBuilder, PATH);
         this.dexGrpcClient = dexGrpcClient;
         this.authStoreService = authStoreService;
     }

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensRoute.java
@@ -52,6 +52,9 @@ public class AuthTokensRoute extends BaseRoute {
     private static final String ID_TOKEN_KEY      = "id_token";
     private static final String REFRESH_TOKEN_KEY = "refresh_token";
 
+    // Regex to match /auth/tokens and /auth/tokens/ only
+    private static final String PATH_PATTERN = "\\/tokens\\/?";
+
     private static final IBeanValidator<TokenPayload> validator = new TokenPayloadValidator();
 
     public AuthTokensRoute(
@@ -61,8 +64,7 @@ public class AuthTokensRoute extends BaseRoute {
         IAuthStoreService authStoreService,
         Environment env
     ) {
-        // Regex to match /auth/tokens only
-        super(responseBuilder, "\\/tokens\\/?");
+        super(responseBuilder, PATH_PATTERN);
         this.oidcProvider = oidcProvider;
         this.dexGrpcClient = dexGrpcClient;
         this.authStoreService = authStoreService;

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensRoute.java
@@ -38,7 +38,7 @@ import dev.galasa.framework.api.common.ResponseBuilder;
 import dev.galasa.framework.api.common.ServletError;
 import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.auth.IAuthStoreService;
-import dev.galasa.framework.spi.auth.IAuthToken;
+import dev.galasa.framework.spi.auth.IInternalAuthToken;
 import dev.galasa.framework.spi.auth.User;
 import dev.galasa.framework.spi.auth.AuthStoreException;
 
@@ -83,11 +83,11 @@ public class AuthTokensRoute extends BaseRoute {
         List<AuthToken> tokensToReturn = new ArrayList<>();
         try {
             // Retrieve all the tokens and put them into a mutable list before sorting them based on their creation time
-            List<IAuthToken> tokens = new ArrayList<>(authStoreService.getTokens());
-            Collections.sort(tokens, Comparator.comparing(IAuthToken::getCreationTime));
+            List<IInternalAuthToken> tokens = new ArrayList<>(authStoreService.getTokens());
+            Collections.sort(tokens, Comparator.comparing(IInternalAuthToken::getCreationTime));
 
             // Convert the token received from the auth store into the token bean that will be returned as JSON
-            for (IAuthToken token : tokens) {
+            for (IInternalAuthToken token : tokens) {
                 tokensToReturn.add(new AuthToken(
                     token.getTokenId(),
                     token.getDescription(),
@@ -162,7 +162,7 @@ public class AuthTokensRoute extends BaseRoute {
      */
     private String getTokensAsJsonString(List<AuthToken> tokens) {
         JsonArray tokensArray = new JsonArray();
-        for (IAuthToken token : tokens) {
+        for (AuthToken token : tokens) {
             String tokenJson = gson.toJson(token);
             tokensArray.add(JsonParser.parseString(tokenJson));
         }

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/DexGrpcClientTest.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/DexGrpcClientTest.java
@@ -123,4 +123,37 @@ public class DexGrpcClientTest {
         assertThat(thrown.getMessage()).contains("GAL5063E", "Failed to delete client with the given ID");
         assertThat(client.getDexClients()).hasSize(2);
     }
+
+    @Test
+    public void testRevokeRefreshWithNonExistantClientThrowsException() throws Exception {
+        // Given...
+        MockDexGrpcClient client = new MockDexGrpcClient("http://my.issuer");
+
+        // When...
+        Throwable thrown = catchThrowableOfType(() -> {
+            client.revokeRefreshToken("my-user", "notfound");
+        }, InternalServletException.class);
+
+        // Then...
+        assertThat(thrown.getMessage()).contains("GAL5064E", "Failed to revoke the token with the given ID");
+    }
+
+    @Test
+    public void testRevokeRefreshRemovesTokenOK() throws Exception {
+        // Given...
+        String userId = "my-user";
+        String clientId = "my-client";
+
+        MockDexGrpcClient client = new MockDexGrpcClient("http://my.issuer");
+        client.addDexClient(clientId, "my-secret", "http://my-callback-url");
+        client.addMockRefreshToken(userId, clientId);
+
+        assertThat(client.getRefreshTokens()).hasSize(1);
+
+        // When...
+        client.revokeRefreshToken(userId, clientId);
+
+        // Then...
+        assertThat(client.getRefreshTokens()).hasSize(0);
+    }
 }

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/mocks/MockDexGrpcClient.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/mocks/MockDexGrpcClient.java
@@ -73,12 +73,11 @@ public class MockDexGrpcClient extends DexGrpcClient {
         com.coreos.dex.api.DexOuterClass.DeleteClientResp.Builder deleteClientRespBuilder = DeleteClientResp.newBuilder();
         String clientId = deleteClientReq.getId();
         Client clientToRemove = getDexClient(clientId);
+        deleteClientRespBuilder.setNotFound(true);
 
         if (clientToRemove != null) {
             dexClients.remove(clientToRemove);
             deleteClientRespBuilder.setNotFound(false);
-        } else {
-            deleteClientRespBuilder.setNotFound(true);
         }
         return deleteClientRespBuilder.build();
     }

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/mocks/MockDexGrpcClient.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/mocks/MockDexGrpcClient.java
@@ -1,8 +1,18 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package dev.galasa.framework.api.authentication.mocks;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import com.coreos.dex.api.DexOuterClass.Client;
 import com.coreos.dex.api.DexOuterClass.CreateClientReq;
 import com.coreos.dex.api.DexOuterClass.CreateClientResp;
+import com.coreos.dex.api.DexOuterClass.DeleteClientReq;
+import com.coreos.dex.api.DexOuterClass.DeleteClientResp;
 import com.coreos.dex.api.DexOuterClass.GetClientReq;
 import com.coreos.dex.api.DexOuterClass.GetClientResp;
 import com.coreos.dex.api.DexOuterClass.CreateClientResp.Builder;
@@ -14,11 +24,11 @@ import io.grpc.StatusRuntimeException;
 // A class that only mocks out methods that interact with Dex's gRPC service
 public class MockDexGrpcClient extends DexGrpcClient {
 
-    private Client dexClient;
+    private List<Client> dexClients = new ArrayList<>();
 
     public MockDexGrpcClient(String issuerHostname, String clientId, String clientSecret, String callbackUrl) {
         super(issuerHostname, "http://my-ecosystem");
-        this.dexClient = createDexClient(clientId, clientSecret, callbackUrl);
+        addDexClient(clientId, clientSecret, callbackUrl);
     }
 
     public MockDexGrpcClient(String issuerHostname) {
@@ -35,8 +45,8 @@ public class MockDexGrpcClient extends DexGrpcClient {
     @Override
     public CreateClientResp sendCreateClientRequest(CreateClientReq createClientReq) {
         Builder createClientRespBuilder = CreateClientResp.newBuilder();
-        if (this.dexClient != null) {
-            createClientRespBuilder.setClient(this.dexClient);
+        if (dexClients != null && !dexClients.isEmpty()) {
+            createClientRespBuilder.setClient(dexClients.get(0));
         }
         return createClientRespBuilder.build();
     }
@@ -44,26 +54,49 @@ public class MockDexGrpcClient extends DexGrpcClient {
     @Override
     public GetClientResp sendGetClientRequest(GetClientReq getClientReq) {
         com.coreos.dex.api.DexOuterClass.GetClientResp.Builder getClientRespBuilder = GetClientResp.newBuilder();
-        if (this.dexClient != null) {
-            if (this.dexClient.getId().equals("error")) {
+        if (dexClients != null && !dexClients.isEmpty()) {
+            Client dexClient = dexClients.get(0);
+            if (dexClient.getId().equals("error")) {
                 throw new StatusRuntimeException(Status.UNKNOWN);
             } else {
-                getClientRespBuilder.setClient(this.dexClient);
+                getClientRespBuilder.setClient(dexClient);
             }
         }
         return getClientRespBuilder.build();
     }
+    @Override
+    public DeleteClientResp sendDeleteClientRequest(DeleteClientReq deleteClientReq) {
+        com.coreos.dex.api.DexOuterClass.DeleteClientResp.Builder deleteClientRespBuilder = DeleteClientResp.newBuilder();
+        String clientId = deleteClientReq.getId();
 
-    private Client createDexClient(String clientId, String clientSecret, String callbackUrl) {
+        Client clientToRemove = null;
+        for (Client dexClient : dexClients) {
+            if (dexClient.getId().equals(clientId)) {
+                clientToRemove = dexClient;
+                break;
+            }
+        }
+
+        if (clientToRemove != null) {
+            dexClients.remove(clientToRemove);
+            deleteClientRespBuilder.setNotFound(false);
+        } else {
+            deleteClientRespBuilder.setNotFound(true);
+        }
+        
+        return deleteClientRespBuilder.build();
+    }
+
+    public void addDexClient(String clientId, String clientSecret, String callbackUrl) {
         com.coreos.dex.api.DexOuterClass.Client.Builder clientBuilder = Client.newBuilder();
         clientBuilder.setId(clientId);
         clientBuilder.setSecret(clientSecret);
         clientBuilder.addRedirectUris(callbackUrl);
 
-        return clientBuilder.build();
+        dexClients.add(clientBuilder.build());
     }
 
-    public Client getDexClient() {
-        return dexClient;
+    public List<Client> getDexClients() {
+        return dexClients;
     }
 }

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/mocks/MockDexGrpcClient.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/mocks/MockDexGrpcClient.java
@@ -87,17 +87,19 @@ public class MockDexGrpcClient extends DexGrpcClient {
     public RevokeRefreshResp sendRevokeRefreshRequest(RevokeRefreshReq revokeRefreshReq) {
         com.coreos.dex.api.DexOuterClass.RevokeRefreshResp.Builder builder = RevokeRefreshResp.newBuilder();
         String clientId = revokeRefreshReq.getClientId();
-        if (clientId.equals("notfound")) {
-            builder.setNotFound(true);
-        } else {
-            builder.setNotFound(false);
+        builder.setNotFound(true);
+
+        if (!clientId.equals("notfound")) {
             String tokenToRemove = null;
             for (String refreshToken : refreshTokens) {
                 if (refreshToken.endsWith(clientId)) {
                     tokenToRemove = refreshToken;
                 }
             }
-            refreshTokens.remove(tokenToRemove);
+            if (tokenToRemove != null) {
+                refreshTokens.remove(tokenToRemove);
+                builder.setNotFound(false);
+            }
         }
         return builder.build();
     }

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/mocks/MockOidcProvider.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/mocks/MockOidcProvider.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package dev.galasa.framework.api.authentication.mocks;
 
 import java.io.IOException;

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthRouteTest.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthRouteTest.java
@@ -37,7 +37,7 @@ import dev.galasa.framework.api.common.mocks.MockHttpServletResponse;
 import dev.galasa.framework.api.common.mocks.MockHttpSession;
 import dev.galasa.framework.api.common.mocks.MockTimeService;
 import dev.galasa.framework.api.common.mocks.MockFramework;
-import dev.galasa.framework.spi.auth.IAuthToken;
+import dev.galasa.framework.spi.auth.IInternalAuthToken;
 import dev.galasa.framework.spi.utils.GalasaGson;
 
 public class AuthRouteTest extends BaseServletTest {
@@ -232,10 +232,10 @@ public class AuthRouteTest extends BaseServletTest {
         assertThat(outStream.toString()).isEqualTo(gson.toJson(expectedJsonObject));
 
         // A record of the newly-created token should have been added to the auth store
-        List<IAuthToken> tokens = mockAuthStoreService.getTokens();
+        List<IInternalAuthToken> tokens = mockAuthStoreService.getTokens();
         assertThat(tokens).hasSize(1);
 
-        IAuthToken newToken = tokens.get(0);
+        IInternalAuthToken newToken = tokens.get(0);
         assertThat(newToken.getDescription()).isEqualTo(tokenDescription);
         assertThat(newToken.getCreationTime()).isEqualTo(tokenCreationTime);
         assertThat(newToken.getOwner().getLoginId()).isEqualTo(userName);

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthTokensDetailsRouteTest.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthTokensDetailsRouteTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.api.authentication.routes;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.junit.Test;
+
+import dev.galasa.framework.api.authentication.internal.routes.AuthTokensDetailsRoute;
+import dev.galasa.framework.api.authentication.mocks.MockAuthenticationServlet;
+import dev.galasa.framework.api.common.AuthToken;
+import dev.galasa.framework.api.common.mocks.MockAuthStoreService;
+import dev.galasa.framework.api.common.mocks.MockFramework;
+import dev.galasa.framework.api.common.mocks.MockHttpServletRequest;
+import dev.galasa.framework.api.common.mocks.MockHttpServletResponse;
+import dev.galasa.framework.spi.auth.IAuthToken;
+import dev.galasa.framework.spi.auth.User;
+
+public class AuthTokensDetailsRouteTest {
+
+    @Test
+    public void testAuthTokensDetailsRouteRegexMatchesExpectedPaths(){
+        //Given...
+        String tokensDetailsRoutePath = new AuthTokensDetailsRoute(null, null, null).getPath();
+
+        //When...
+        Pattern routePattern = Pattern.compile(tokensDetailsRoutePath);
+
+        //Then...
+        // The route should only accept /tokens/{tokenid}, where {tokenid} contains:
+        // - alphanumeric characters
+        // - dashes (-)
+        // - underscores (_)
+        assertThat(routePattern.matcher("/tokens/abc").matches()).isTrue();
+        assertThat(routePattern.matcher("/tokens/123").matches()).isTrue();
+        assertThat(routePattern.matcher("/tokens/1-token-2").matches()).isTrue();
+        assertThat(routePattern.matcher("/tokens/token_1_2_a876").matches()).isTrue();
+        assertThat(routePattern.matcher("/tokens/this-1s_4n-id").matches()).isTrue();
+
+        // The route should not accept the following
+        assertThat(routePattern.matcher("/tokens/hello-world!").matches()).isFalse();
+        assertThat(routePattern.matcher("/token/is-missing-an-s").matches()).isFalse();
+        assertThat(routePattern.matcher("/tokens/////").matches()).isFalse();
+        assertThat(routePattern.matcher("/t0kens/    ").matches()).isFalse();
+        assertThat(routePattern.matcher("/").matches()).isFalse();
+        assertThat(routePattern.matcher("").matches()).isFalse();
+    }
+
+    @Test
+    public void testDeleteAuthTokensRevokesTokenOK() throws Exception {
+        // Given...
+        String tokenId = "id123";
+        String description = "test token";
+        Instant creationTime = Instant.now();
+        User owner = new User("username");
+
+        List<IAuthToken> tokens = new ArrayList<>();
+        tokens.add(new AuthToken(tokenId, description, creationTime, owner));
+
+        MockAuthStoreService authStoreService = new MockAuthStoreService(tokens);
+        MockAuthenticationServlet servlet = new MockAuthenticationServlet(new MockFramework(authStoreService));
+
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest("/tokens/" + tokenId, "", "DELETE");
+        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
+
+        // When...
+        assertThat(authStoreService.getTokens()).hasSize(1);
+        servlet.init();
+        servlet.doDelete(mockRequest, servletResponse);
+
+        // Then...
+        assertThat(servletResponse.getStatus()).isEqualTo(200);
+        assertThat(authStoreService.getTokens()).hasSize(0);
+    } 
+}

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthTokensDetailsRouteTest.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthTokensDetailsRouteTest.java
@@ -56,6 +56,7 @@ public class AuthTokensDetailsRouteTest extends BaseServletTest {
         // - dashes (-)
         // - underscores (_)
         assertThat(routePattern.matcher("/tokens/abc").matches()).isTrue();
+        assertThat(routePattern.matcher("/tokens/abc/").matches()).isTrue();
         assertThat(routePattern.matcher("/tokens/123").matches()).isTrue();
         assertThat(routePattern.matcher("/tokens/1-token-2").matches()).isTrue();
         assertThat(routePattern.matcher("/tokens/token_1_2_a876").matches()).isTrue();

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthTokensDetailsRouteTest.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthTokensDetailsRouteTest.java
@@ -10,18 +10,25 @@ import static org.assertj.core.api.Assertions.*;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
+
+import javax.servlet.ServletOutputStream;
 
 import org.junit.Test;
 
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+
 import dev.galasa.framework.api.authentication.internal.routes.AuthTokensDetailsRoute;
 import dev.galasa.framework.api.authentication.mocks.MockAuthenticationServlet;
-import dev.galasa.framework.api.common.AuthToken;
+import dev.galasa.framework.api.authentication.mocks.MockDexGrpcClient;
 import dev.galasa.framework.api.common.mocks.MockAuthStoreService;
 import dev.galasa.framework.api.common.mocks.MockFramework;
 import dev.galasa.framework.api.common.mocks.MockHttpServletRequest;
 import dev.galasa.framework.api.common.mocks.MockHttpServletResponse;
-import dev.galasa.framework.spi.auth.IAuthToken;
+import dev.galasa.framework.api.common.mocks.MockInternalAuthToken;
+import dev.galasa.framework.spi.auth.IInternalAuthToken;
 import dev.galasa.framework.spi.auth.User;
 
 public class AuthTokensDetailsRouteTest {
@@ -59,16 +66,28 @@ public class AuthTokensDetailsRouteTest {
         // Given...
         String tokenId = "id123";
         String description = "test token";
+        String clientId = "my-client";
         Instant creationTime = Instant.now();
         User owner = new User("username");
 
-        List<IAuthToken> tokens = new ArrayList<>();
-        tokens.add(new AuthToken(tokenId, description, creationTime, owner));
+        List<IInternalAuthToken> tokens = new ArrayList<>();
+        tokens.add(new MockInternalAuthToken(tokenId, description, creationTime, owner, clientId));
+
+        MockDexGrpcClient mockDexGrpcClient = new MockDexGrpcClient("http://my-issuer");
+        mockDexGrpcClient.addDexClient(clientId, "my-secret", "http://a-callback-url");
+        mockDexGrpcClient.addMockRefreshToken(owner.getLoginId(), clientId);
 
         MockAuthStoreService authStoreService = new MockAuthStoreService(tokens);
-        MockAuthenticationServlet servlet = new MockAuthenticationServlet(new MockFramework(authStoreService));
+        MockAuthenticationServlet servlet = new MockAuthenticationServlet(null, mockDexGrpcClient, new MockFramework(authStoreService));
 
-        MockHttpServletRequest mockRequest = new MockHttpServletRequest("/tokens/" + tokenId, "", "DELETE");
+        Algorithm mockJwtSigningAlgorithm = Algorithm.HMAC256("dummysecret");
+        String mockJwt = JWT.create()
+            .withSubject(owner.getLoginId())
+            .withIssuedAt(Instant.EPOCH)
+            .sign(mockJwtSigningAlgorithm);
+
+        Map<String, String> headers = Map.of("Authorization", "Bearer " + mockJwt);
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest("/tokens/" + tokenId, "", "DELETE", headers);
         MockHttpServletResponse servletResponse = new MockHttpServletResponse();
 
         // When...
@@ -79,5 +98,48 @@ public class AuthTokensDetailsRouteTest {
         // Then...
         assertThat(servletResponse.getStatus()).isEqualTo(200);
         assertThat(authStoreService.getTokens()).hasSize(0);
-    } 
+    }
+
+    @Test
+    public void testDeleteAuthTokensWithFailingAuthStoreAccessThrowsError() throws Exception {
+        // Given...
+        String tokenId = "id123";
+        String description = "test token";
+        String clientId = "my-client";
+        Instant creationTime = Instant.now();
+        User owner = new User("username");
+
+        List<IInternalAuthToken> tokens = new ArrayList<>();
+        tokens.add(new MockInternalAuthToken(tokenId, description, creationTime, owner, clientId));
+
+        MockDexGrpcClient mockDexGrpcClient = new MockDexGrpcClient("http://my-issuer");
+        mockDexGrpcClient.addDexClient(clientId, "my-secret", "http://a-callback-url");
+        mockDexGrpcClient.addMockRefreshToken(owner.getLoginId(), clientId);
+
+        MockAuthStoreService authStoreService = new MockAuthStoreService(tokens);
+
+        // Throw an exception to simulate an auth store failure
+        authStoreService.setThrowException(true);
+
+        MockAuthenticationServlet servlet = new MockAuthenticationServlet(null, mockDexGrpcClient, new MockFramework(authStoreService));
+
+        Algorithm mockJwtSigningAlgorithm = Algorithm.HMAC256("dummysecret");
+        String mockJwt = JWT.create()
+            .withSubject(owner.getLoginId())
+            .withIssuedAt(Instant.EPOCH)
+            .sign(mockJwtSigningAlgorithm);
+
+        Map<String, String> headers = Map.of("Authorization", "Bearer " + mockJwt);
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest("/tokens/" + tokenId, "", "DELETE", headers);
+        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
+        ServletOutputStream outStream = servletResponse.getOutputStream();
+
+        // When...
+        servlet.init();
+        servlet.doDelete(mockRequest, servletResponse);
+
+        // Then...
+        assertThat(servletResponse.getStatus()).isEqualTo(500);
+        assertThat(outStream.toString()).contains("GAL5064E", "Failed to revoke the token with the given ID");
+    }
 }

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthTokensDetailsRouteTest.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthTokensDetailsRouteTest.java
@@ -180,6 +180,6 @@ public class AuthTokensDetailsRouteTest {
 
         // Then...
         assertThat(servletResponse.getStatus()).isEqualTo(404);
-        assertThat(outStream.toString()).contains("GAL5064E", "Failed to revoke the token with the given ID");
+        assertThat(outStream.toString()).contains("GAL5066E", "No such token with the given ID exists");
     }
 }

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthTokensDetailsRouteTest.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthTokensDetailsRouteTest.java
@@ -23,6 +23,7 @@ import com.auth0.jwt.algorithms.Algorithm;
 import dev.galasa.framework.api.authentication.internal.routes.AuthTokensDetailsRoute;
 import dev.galasa.framework.api.authentication.mocks.MockAuthenticationServlet;
 import dev.galasa.framework.api.authentication.mocks.MockDexGrpcClient;
+import dev.galasa.framework.api.common.BaseServletTest;
 import dev.galasa.framework.api.common.mocks.MockAuthStoreService;
 import dev.galasa.framework.api.common.mocks.MockFramework;
 import dev.galasa.framework.api.common.mocks.MockHttpServletRequest;
@@ -31,10 +32,18 @@ import dev.galasa.framework.api.common.mocks.MockInternalAuthToken;
 import dev.galasa.framework.spi.auth.IInternalAuthToken;
 import dev.galasa.framework.spi.auth.User;
 
-public class AuthTokensDetailsRouteTest {
+public class AuthTokensDetailsRouteTest extends BaseServletTest {
+
+    private String createMockJwt(String userId) {
+        Algorithm mockJwtSigningAlgorithm = Algorithm.HMAC256("dummysecret");
+        return JWT.create()
+            .withSubject(userId)
+            .withIssuedAt(Instant.EPOCH)
+            .sign(mockJwtSigningAlgorithm);
+    }
 
     @Test
-    public void testAuthTokensDetailsRouteRegexMatchesExpectedPaths(){
+    public void testAuthTokensDetailsRouteRegexMatchesExpectedPaths() throws Exception {
         //Given...
         String tokensDetailsRoutePath = new AuthTokensDetailsRoute(null, null, null).getPath();
 
@@ -80,11 +89,7 @@ public class AuthTokensDetailsRouteTest {
         MockAuthStoreService authStoreService = new MockAuthStoreService(tokens);
         MockAuthenticationServlet servlet = new MockAuthenticationServlet(null, mockDexGrpcClient, new MockFramework(authStoreService));
 
-        Algorithm mockJwtSigningAlgorithm = Algorithm.HMAC256("dummysecret");
-        String mockJwt = JWT.create()
-            .withSubject(owner.getLoginId())
-            .withIssuedAt(Instant.EPOCH)
-            .sign(mockJwtSigningAlgorithm);
+        String mockJwt = createMockJwt(owner.getLoginId());
 
         Map<String, String> headers = Map.of("Authorization", "Bearer " + mockJwt);
         MockHttpServletRequest mockRequest = new MockHttpServletRequest("/tokens/" + tokenId, "", "DELETE", headers);
@@ -123,11 +128,7 @@ public class AuthTokensDetailsRouteTest {
 
         MockAuthenticationServlet servlet = new MockAuthenticationServlet(null, mockDexGrpcClient, new MockFramework(authStoreService));
 
-        Algorithm mockJwtSigningAlgorithm = Algorithm.HMAC256("dummysecret");
-        String mockJwt = JWT.create()
-            .withSubject(owner.getLoginId())
-            .withIssuedAt(Instant.EPOCH)
-            .sign(mockJwtSigningAlgorithm);
+        String mockJwt = createMockJwt(owner.getLoginId());
 
         Map<String, String> headers = Map.of("Authorization", "Bearer " + mockJwt);
         MockHttpServletRequest mockRequest = new MockHttpServletRequest("/tokens/" + tokenId, "", "DELETE", headers);
@@ -140,7 +141,7 @@ public class AuthTokensDetailsRouteTest {
 
         // Then...
         assertThat(servletResponse.getStatus()).isEqualTo(500);
-        assertThat(outStream.toString()).contains("GAL5064E", "Failed to revoke the token with the given ID");
+        checkErrorStructure(outStream.toString(), 5064, "GAL5064E", "Failed to revoke the token with the given ID");
     }
 
     @Test
@@ -160,14 +161,9 @@ public class AuthTokensDetailsRouteTest {
         mockDexGrpcClient.addMockRefreshToken(owner.getLoginId(), clientId);
 
         MockAuthStoreService authStoreService = new MockAuthStoreService(tokens);
-
         MockAuthenticationServlet servlet = new MockAuthenticationServlet(null, mockDexGrpcClient, new MockFramework(authStoreService));
 
-        Algorithm mockJwtSigningAlgorithm = Algorithm.HMAC256("dummysecret");
-        String mockJwt = JWT.create()
-            .withSubject(owner.getLoginId())
-            .withIssuedAt(Instant.EPOCH)
-            .sign(mockJwtSigningAlgorithm);
+        String mockJwt = createMockJwt(owner.getLoginId());
 
         Map<String, String> headers = Map.of("Authorization", "Bearer " + mockJwt);
         MockHttpServletRequest mockRequest = new MockHttpServletRequest("/tokens/" + tokenId, "", "DELETE", headers);
@@ -180,7 +176,7 @@ public class AuthTokensDetailsRouteTest {
 
         // Then...
         assertThat(servletResponse.getStatus()).isEqualTo(404);
-        assertThat(outStream.toString()).contains("GAL5066E", "No such token with the given ID exists");
+        checkErrorStructure(outStream.toString(), 5066, "GAL5066E", "No such token with the given ID exists");
     }
 
     @Test
@@ -200,14 +196,9 @@ public class AuthTokensDetailsRouteTest {
         mockDexGrpcClient.addMockRefreshToken(owner.getLoginId(), clientId);
 
         MockAuthStoreService authStoreService = new MockAuthStoreService(tokens);
-
         MockAuthenticationServlet servlet = new MockAuthenticationServlet(null, mockDexGrpcClient, new MockFramework(authStoreService));
 
-        Algorithm mockJwtSigningAlgorithm = Algorithm.HMAC256("dummysecret");
-        String mockJwt = JWT.create()
-            .withSubject(owner.getLoginId())
-            .withIssuedAt(Instant.EPOCH)
-            .sign(mockJwtSigningAlgorithm);
+        String mockJwt = createMockJwt(owner.getLoginId());
 
         Map<String, String> headers = Map.of("Authorization", "Bearer " + mockJwt);
         MockHttpServletRequest mockRequest = new MockHttpServletRequest("/tokens/" + tokenId, "", "DELETE", headers);
@@ -220,7 +211,7 @@ public class AuthTokensDetailsRouteTest {
 
         // Then...
         assertThat(servletResponse.getStatus()).isEqualTo(404);
-        assertThat(outStream.toString()).contains("GAL5063E", "Failed to delete client with the given ID");
+        checkErrorStructure(outStream.toString(), 5063, "GAL5063E", "Failed to delete client with the given ID");
     }
 
     @Test
@@ -240,14 +231,9 @@ public class AuthTokensDetailsRouteTest {
         mockDexGrpcClient.addDexClient(clientId, "my-secret", "http://a-callback-url");
 
         MockAuthStoreService authStoreService = new MockAuthStoreService(tokens);
-
         MockAuthenticationServlet servlet = new MockAuthenticationServlet(null, mockDexGrpcClient, new MockFramework(authStoreService));
 
-        Algorithm mockJwtSigningAlgorithm = Algorithm.HMAC256("dummysecret");
-        String mockJwt = JWT.create()
-            .withSubject(owner.getLoginId())
-            .withIssuedAt(Instant.EPOCH)
-            .sign(mockJwtSigningAlgorithm);
+        String mockJwt = createMockJwt(owner.getLoginId());
 
         Map<String, String> headers = Map.of("Authorization", "Bearer " + mockJwt);
         MockHttpServletRequest mockRequest = new MockHttpServletRequest("/tokens/" + tokenId, "", "DELETE", headers);
@@ -260,6 +246,6 @@ public class AuthTokensDetailsRouteTest {
 
         // Then...
         assertThat(servletResponse.getStatus()).isEqualTo(404);
-        assertThat(outStream.toString()).contains("GAL5064E", "Failed to revoke the token with the given ID");
+        checkErrorStructure(outStream.toString(), 5064, "GAL5064E", "Failed to revoke the token with the given ID");
     }
 }

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthTokensRouteTest.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthTokensRouteTest.java
@@ -31,9 +31,10 @@ import dev.galasa.framework.api.common.AuthToken;
 import dev.galasa.framework.api.common.BaseServletTest;
 import dev.galasa.framework.api.common.mocks.MockHttpServletRequest;
 import dev.galasa.framework.api.common.mocks.MockHttpServletResponse;
+import dev.galasa.framework.api.common.mocks.MockInternalAuthToken;
 import dev.galasa.framework.api.common.mocks.MockTimeService;
 import dev.galasa.framework.api.common.mocks.MockAuthStoreService;
-import dev.galasa.framework.spi.auth.IAuthToken;
+import dev.galasa.framework.spi.auth.IInternalAuthToken;
 import dev.galasa.framework.spi.auth.User;
 import dev.galasa.framework.spi.utils.GalasaGson;
 import dev.galasa.framework.api.common.mocks.MockFramework;
@@ -124,11 +125,12 @@ public class AuthTokensRouteTest extends BaseServletTest {
         // Given...
         String tokenId = "id123";
         String description = "test token";
+        String clientId = "my-client";
         Instant creationTime = Instant.now();
         User owner = new User("username");
 
-        List<IAuthToken> tokens = List.of(
-            new AuthToken(tokenId, description, creationTime, owner)
+        List<IInternalAuthToken> tokens = List.of(
+            new MockInternalAuthToken(tokenId, description, creationTime, owner, clientId)
         );
         MockAuthStoreService authStoreService = new MockAuthStoreService(tokens);
         MockAuthenticationServlet servlet = new MockAuthenticationServlet(new MockFramework(authStoreService));
@@ -161,11 +163,12 @@ public class AuthTokensRouteTest extends BaseServletTest {
         // Given...
         String tokenId = "id123";
         String description = "test token";
+        String clientId = "my-client";
         Instant creationTime = Instant.now();
         User owner = new User("username");
 
-        List<IAuthToken> tokens = List.of(
-            new AuthToken(tokenId, description, creationTime, owner)
+        List<IInternalAuthToken> tokens = List.of(
+            new MockInternalAuthToken(tokenId, description, creationTime, owner, clientId)
         );
         MockAuthStoreService authStoreService = new MockAuthStoreService(tokens);
         authStoreService.setThrowException(true);
@@ -200,7 +203,13 @@ public class AuthTokensRouteTest extends BaseServletTest {
         AuthToken token3 = new AuthToken("token3", "future creation time", time3, owner);
         AuthToken token4 = new AuthToken("token4", "creation time after epoch, same as token1", time2, owner);
 
-        List<IAuthToken> tokens = List.of(token1, token2, token3, token4);
+        List<IInternalAuthToken> tokens = List.of(
+            new MockInternalAuthToken(token1),
+            new MockInternalAuthToken(token2),
+            new MockInternalAuthToken(token3),
+            new MockInternalAuthToken(token4)
+        );
+
         List<AuthToken> expectedTokenOrder = List.of(token2, token1, token4, token3);
 
         MockAuthStoreService authStoreService = new MockAuthStoreService(tokens);
@@ -476,10 +485,10 @@ public class AuthTokensRouteTest extends BaseServletTest {
         assertThat(outStream.toString()).isEqualTo(gson.toJson(expectedJsonObject));
 
         // A record of the newly-created token should have been added to the auth store
-        List<IAuthToken> tokens = mockAuthStoreService.getTokens();
+        List<IInternalAuthToken> tokens = mockAuthStoreService.getTokens();
         assertThat(tokens).hasSize(1);
 
-        IAuthToken newToken = tokens.get(0);
+        IInternalAuthToken newToken = tokens.get(0);
         assertThat(newToken.getDescription()).isEqualTo(tokenDescription);
         assertThat(newToken.getCreationTime()).isEqualTo(tokenCreationTime);
         assertThat(newToken.getOwner().getLoginId()).isEqualTo(userName);

--- a/galasa-parent/dev.galasa.framework.api.common/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api.common/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 description = 'Framework API - Common Packages'
 
-version = '0.35.0'
+version = '0.36.0'
 
 dependencies {
     implementation project(':dev.galasa.framework')

--- a/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/AuthToken.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/AuthToken.java
@@ -9,10 +9,9 @@ import java.time.Instant;
 
 import com.google.gson.annotations.SerializedName;
 
-import dev.galasa.framework.spi.auth.IAuthToken;
 import dev.galasa.framework.spi.auth.User;
 
-public class AuthToken implements IAuthToken {
+public class AuthToken {
 
     @SerializedName("token_id")
     private String tokenId;

--- a/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/BaseServlet.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/BaseServlet.java
@@ -84,12 +84,14 @@ public class BaseServlet extends HttpServlet {
             errorString = ex.getMessage();
             httpStatusCode = ex.getHttpFailureCode();
             logger.error(errorString, ex);
-            getResponseBuilder().buildResponse(req, res, "application/json", errorString, httpStatusCode);
         } catch (Throwable t) {
             // We didn't expect this failure to arrive. So deliver a generic error message.
             errorString = new ServletError(GAL5000_GENERIC_API_ERROR).toJsonString();
             httpStatusCode = HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
             logger.error(errorString, t);
+        }
+
+        if (!errorString.isEmpty()) {
             getResponseBuilder().buildResponse(req, res, "application/json", errorString, httpStatusCode);
         }
     }

--- a/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/BaseServlet.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/BaseServlet.java
@@ -79,21 +79,19 @@ public class BaseServlet extends HttpServlet {
 
         try {
             processRoutes(req, res);
-            return;
         } catch (InternalServletException ex) {
-            // the message is a curated servlet message, we intentionally threw up to this
-            // level.
+            // the message is a curated servlet message, we intentionally threw up to this level.
             errorString = ex.getMessage();
             httpStatusCode = ex.getHttpFailureCode();
             logger.error(errorString, ex);
+            getResponseBuilder().buildResponse(req, res, "application/json", errorString, httpStatusCode);
         } catch (Throwable t) {
             // We didn't expect this failure to arrive. So deliver a generic error message.
             errorString = new ServletError(GAL5000_GENERIC_API_ERROR).toJsonString();
             httpStatusCode = HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
             logger.error(errorString, t);
+            getResponseBuilder().buildResponse(req, res, "application/json", errorString, httpStatusCode);
         }
-
-        getResponseBuilder().buildResponse(req, res, "application/json", errorString, httpStatusCode);
     }
 
     private void processRoutes(HttpServletRequest req, HttpServletResponse res)
@@ -106,6 +104,7 @@ public class BaseServlet extends HttpServlet {
 
         QueryParameters queryParameters = new QueryParameters(req.getParameterMap());
 
+        boolean pathMatched = false;
         for (Map.Entry<String, IRoute> entry : routes.entrySet()) {
 
             String routePattern = entry.getKey();
@@ -114,6 +113,7 @@ public class BaseServlet extends HttpServlet {
             Matcher matcher = Pattern.compile(routePattern).matcher(url);
 
             if (matcher.matches()) {
+                pathMatched = true;
                 logger.info("BaseServlet: Found a route that matches.");
                 if (req.getMethod().contains("PUT")){
                     route.handlePutRequest(url, queryParameters, req, res);
@@ -124,13 +124,15 @@ public class BaseServlet extends HttpServlet {
                 } else {
                     route.handleGetRequest(url, queryParameters, req, res);
                 }
-                return;
+                break;
             }
         }
 
-        // No matching route was found, throw a 404 error.
-        logger.info("BaseServlet: No matching route found.");
-        ServletError error = new ServletError(GAL5404_UNRESOLVED_ENDPOINT_ERROR, url);
-        throw new InternalServletException(error, HttpServletResponse.SC_NOT_FOUND);
+        if (!pathMatched) {
+            // No matching route was found, throw a 404 error.
+            logger.info("BaseServlet: No matching route found.");
+            ServletError error = new ServletError(GAL5404_UNRESOLVED_ENDPOINT_ERROR, url);
+            throw new InternalServletException(error, HttpServletResponse.SC_NOT_FOUND);
+        }
     }
 }

--- a/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
@@ -97,7 +97,7 @@ public enum ServletErrorMessage {
     GAL5062_INVALID_TOKEN_REQUEST_BODY                (5062, "E: Invalid request body provided. Please ensure that you have provided a client ID and either a refresh token or a authorization code in your request. Allowable characters for these parameters are 'a'-'z', 'A'-'Z', '0'-'9', '-' (dash), and '_' (underscore)"),
     GAL5063_FAILED_TO_DELETE_CLIENT                   (5063, "E: Failed to delete client with the given ID. Please ensure that you have provided a valid ID representing an existing Dex client in your request and try again"),
     GAL5064_FAILED_TO_REVOKE_TOKEN                    (5064, "E: Failed to revoke the token with the given ID. Please ensure that you have provided a valid ID representing an existing auth token in your request and try again"),
-    GAL5064_FAILED_TO_GET_TOKEN_ID_FROM_URL           (5065, "E: Failed to retrieve a token ID from the request path. Please ensure that you have provided a valid ID representing an existing auth token in your request and try again"),
+    GAL5065_FAILED_TO_GET_TOKEN_ID_FROM_URL           (5065, "E: Failed to retrieve a token ID from the request path. Please ensure that you have provided a valid ID representing an existing auth token in your request and try again"),
     ;
 
 

--- a/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
@@ -95,6 +95,9 @@ public enum ServletErrorMessage {
     GAL5060_INVALID_OIDC_URI_RECEIVED                 (5060, "E: Internal server error. Invalid OpenID Connect URL received from the Galasa Dex server. Report the problem to your Galasa Ecosystem owner."),
     GAL5061_MISMATCHED_OIDC_URI_RECEIVED              (5061, "E: Internal server error. OpenID Connect URL received from the Galasa Dex server does not match the expected Dex server scheme or host. Report the problem to your Galasa Ecosystem owner."),
     GAL5062_INVALID_TOKEN_REQUEST_BODY                (5062, "E: Invalid request body provided. Please ensure that you have provided a client ID and either a refresh token or a authorization code in your request. Allowable characters for these parameters are 'a'-'z', 'A'-'Z', '0'-'9', '-' (dash), and '_' (underscore)"),
+    GAL5063_FAILED_TO_DELETE_CLIENT                   (5063, "E: Failed to delete client with the given ID. Please ensure that you have provided a valid ID representing an existing Dex client in your request and try again"),
+    GAL5064_FAILED_TO_REVOKE_TOKEN                    (5064, "E: Failed to revoke the token with the given ID. Please ensure that you have provided a valid ID representing an existing auth token in your request and try again"),
+    GAL5064_FAILED_TO_GET_TOKEN_ID_FROM_URL           (5065, "E: Failed to retrieve a token ID from the request path. Please ensure that you have provided a valid ID representing an existing auth token in your request and try again"),
     ;
 
 

--- a/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
@@ -98,6 +98,7 @@ public enum ServletErrorMessage {
     GAL5063_FAILED_TO_DELETE_CLIENT                   (5063, "E: Failed to delete client with the given ID. Please ensure that you have provided a valid ID representing an existing Dex client in your request and try again"),
     GAL5064_FAILED_TO_REVOKE_TOKEN                    (5064, "E: Failed to revoke the token with the given ID. Please ensure that you have provided a valid ID representing an existing auth token in your request and try again"),
     GAL5065_FAILED_TO_GET_TOKEN_ID_FROM_URL           (5065, "E: Failed to retrieve a token ID from the request path. Please ensure that you have provided a valid ID representing an existing auth token in your request and try again"),
+    GAL5066_ERROR_NO_SUCH_TOKEN_EXISTS                (5066, "E: No such token with the given ID exists. Please ensure that you have provided a valid ID representing an existing auth token in your request and try again"),
     ;
 
 

--- a/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockAuthStoreService.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockAuthStoreService.java
@@ -10,21 +10,20 @@ import java.util.ArrayList;
 import java.util.List;
 
 import dev.galasa.framework.spi.auth.IAuthStoreService;
-import dev.galasa.framework.spi.auth.IAuthToken;
+import dev.galasa.framework.spi.auth.IInternalAuthToken;
 import dev.galasa.framework.spi.auth.User;
 import dev.galasa.framework.spi.utils.ITimeService;
-import dev.galasa.framework.api.common.AuthToken;
 import dev.galasa.framework.spi.auth.AuthStoreException;
 
 public class MockAuthStoreService implements IAuthStoreService {
 
-    List<IAuthToken> tokens = new ArrayList<>();
+    List<IInternalAuthToken> tokens = new ArrayList<>();
     private ITimeService timeService;
     private int tokenIdCounter = 0;
 
     private boolean throwException = false;
 
-    public MockAuthStoreService(List<IAuthToken> tokens) {
+    public MockAuthStoreService(List<IInternalAuthToken> tokens) {
         this.tokens = tokens;
         this.timeService = new MockTimeService(Instant.now());
     }
@@ -38,11 +37,10 @@ public class MockAuthStoreService implements IAuthStoreService {
     }
 
     @Override
-    public List<IAuthToken> getTokens() throws AuthStoreException {
+    public List<IInternalAuthToken> getTokens() throws AuthStoreException {
         if (throwException) {
             throwAuthStoreException();
         }
-
         return tokens;
     }
 
@@ -51,7 +49,7 @@ public class MockAuthStoreService implements IAuthStoreService {
         if (throwException) {
             throwAuthStoreException();
         }
-        tokens.add(new AuthToken("token-" + tokenIdCounter, description, timeService.now(), owner));
+        tokens.add(new MockInternalAuthToken("token-" + tokenIdCounter, description, timeService.now(), owner, clientId));
         tokenIdCounter++;
     }
 
@@ -61,7 +59,11 @@ public class MockAuthStoreService implements IAuthStoreService {
 
     @Override
     public void deleteToken(String tokenId) throws AuthStoreException {
-        IAuthToken tokenToRemove = getToken(tokenId);
+        if (throwException) {
+            throwAuthStoreException();
+        }
+
+        IInternalAuthToken tokenToRemove = getToken(tokenId);
         if (tokenToRemove != null) {
             tokens.remove(tokenToRemove);
         } else {
@@ -70,9 +72,13 @@ public class MockAuthStoreService implements IAuthStoreService {
     }
 
     @Override
-    public IAuthToken getToken(String tokenId) throws AuthStoreException {
-        IAuthToken tokenToReturn = null;
-        for (IAuthToken token : tokens) {
+    public IInternalAuthToken getToken(String tokenId) throws AuthStoreException {
+        if (throwException) {
+            throwAuthStoreException();
+        }
+
+        IInternalAuthToken tokenToReturn = null;
+        for (IInternalAuthToken token : tokens) {
             if (token.getTokenId().equals(tokenId)) {
                 tokenToReturn = token;
                 break;

--- a/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockAuthStoreService.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockAuthStoreService.java
@@ -58,4 +58,21 @@ public class MockAuthStoreService implements IAuthStoreService {
     private void throwAuthStoreException() throws AuthStoreException {
         throw new AuthStoreException("simulating an unexpected failure!");
     }
+
+    @Override
+    public void deleteToken(String tokenId) throws AuthStoreException {
+        IAuthToken tokenToRemove = null;
+        for (IAuthToken token : tokens) {
+            if (token.getTokenId().equals(tokenId)) {
+                tokenToRemove = token;
+                break;
+            }
+        }
+        
+        if (tokenToRemove != null) {
+            tokens.remove(tokenToRemove);
+        } else {
+            throw new AuthStoreException("did not find token to delete!");
+        }
+    }
 }

--- a/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockAuthStoreService.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockAuthStoreService.java
@@ -61,18 +61,23 @@ public class MockAuthStoreService implements IAuthStoreService {
 
     @Override
     public void deleteToken(String tokenId) throws AuthStoreException {
-        IAuthToken tokenToRemove = null;
-        for (IAuthToken token : tokens) {
-            if (token.getTokenId().equals(tokenId)) {
-                tokenToRemove = token;
-                break;
-            }
-        }
-        
+        IAuthToken tokenToRemove = getToken(tokenId);
         if (tokenToRemove != null) {
             tokens.remove(tokenToRemove);
         } else {
             throw new AuthStoreException("did not find token to delete!");
         }
+    }
+
+    @Override
+    public IAuthToken getToken(String tokenId) throws AuthStoreException {
+        IAuthToken tokenToReturn = null;
+        for (IAuthToken token : tokens) {
+            if (token.getTokenId().equals(tokenId)) {
+                tokenToReturn = token;
+                break;
+            }
+        }
+        return tokenToReturn;
     }
 }

--- a/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockInternalAuthToken.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockInternalAuthToken.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.api.common.mocks;
+
+import java.time.Instant;
+
+import dev.galasa.framework.api.common.AuthToken;
+import dev.galasa.framework.spi.auth.IInternalAuthToken;
+import dev.galasa.framework.spi.auth.User;
+
+public class MockInternalAuthToken implements IInternalAuthToken {
+
+    private String tokenId;
+    private String description;
+    private String dexClientId;
+    private Instant creationTime;
+    private User owner;
+
+    public MockInternalAuthToken(String tokenId, String description, Instant creationTime, User owner, String dexClientId) {
+        this.tokenId = tokenId;
+        this.description = description;
+        this.dexClientId = dexClientId;
+        this.creationTime = creationTime;
+        this.owner = owner;
+    }
+
+    public MockInternalAuthToken(AuthToken tokenToCopy) {
+        this.tokenId = tokenToCopy.getTokenId();
+        this.description = tokenToCopy.getDescription();
+        this.creationTime = tokenToCopy.getCreationTime();
+        this.owner = tokenToCopy.getOwner();
+    }
+
+    @Override
+    public String getTokenId() {
+        return tokenId;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public String getDexClientId() {
+        return dexClientId;
+    }
+
+    @Override
+    public Instant getCreationTime() {
+        return creationTime;
+    }
+
+    @Override
+    public User getOwner() {
+        return owner;
+    }
+}

--- a/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -306,7 +306,7 @@ paths:
       - $ref: '#/components/parameters/ClientApiVersion'
     delete:
       operationId: deleteToken
-      summary: Deletes a token which is used for authenticating with the Galasa API server.
+      summary: Revokes a token which is used for authenticating with the Galasa API server.
       description: |
         Revokes access for a preivously generated token through specifing the token ID.
 
@@ -324,12 +324,12 @@ paths:
           type: string
       responses:
         '200':
-          description: Action Message
+          description: Success message indicating that the given token has been revoked
           content:
             text/plain:
               schema:
                 type: string
-              example: Successfully deleted token with tokenId from the database
+              example: Successfully revoked token with tokenId from the database
         '401':
           description: Unauthorized as a valid bearer token has not been provided in the "Authorization" header
           content:

--- a/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -329,7 +329,7 @@ paths:
             text/plain:
               schema:
                 type: string
-              example: Successfully revoked token with tokenId from the database
+              example: Successfully revoked token with ID 'tokenId'
         '401':
           description: Unauthorized as a valid bearer token has not been provided in the "Authorization" header
           content:
@@ -342,6 +342,18 @@ paths:
                     error_code: 5401
                     error_message: "GAL5401E: Unauthorized. Please ensure you have provided a valid 'Authorization' header with a valid bearer token and try again."
                   summary: The request was unauthenticated so is unauthorized.
+        '404':
+          description: Could not find an existing auth token with the given ID
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+              examples:
+                notfounderror:
+                  value:
+                    error_code: 5064
+                    error_message: "GAL5064E: Failed to revoke the token with the given ID. Please ensure that you have provided a valid ID representing an existing auth token in your request and try again"
+                  summary: The given token ID in the request did not correspond to an existing token record stored in the Galasa auth store.
         '500':
           description: Internal Server Error
           content:
@@ -2032,7 +2044,7 @@ components:
           description: The authorization code to be exchanged for a JWT, mutually exclusive with "refresh_token".
         description:
           type: string
-          description: A single-line description to be associated with the Galasa auth token.
+          description: Optional. A single-line description to be associated with the Galasa personal access token being created for the first time.
     AuthTokens:
       type: object
       properties:

--- a/galasa-parent/dev.galasa.framework.api/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 description = 'Framework API'
 
-version = '0.34.0'
+version = '0.36.0'
 
 dependencies {
 

--- a/galasa-parent/dev.galasa.framework.api/src/test/java/dev/galasa/framework/api/mocks/MockAuthStore.java
+++ b/galasa-parent/dev.galasa.framework.api/src/test/java/dev/galasa/framework/api/mocks/MockAuthStore.java
@@ -34,4 +34,9 @@ public class MockAuthStore implements IAuthStore, IAuthStoreService {
     public void deleteToken(String tokenId) throws AuthStoreException {
         throw new UnsupportedOperationException("Unimplemented method 'deleteToken'");
     }
+
+    @Override
+    public IAuthToken getToken(String tokenId) throws AuthStoreException {
+        throw new UnsupportedOperationException("Unimplemented method 'getToken'");
+    }
 }

--- a/galasa-parent/dev.galasa.framework.api/src/test/java/dev/galasa/framework/api/mocks/MockAuthStore.java
+++ b/galasa-parent/dev.galasa.framework.api/src/test/java/dev/galasa/framework/api/mocks/MockAuthStore.java
@@ -9,14 +9,14 @@ import java.util.List;
 
 import dev.galasa.framework.spi.auth.IAuthStore;
 import dev.galasa.framework.spi.auth.IAuthStoreService;
-import dev.galasa.framework.spi.auth.IAuthToken;
+import dev.galasa.framework.spi.auth.IInternalAuthToken;
 import dev.galasa.framework.spi.auth.User;
 import dev.galasa.framework.spi.auth.AuthStoreException;
 
 public class MockAuthStore implements IAuthStore, IAuthStoreService {
 
     @Override
-    public List<IAuthToken> getTokens() throws AuthStoreException {
+    public List<IInternalAuthToken> getTokens() throws AuthStoreException {
         throw new UnsupportedOperationException("Unimplemented method 'getTokens'");
     }
 
@@ -36,7 +36,7 @@ public class MockAuthStore implements IAuthStore, IAuthStoreService {
     }
 
     @Override
-    public IAuthToken getToken(String tokenId) throws AuthStoreException {
+    public IInternalAuthToken getToken(String tokenId) throws AuthStoreException {
         throw new UnsupportedOperationException("Unimplemented method 'getToken'");
     }
 }

--- a/galasa-parent/dev.galasa.framework.api/src/test/java/dev/galasa/framework/api/mocks/MockAuthStore.java
+++ b/galasa-parent/dev.galasa.framework.api/src/test/java/dev/galasa/framework/api/mocks/MockAuthStore.java
@@ -29,4 +29,9 @@ public class MockAuthStore implements IAuthStore, IAuthStoreService {
     public void storeToken(String clientId, String description, User owner) throws AuthStoreException {
         throw new UnsupportedOperationException("Unimplemented method 'storeToken'");
     }
+
+    @Override
+    public void deleteToken(String tokenId) throws AuthStoreException {
+        throw new UnsupportedOperationException("Unimplemented method 'deleteToken'");
+    }
 }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/auth/FrameworkAuthStoreService.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/auth/FrameworkAuthStoreService.java
@@ -30,6 +30,20 @@ public class FrameworkAuthStoreService implements IAuthStoreService {
     }
 
     @Override
+    public IAuthToken getToken(String tokenId) throws AuthStoreException {
+        List<IAuthToken> tokens = authStore.getTokens();
+
+        IAuthToken tokenToReturn = null;
+        for (IAuthToken token : tokens) {
+            if (token.getTokenId().equals(tokenId)) {
+                tokenToReturn = token;
+                break;
+            }
+        }
+        return tokenToReturn;
+    }
+
+    @Override
     public void storeToken(String clientId, String description, User owner) throws AuthStoreException {
         authStore.storeToken(clientId, description, owner);
     }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/auth/FrameworkAuthStoreService.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/auth/FrameworkAuthStoreService.java
@@ -34,4 +34,8 @@ public class FrameworkAuthStoreService implements IAuthStoreService {
         authStore.storeToken(clientId, description, owner);
     }
 
+    @Override
+    public void deleteToken(String tokenId) throws AuthStoreException {
+        authStore.deleteToken(tokenId);
+    }
 }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/auth/FrameworkAuthStoreService.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/auth/FrameworkAuthStoreService.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 import dev.galasa.framework.spi.auth.IAuthStore;
 import dev.galasa.framework.spi.auth.IAuthStoreService;
-import dev.galasa.framework.spi.auth.IAuthToken;
+import dev.galasa.framework.spi.auth.IInternalAuthToken;
 import dev.galasa.framework.spi.auth.User;
 import dev.galasa.framework.spi.auth.AuthStoreException;
 
@@ -25,16 +25,16 @@ public class FrameworkAuthStoreService implements IAuthStoreService {
     }
 
     @Override
-    public List<IAuthToken> getTokens() throws AuthStoreException {
+    public List<IInternalAuthToken> getTokens() throws AuthStoreException {
         return authStore.getTokens();
     }
 
     @Override
-    public IAuthToken getToken(String tokenId) throws AuthStoreException {
-        List<IAuthToken> tokens = authStore.getTokens();
+    public IInternalAuthToken getToken(String tokenId) throws AuthStoreException {
+        List<IInternalAuthToken> tokens = authStore.getTokens();
 
-        IAuthToken tokenToReturn = null;
-        for (IAuthToken token : tokens) {
+        IInternalAuthToken tokenToReturn = null;
+        for (IInternalAuthToken token : tokens) {
             if (token.getTokenId().equals(tokenId)) {
                 tokenToReturn = token;
                 break;

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/auth/IAuthStore.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/auth/IAuthStore.java
@@ -27,5 +27,13 @@ public interface IAuthStore {
      */
     void storeToken(String clientId, String description, User owner) throws AuthStoreException;
 
+    /**
+     * Deletes an existing token in the auth store's tokens database.
+     * 
+     * @param tokenId the ID of the token to delete.
+     * @throws AuthStoreException if there was an issue accessing the auth store.
+     */
+    void deleteToken(String tokenId) throws AuthStoreException;
+
     void shutdown() throws AuthStoreException;
 }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/auth/IAuthStore.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/auth/IAuthStore.java
@@ -10,15 +10,15 @@ import java.util.List;
 public interface IAuthStore {
 
     /**
-     * Returns a list of all the tokens stored in the auth store.
+     * Returns a list of all the token records stored in the auth store.
      *
-     * @return a list of all tokens stored in the auth store.
+     * @return a list of all token records stored in the auth store.
      * @throws AuthStoreException if there is an issue accessing the auth store.
      */
     List<IAuthToken> getTokens() throws AuthStoreException;
 
     /**
-     * Stores a new token in the auth store's tokens database.
+     * Stores a new token record in the auth store's tokens database.
      *
      * @param clientId    the ID of the Dex client that the token works with.
      * @param description the user-provided description of the token.
@@ -28,9 +28,9 @@ public interface IAuthStore {
     void storeToken(String clientId, String description, User owner) throws AuthStoreException;
 
     /**
-     * Deletes an existing token in the auth store's tokens database.
+     * Deletes an existing token record from the auth store's tokens database.
      * 
-     * @param tokenId the ID of the token to delete.
+     * @param tokenId the ID of the token record to delete.
      * @throws AuthStoreException if there was an issue accessing the auth store.
      */
     void deleteToken(String tokenId) throws AuthStoreException;

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/auth/IAuthStore.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/auth/IAuthStore.java
@@ -15,7 +15,7 @@ public interface IAuthStore {
      * @return a list of all token records stored in the auth store.
      * @throws AuthStoreException if there is an issue accessing the auth store.
      */
-    List<IAuthToken> getTokens() throws AuthStoreException;
+    List<IInternalAuthToken> getTokens() throws AuthStoreException;
 
     /**
      * Stores a new token record in the auth store's tokens database.

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/auth/IAuthStoreService.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/auth/IAuthStoreService.java
@@ -10,12 +10,21 @@ import java.util.List;
 public interface IAuthStoreService {
 
     /**
-     * Returns a list of all the tokens stored in the auth store.
+     * Returns a list of all the auth token records stored in the auth store.
      *
-     * @return a list of all tokens stored in the auth store.
+     * @return a list of all auth token records stored in the auth store.
      * @throws AuthStoreException if there is an issue accessing the auth store.
      */
     List<IAuthToken> getTokens() throws AuthStoreException;
+
+    /**
+     * Gets an token record given its ID from the auth store.
+     * 
+     * @param tokenId the ID of the token record to retrieve
+     * @return an auth token givne 
+     * @throws AuthStoreException
+     */
+    IAuthToken getToken(String tokenId) throws AuthStoreException;
 
     /**
      * Stores a new token in the auth store's tokens database.

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/auth/IAuthStoreService.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/auth/IAuthStoreService.java
@@ -26,4 +26,12 @@ public interface IAuthStoreService {
      * @throws AuthStoreException if there is an issue accessing the auth store.
      */
     void storeToken(String clientId, String description, User owner) throws AuthStoreException;
+
+    /**
+     * Deletes an existing token in the auth store's tokens database.
+     * 
+     * @param tokenId the ID of the token to delete.
+     * @throws AuthStoreException if there was an issue accessing the auth store.
+     */
+    void deleteToken(String tokenId) throws AuthStoreException;
 }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/auth/IAuthStoreService.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/auth/IAuthStoreService.java
@@ -15,7 +15,7 @@ public interface IAuthStoreService {
      * @return a list of all auth token records stored in the auth store.
      * @throws AuthStoreException if there is an issue accessing the auth store.
      */
-    List<IAuthToken> getTokens() throws AuthStoreException;
+    List<IInternalAuthToken> getTokens() throws AuthStoreException;
 
     /**
      * Gets an token record given its ID from the auth store.
@@ -24,7 +24,7 @@ public interface IAuthStoreService {
      * @return an auth token givne 
      * @throws AuthStoreException
      */
-    IAuthToken getToken(String tokenId) throws AuthStoreException;
+    IInternalAuthToken getToken(String tokenId) throws AuthStoreException;
 
     /**
      * Stores a new token in the auth store's tokens database.

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/auth/IInternalAuthToken.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/auth/IInternalAuthToken.java
@@ -8,15 +8,17 @@ package dev.galasa.framework.spi.auth;
 import java.time.Instant;
 
 /**
- * An interface for auth token beans to implement. This allows token properties to
+ * An interface for auth token beans used internally to implement. This allows token properties to
  * be retrieved from different sources (e.g. the ID of a token can correspond to
  * the ID of a database record).
  */
-public interface IAuthToken {
+public interface IInternalAuthToken {
 
     String getTokenId();
 
     String getDescription();
+
+    String getDexClientId();
 
     Instant getCreationTime();
 

--- a/release.yaml
+++ b/release.yaml
@@ -75,13 +75,13 @@ framework:
 api:
   bundles:
   - artifact: dev.galasa.framework.api
-    version: 0.34.0
+    version: 0.36.0
     obr: true
     isolated: true
     codecoverage: true
 
   - artifact: dev.galasa.framework.api.authentication
-    version: 0.35.0
+    version: 0.36.0
     obr: true
     isolated: true
     codecoverage: true
@@ -93,7 +93,7 @@ api:
     codecoverage: true
 
   - artifact: dev.galasa.framework.api.common
-    version: 0.35.0
+    version: 0.36.0
     obr: true
     isolated: true
     codecoverage: true


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1729

## Changes
- Added a new `DELETE /auth/tokens/{tokenid}` route used to revoke auth tokens from the ecosystem using Dex's gRPC API to revoke the refresh token and the associated Dex client, before deleting the record of the token from the ecosystem's auth store
- Updated the OpenAPI docs to include a 404 response from the new endpoint when a token with the given ID does not exist
- Removed early returns in the BaseServlet class when matching servlet routes for improved readability
- Changed `IAuthToken` into `IInternalAuthToken` for use by internal auth token beans (e.g. CouchDBAuthToken in extensions) to store additional information like Dex client IDs that should not be displayed to users via API responses