### PR TITLE
Documentation in openapi gets rendered as a close-comment in golang code. Fixed

### DIFF
--- a/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -1129,7 +1129,8 @@ paths:
         The OpenAPI specification can be returned in either YAML or JSON format, based on the value provided in the
         'Accept' HTTP header in requests to this endpoint. As such, the supported response content types are
         'application/yaml' or 'application/json'. By default, a JSON representation of the OpenAPI specification
-        will be returned if the 'Accept' header is omitted or if it is set to 'application/*' or '*/*'.
+        will be returned if the 'Accept' header is omitted or if it is set to accept any application mime type, 
+        or any mime type. For example: 'application/*'.
       tags:
         - OpenAPI API
       responses:


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
The documentation in openapi included the text: `blah blah blah'*/*'.` character sequence.
When rendered into Golang code, it produces this:
```
/*
blah blah blah '*/*'.
*/
```

But the */ is a close-comment, so the `*'.\n*/` is expected to be code. 

Re-wording the documentation to avoid this problem.