### PR TITLE
Iss1769 - Make topic name of event configurable from CPS not hard coded

### DIFF
--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
@@ -122,7 +122,7 @@ public class TestRunner {
         try {
             this.produceEvents = isProduceEventsFeatureFlagTrue();
         } catch (ConfigurationPropertyStoreException e) {
-            throw new TestRunException("Problem loading the CPS property for event production.");
+            throw new TestRunException("Problem reading the CPS property to check if framework event production has been activated.");
         }
 
         IRun run = this.framework.getTestRun();
@@ -656,13 +656,15 @@ public class TestRunner {
             logger.debug("Producing a test run lifecycle status change event.");
 
             String message = String.format("Galasa test run %s is now in status: %s.", framework.getTestRunName(), status.toString());
-            TestRunLifecycleStatusChangedEvent testRunLifecycleStatusChangedEvent = new TestRunLifecycleStatusChangedEvent(Instant.now().toString(), message);
+            TestRunLifecycleStatusChangedEvent testRunLifecycleStatusChangedEvent = new TestRunLifecycleStatusChangedEvent(this.cps, Instant.now().toString(), message);
             String topic = testRunLifecycleStatusChangedEvent.getTopic();
 
-            try {
-                framework.getEventsService().produceEvent(topic, testRunLifecycleStatusChangedEvent);
-            } catch (EventsException e) {
-                throw new TestRunException("Failed to publish a test run lifecycle status change event to the Events Service", e);
+            if (topic != null) {
+                try {
+                    framework.getEventsService().produceEvent(topic, testRunLifecycleStatusChangedEvent);
+                } catch (EventsException e) {
+                    throw new TestRunException("Failed to publish a test run lifecycle status changed event to the Events Service", e);
+                }
             }
         }
 

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
@@ -50,6 +50,7 @@ import dev.galasa.framework.spi.IRun;
 import dev.galasa.framework.spi.Result;
 import dev.galasa.framework.spi.ResultArchiveStoreException;
 import dev.galasa.framework.spi.SharedEnvironmentRunType;
+import dev.galasa.framework.spi.events.TestHeartbeatStoppedEvent;
 import dev.galasa.framework.spi.events.TestRunLifecycleStatusChangedEvent;
 import dev.galasa.framework.spi.language.GalasaTest;
 import dev.galasa.framework.spi.teststructure.TestStructure;
@@ -652,22 +653,6 @@ public class TestRunner {
 
     private void updateStatus(TestRunLifecycleStatus status, String timestamp) throws TestRunException {
 
-        if (this.produceEvents) {
-            logger.debug("Producing a test run lifecycle status change event.");
-
-            String message = String.format("Galasa test run %s is now in status: %s.", framework.getTestRunName(), status.toString());
-            TestRunLifecycleStatusChangedEvent testRunLifecycleStatusChangedEvent = new TestRunLifecycleStatusChangedEvent(this.cps, Instant.now().toString(), message);
-            String topic = testRunLifecycleStatusChangedEvent.getTopic();
-
-            if (topic != null) {
-                try {
-                    framework.getEventsService().produceEvent(topic, testRunLifecycleStatusChangedEvent);
-                } catch (EventsException e) {
-                    throw new TestRunException("Failed to publish a test run lifecycle status changed event to the Events Service", e);
-                }
-            }
-        }
-
         this.testStructure.setStatus(status.toString());
         if ("finished".equals(status.toString())) {
             updateResult();
@@ -683,6 +668,30 @@ public class TestRunner {
             }
         } catch (DynamicStatusStoreException e) {
             throw new TestRunException("Failed to update status", e);
+        }
+
+        try {
+            produceTestRunLifecycleStatusChangedEvent(status);
+        } catch (TestRunException e) {
+            logger.error("Unable to produce a test run lifecycle status changed event to the Events Service", e);
+        }
+    }
+
+    private void produceTestRunLifecycleStatusChangedEvent(TestRunLifecycleStatus status) throws TestRunException {
+        if (this.produceEvents) {
+            logger.debug("Producing a test run lifecycle status change event.");
+
+            String message = String.format("Galasa test run %s is now in status: %s.", framework.getTestRunName(), status.toString());
+            TestRunLifecycleStatusChangedEvent testRunLifecycleStatusChangedEvent = new TestRunLifecycleStatusChangedEvent(this.cps, Instant.now().toString(), message);
+            String topic = testRunLifecycleStatusChangedEvent.getTopic();
+
+            if (topic != null) {
+                try {
+                    framework.getEventsService().produceEvent(topic, testRunLifecycleStatusChangedEvent);
+                } catch (EventsException e) {
+                    throw new TestRunException("Failed to publish a test run lifecycle status changed event to the Events Service", e);
+                }
+            }
         }
     }
 
@@ -712,6 +721,30 @@ public class TestRunner {
             dss.delete("run." + run.getName() + ".heartbeat");
         } catch (DynamicStatusStoreException e) {
             logger.error("Unable to delete heartbeat", e);
+        }
+
+        try {
+            produceTestHeartbeatStoppedEvent();
+        } catch (TestRunException e) {
+            logger.error("Unable to produce a test heartbeat stopped event to the Events Service", e);
+        }
+    }
+
+    private void produceTestHeartbeatStoppedEvent() throws TestRunException {
+        if (this.produceEvents) {
+            logger.debug("Producing a test heartbeat stopped event.");
+
+            String message = String.format("Galasa test run %s's heartbeat has been stopped.", framework.getTestRunName());
+            TestHeartbeatStoppedEvent testHeartbeatStoppedEvent = new TestHeartbeatStoppedEvent(this.cps, Instant.now().toString(), message);
+            String topic = testHeartbeatStoppedEvent.getTopic();
+
+            if (topic != null) {
+                try {
+                    framework.getEventsService().produceEvent(topic, testHeartbeatStoppedEvent);
+                } catch (EventsException e) {
+                    throw new TestRunException("Failed to publish a test heartbeat stopped event to the Events Service", e);
+                }
+            }
         }
     }
 

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/events/TestHeartbeatStoppedEvent.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/events/TestHeartbeatStoppedEvent.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.spi.events;
+
+import dev.galasa.framework.TestRunException;
+import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
+import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
+
+public class TestHeartbeatStoppedEvent extends Event {
+
+    private final String TOPIC;
+
+    public TestHeartbeatStoppedEvent(IConfigurationPropertyStoreService cps, String timestamp, String message) throws TestRunException {
+        super(timestamp, message);
+        try {
+            this.TOPIC = cps.getProperty(this.getClass().getSimpleName().toLowerCase(), "name", "topic");
+        } catch (ConfigurationPropertyStoreException e) {
+            throw new TestRunException("There was a problem retrieving from the CPS the name of the topic to send TestHeartbeatStoppedEvents.", e);
+        }
+    }
+
+    public String getTopic() {
+        return this.TOPIC;
+    }
+    
+}

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/events/TestRunLifecycleStatusChangedEvent.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/events/TestRunLifecycleStatusChangedEvent.java
@@ -5,12 +5,21 @@
  */
 package dev.galasa.framework.spi.events;
 
+import dev.galasa.framework.TestRunException;
+import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
+import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
+
 public class TestRunLifecycleStatusChangedEvent extends Event {
 
-    private final String TOPIC = "Tests.StatusChangedEvent";
+    private final String TOPIC;
 
-    public TestRunLifecycleStatusChangedEvent(String timestamp, String message) {
+    public TestRunLifecycleStatusChangedEvent(IConfigurationPropertyStoreService cps, String timestamp, String message) throws TestRunException {
         super(timestamp, message);
+        try {
+            this.TOPIC = cps.getProperty(this.getClass().getSimpleName().toLowerCase(), "name", "topic");
+        } catch (ConfigurationPropertyStoreException e) {
+            throw new TestRunException("There was a problem retrieving from the CPS the name of the topic to send TestRunLifecycleStatusChangedEvents.", e);
+        }
     }
 
     public String getTopic() {


### PR DESCRIPTION
## Why?

Makes the topic name for test run lifecycle status change events configurable in the CPS. This means users can choose the topic they want to send this type of event and also means if they don't want to produce this type of event, if they don't set the topic, it will skip producing this type of event.

Additionally added a second event type which will/can go to another topic name to test publishing to multiple topics, and creation of multiple producers, one for each topic.