### PR TITLE
corrected output of legacy cps route to only return one property as per the openapi.yaml definition

### DIFF
--- a/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/routes/AllPropertiesInNamesapceFilteredRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/routes/AllPropertiesInNamesapceFilteredRoute.java
@@ -14,6 +14,8 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.google.gson.JsonObject;
+
 import dev.galasa.framework.api.common.InternalServletException;
 import dev.galasa.framework.api.common.QueryParameters;
 import dev.galasa.framework.api.common.ResponseBuilder;
@@ -64,7 +66,7 @@ public class AllPropertiesInNamesapceFilteredRoute extends CPSRoute {
     }
 
     private String getNamespaceProperties( QueryParameters queryParams) throws InternalServletException{
-        String properties = "";
+        JsonObject responseProperty = new JsonObject();
          try {
             nameValidator.assertNamespaceCharPatternIsValid(namespaceName);
             CPSFacade cps = new CPSFacade(framework);
@@ -75,11 +77,17 @@ public class AllPropertiesInNamesapceFilteredRoute extends CPSRoute {
             }
             List<String> infixes = queryParams.getMultipleString("infix", null);
             Map<GalasaPropertyName, CPSProperty> propertiesMap = getProperties(namespace, prefix, suffix, infixes);
-            properties = buildPropertiesResponseBody(propertiesMap);
+            //Get First Property From propertiesMap and send it as a response
+            if ( propertiesMap.size() > 0 ){
+                CPSProperty property = propertiesMap.entrySet().iterator().next().getValue();
+                responseProperty.addProperty("name", property.getName());
+                responseProperty.addProperty("value", property.getValue());
+            }
+
         }catch (FrameworkException f){
             ServletError error = new ServletError(GAL5016_INVALID_NAMESPACE_ERROR,namespaceName);  
             throw new InternalServletException(error, HttpServletResponse.SC_NOT_FOUND, f);
         }
-        return properties;
+        return gson.toJson(responseProperty);
     }
 }

--- a/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestAllPropertiesInNamespaceFilteredRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestAllPropertiesInNamespaceFilteredRoute.java
@@ -250,7 +250,7 @@ public class TestAllPropertiesInNamespaceFilteredRoute extends CpsServletTest {
     }
 
 	@Test
-	public void TestGetNamespacesWithFrameworkWithDataReturnsOk() throws Exception{
+	public void TestGetNamespacesWithFrameworkWithDataNoMatchReturnsOk() throws Exception{
 		// Given...
 		setServlet("/namespace/framework/prefix/prop/suffix/erty","framework",new HashMap<String,String[]>());
 		MockCpsServlet servlet = getServlet();
@@ -265,7 +265,7 @@ public class TestAllPropertiesInNamespaceFilteredRoute extends CpsServletTest {
 		// Then...
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(outStream.toString()).isEqualTo("[]");
+		assertThat(outStream.toString()).isEqualTo("{}");
 	}
 
     @Test
@@ -284,7 +284,7 @@ public class TestAllPropertiesInNamespaceFilteredRoute extends CpsServletTest {
 		// Then...
 		assertThat(resp.getStatus()).isEqualTo(200);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-		assertThat(outStream.toString()).isEqualTo("[\n  {\n    \"name\": \"property.1\",\n    \"value\": \"value1\"\n  }\n]");
+		assertThat(outStream.toString()).isEqualTo("{\n  \"name\": \"property.1\",\n  \"value\": \"value1\"\n}");
 	}
    
     @Test


### PR DESCRIPTION
## Why?

This is to fix the vulnerabilities caused by the calls of the AccessCPS.java class due to calls made to the gson package
