### PR TITLE
Reverting name of the getMethods() call

### DIFF
--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GherkinTestRunner.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GherkinTestRunner.java
@@ -210,7 +210,7 @@ public class GherkinTestRunner {
             return;
         }
 
-        if(gherkinTest.getName() == null || gherkinTest.getScenarios().size() == 0) {
+        if(gherkinTest.getName() == null || gherkinTest.getMethods().size() == 0) {
             throw new TestRunException("Feature file is invalid at URI: " + run.getGherkin());
         }
             
@@ -309,7 +309,7 @@ public class GherkinTestRunner {
     private void logStatementsNotRecognisedByAnyManager(GherkinTest gherkinTest) {
         logger.error("The following Gherkin statements have not been registered to a Manager");
         
-        for(GherkinMethod scenario : gherkinTest.getScenarios()) {
+        for(GherkinMethod scenario : gherkinTest.getMethods()) {
             logger.info("    Scenario: " + scenario.getName());
             for(IGherkinExecutable executable : scenario.getExecutables()) {
                 Object owner = executable.getOwner();

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/language/gherkin/GherkinTest.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/language/gherkin/GherkinTest.java
@@ -88,7 +88,7 @@ public class GherkinTest {
         return this.feature.getName();
     }
 
-    public List<GherkinMethod> getScenarios() {
+    public List<GherkinMethod> getMethods() {
         return this.feature.getScenarios();
     }
 

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/spi/language/gherkin/TestGherkinTest.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/spi/language/gherkin/TestGherkinTest.java
@@ -121,7 +121,7 @@ public class TestGherkinTest {
         GherkinTest test = new GherkinTest(run,testStructure,gherkinReader);
         assertThat(test).isNotNull();
         assertThat(test.getName()).isEqualTo("Browse the catalog and order");
-        assertThat(test.getScenarios()).hasSize(1);
+        assertThat(test.getMethods()).hasSize(1);
     }
 
     @Test
@@ -219,7 +219,7 @@ public class TestGherkinTest {
         assertThat(test.getName()).isEqualTo("Browse the catalog and order");
 
         // TODO: Explain why there is only one method, despite the table having two rows ? 
-        assertThat(test.getScenarios()).hasSize(3);
+        assertThat(test.getMethods()).hasSize(3);
     }
 
     @Test
@@ -260,8 +260,8 @@ public class TestGherkinTest {
         GherkinTest test = new GherkinTest(run,testStructure,gherkinReader);
         assertThat(test).isNotNull();
         assertThat(test.getName()).isEqualTo("Browse the catalog and order");
-        assertThat(test.getScenarios()).hasSize(1);
-        assertThat(test.getScenarios().get(0).getName()).isEqualTo("Scenario 1");
+        assertThat(test.getMethods()).hasSize(1);
+        assertThat(test.getMethods().get(0).getName()).isEqualTo("Scenario 1");
     }
 
     @Test
@@ -309,9 +309,9 @@ public class TestGherkinTest {
         GherkinTest test = new GherkinTest(run,testStructure,gherkinReader);
         assertThat(test).isNotNull();
         assertThat(test.getName()).isEqualTo("Browse the catalog and order");
-        assertThat(test.getScenarios()).hasSize(2);
-        assertThat(test.getScenarios().get(0).getName()).isEqualTo("Scenario 1");
-        assertThat(test.getScenarios().get(1).getName()).isEqualTo("Scenario 2");
+        assertThat(test.getMethods()).hasSize(2);
+        assertThat(test.getMethods().get(0).getName()).isEqualTo("Scenario 1");
+        assertThat(test.getMethods().get(1).getName()).isEqualTo("Scenario 2");
     }
 
     @Test
@@ -361,11 +361,11 @@ public class TestGherkinTest {
         GherkinTest test = new GherkinTest(run,testStructure,gherkinReader);
         assertThat(test).isNotNull();
         assertThat(test.getName()).isEqualTo("Browse the catalog and order");
-        assertThat(test.getScenarios()).hasSize(4);
-        assertThat(test.getScenarios().get(0).getName()).isEqualTo("Scenario 1");
-        assertThat(test.getScenarios().get(1).getName()).isEqualTo("Scenario outline 1-0");
-        assertThat(test.getScenarios().get(2).getName()).isEqualTo("Scenario outline 1-1");
-        assertThat(test.getScenarios().get(3).getName()).isEqualTo("Scenario outline 1-2");
+        assertThat(test.getMethods()).hasSize(4);
+        assertThat(test.getMethods().get(0).getName()).isEqualTo("Scenario 1");
+        assertThat(test.getMethods().get(1).getName()).isEqualTo("Scenario outline 1-0");
+        assertThat(test.getMethods().get(2).getName()).isEqualTo("Scenario outline 1-1");
+        assertThat(test.getMethods().get(3).getName()).isEqualTo("Scenario outline 1-2");
     }
 
     @Test
@@ -416,13 +416,13 @@ public class TestGherkinTest {
         GherkinTest test = new GherkinTest(run,testStructure,gherkinReader);
         assertThat(test).isNotNull();
         assertThat(test.getName()).isEqualTo("Browse the catalog and order");
-        assertThat(test.getScenarios()).hasSize(6);
-        assertThat(test.getScenarios().get(0).getName()).isEqualTo("Scenario outline 1-0");
-        assertThat(test.getScenarios().get(1).getName()).isEqualTo("Scenario outline 1-1");
-        assertThat(test.getScenarios().get(2).getName()).isEqualTo("Scenario outline 1-2");
-        assertThat(test.getScenarios().get(3).getName()).isEqualTo("Scenario outline 2-0");
-        assertThat(test.getScenarios().get(4).getName()).isEqualTo("Scenario outline 2-1");
-        assertThat(test.getScenarios().get(5).getName()).isEqualTo("Scenario outline 2-2");
+        assertThat(test.getMethods()).hasSize(6);
+        assertThat(test.getMethods().get(0).getName()).isEqualTo("Scenario outline 1-0");
+        assertThat(test.getMethods().get(1).getName()).isEqualTo("Scenario outline 1-1");
+        assertThat(test.getMethods().get(2).getName()).isEqualTo("Scenario outline 1-2");
+        assertThat(test.getMethods().get(3).getName()).isEqualTo("Scenario outline 2-0");
+        assertThat(test.getMethods().get(4).getName()).isEqualTo("Scenario outline 2-1");
+        assertThat(test.getMethods().get(5).getName()).isEqualTo("Scenario outline 2-2");
     }
 
     @Test
@@ -472,11 +472,11 @@ public class TestGherkinTest {
         GherkinTest test = new GherkinTest(run,testStructure,gherkinReader);
         assertThat(test).isNotNull();
         assertThat(test.getName()).isEqualTo("Browse the catalog and order");
-        assertThat(test.getScenarios()).hasSize(4);
-        assertThat(test.getScenarios().get(0).getName()).isEqualTo("Scenario outline 1-0");
-        assertThat(test.getScenarios().get(1).getName()).isEqualTo("Scenario outline 1-1");
-        assertThat(test.getScenarios().get(2).getName()).isEqualTo("Scenario outline 1-2");
-        assertThat(test.getScenarios().get(3).getName()).isEqualTo("Scenario 1");
+        assertThat(test.getMethods()).hasSize(4);
+        assertThat(test.getMethods().get(0).getName()).isEqualTo("Scenario outline 1-0");
+        assertThat(test.getMethods().get(1).getName()).isEqualTo("Scenario outline 1-1");
+        assertThat(test.getMethods().get(2).getName()).isEqualTo("Scenario outline 1-2");
+        assertThat(test.getMethods().get(3).getName()).isEqualTo("Scenario 1");
     }
 
     @Test
@@ -514,8 +514,8 @@ public class TestGherkinTest {
         GherkinTest test = new GherkinTest(run,testStructure,gherkinReader);
         assertThat(test).isNotNull();
         assertThat(test.getName()).isEqualTo("Browse the catalog and order");
-        assertThat(test.getScenarios()).hasSize(1);
-        assertThat(test.getScenarios().get(0).getName()).isEqualTo("Scenario 1");
+        assertThat(test.getMethods()).hasSize(1);
+        assertThat(test.getMethods().get(0).getName()).isEqualTo("Scenario 1");
     }
 
    


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
The previous change re-named a method in the SPI, but that broke the manager code, so reverting that name-change.