### PR TITLE
Revert accept header validation due to CLI issues

### DIFF
--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthClientsRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthClientsRoute.java
@@ -17,7 +17,6 @@ import dev.galasa.framework.api.authentication.internal.DexClient;
 import dev.galasa.framework.api.authentication.internal.DexGrpcClient;
 import dev.galasa.framework.api.common.BaseRoute;
 import dev.galasa.framework.api.common.InternalServletException;
-import dev.galasa.framework.api.common.MimeType;
 import dev.galasa.framework.api.common.QueryParameters;
 import dev.galasa.framework.api.common.ResponseBuilder;
 import dev.galasa.framework.api.common.ServletError;
@@ -45,8 +44,6 @@ public class AuthClientsRoute extends BaseRoute {
             HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException, FrameworkException {
 
         logger.info("handlePostRequest() entered");
-
-        validateAcceptHeader(request, MimeType.APPLICATION_JSON);
 
         Client newDexClient = dexGrpcClient.createClient(AuthCallbackRoute.getExternalAuthCallbackUrl());
         if (newDexClient == null) {

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthRoute.java
@@ -30,7 +30,6 @@ import dev.galasa.framework.api.common.Environment;
 import dev.galasa.framework.api.common.IBeanValidator;
 import dev.galasa.framework.api.common.InternalServletException;
 import dev.galasa.framework.api.common.InternalUser;
-import dev.galasa.framework.api.common.MimeType;
 import dev.galasa.framework.api.common.QueryParameters;
 import dev.galasa.framework.api.common.ResponseBuilder;
 import dev.galasa.framework.api.common.ServletError;
@@ -124,8 +123,6 @@ public class AuthRoute extends BaseRoute {
             HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException, FrameworkException {
 
         logger.info("AuthRoute: handlePostRequest() entered.");
-
-        validateAcceptHeader(request, MimeType.APPLICATION_JSON);
 
         // Check that the request body contains the required payload
         TokenPayload requestPayload = parseRequestBody(request, TokenPayload.class);

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensDetailsRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensDetailsRoute.java
@@ -16,7 +16,6 @@ import javax.servlet.http.HttpServletResponse;
 import dev.galasa.framework.api.authentication.internal.DexGrpcClient;
 import dev.galasa.framework.api.common.BaseRoute;
 import dev.galasa.framework.api.common.InternalServletException;
-import dev.galasa.framework.api.common.MimeType;
 import dev.galasa.framework.api.common.QueryParameters;
 import dev.galasa.framework.api.common.ResponseBuilder;
 import dev.galasa.framework.api.common.ServletError;
@@ -48,8 +47,6 @@ public class AuthTokensDetailsRoute extends BaseRoute {
     public HttpServletResponse handleDeleteRequest(String pathInfo, QueryParameters queryParameters,
             HttpServletRequest request, HttpServletResponse response)
             throws FrameworkException {
-
-        validateAcceptHeader(request, MimeType.TEXT_PLAIN);
 
         String tokenId = getTokenIdFromUrl(pathInfo);
         revokeToken(tokenId);

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/main/java/dev/galasa/framework/api/authentication/internal/routes/AuthTokensRoute.java
@@ -35,7 +35,6 @@ import dev.galasa.framework.api.common.Environment;
 import dev.galasa.framework.api.common.IBeanValidator;
 import dev.galasa.framework.api.common.InternalServletException;
 import dev.galasa.framework.api.common.InternalUser;
-import dev.galasa.framework.api.common.MimeType;
 import dev.galasa.framework.api.common.QueryParameters;
 import dev.galasa.framework.api.common.ResponseBuilder;
 import dev.galasa.framework.api.common.ServletError;
@@ -85,8 +84,6 @@ public class AuthTokensRoute extends BaseRoute {
 
         logger.info("handleGetRequest() entered");
 
-        validateAcceptHeader(request, MimeType.APPLICATION_JSON);
-
         List<AuthToken> tokensToReturn = new ArrayList<>();
         try {
             // Retrieve all the tokens and put them into a mutable list before sorting them based on their creation time
@@ -120,8 +117,6 @@ public class AuthTokensRoute extends BaseRoute {
             HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException, FrameworkException {
 
         logger.info("AuthRoute: handlePostRequest() entered.");
-
-        validateAcceptHeader(request, MimeType.APPLICATION_JSON);
 
         // Check that the request body contains the required payload
         TokenPayload requestPayload = parseRequestBody(request, TokenPayload.class);

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthClientsRouteTest.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthClientsRouteTest.java
@@ -83,33 +83,6 @@ public class AuthClientsRouteTest extends BaseServletTest {
     }
 
     @Test
-    public void testAuthClientsPostRequestWithBadAcceptHeaderThrowsError() throws Exception {
-        // Given...
-        String clientId = "my-client-id";
-        String clientSecret = "my-client-secret"; // Mock value, not a secret //pragma: allowlist secret
-        String redirectUri = "http://my.app/callback";
-
-        DexGrpcClient mockDexGrpcClient = new MockDexGrpcClient("http://issuer.url", clientId, clientSecret, redirectUri);
-
-        MockAuthenticationServlet servlet = new MockAuthenticationServlet(mockDexGrpcClient);
-
-        MockHttpServletRequest mockRequest = new MockHttpServletRequest("/clients", "", "POST");
-
-        mockRequest.setHeader("Accept", "not-a-supported-type");
-
-        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
-        ServletOutputStream outStream = servletResponse.getOutputStream();
-
-        // When...
-        servlet.init();
-        servlet.doPost(mockRequest, servletResponse);
-
-        // Then...
-        assertThat(servletResponse.getStatus()).isEqualTo(406);
-        checkErrorStructure(outStream.toString(), 5406, "GAL5406E", "Unsupported 'Accept' header value set. Supported response types are: [application/json]");
-    }
-
-    @Test
     public void testAuthClientsPostRequestWithGoodAcceptHeaderReturnsClient() throws Exception {
         // Given...
         String clientId = "my-client-id";

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthTokensDetailsRouteTest.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthTokensDetailsRouteTest.java
@@ -7,7 +7,6 @@ package dev.galasa.framework.api.authentication.routes;
 
 import static org.assertj.core.api.Assertions.*;
 
-import java.io.OutputStream;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -126,42 +125,6 @@ public class AuthTokensDetailsRouteTest extends BaseServletTest {
         // Then...
         assertThat(servletResponse.getStatus()).isEqualTo(200);
         assertThat(authStoreService.getTokens()).hasSize(0);
-    }
-
-    @Test
-    public void testDeleteAuthTokensWithBadAcceptHeaderThrowsError() throws Exception {
-        // Given...
-        String tokenId = "id123";
-        String description = "test token";
-        String clientId = "my-client";
-        Instant creationTime = Instant.now();
-        IInternalUser owner = new InternalUser("username", "dexId");
-
-        List<IInternalAuthToken> tokens = new ArrayList<>();
-        tokens.add(new MockInternalAuthToken(tokenId, description, creationTime, owner, clientId));
-
-        MockDexGrpcClient mockDexGrpcClient = new MockDexGrpcClient("http://my-issuer");
-        mockDexGrpcClient.addDexClient(clientId, "my-secret", "http://a-callback-url");
-        mockDexGrpcClient.addMockRefreshToken(owner.getLoginId(), clientId);
-
-        MockAuthStoreService authStoreService = new MockAuthStoreService(tokens);
-        MockAuthenticationServlet servlet = new MockAuthenticationServlet(null, mockDexGrpcClient, new MockFramework(authStoreService));
-
-        MockHttpServletRequest mockRequest = new MockHttpServletRequest("/tokens/" + tokenId, "", "DELETE");
-
-        mockRequest.setHeader("Accept", "not-supported!");
-
-        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
-        OutputStream outStream = servletResponse.getOutputStream();
-
-        // When...
-        assertThat(authStoreService.getTokens()).hasSize(1);
-        servlet.init();
-        servlet.doDelete(mockRequest, servletResponse);
-
-        // Then...
-        assertThat(servletResponse.getStatus()).isEqualTo(406);
-        checkErrorStructure(outStream.toString(), 5406, "GAL5406E", "Unsupported 'Accept' header value set. Supported response types are: [text/plain]");
     }
 
     @Test

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthTokensRouteTest.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthTokensRouteTest.java
@@ -202,38 +202,6 @@ public class AuthTokensRouteTest extends BaseServletTest {
     }
 
     @Test
-    public void testGetAuthTokensWithBadAcceptHeaderThrowsError() throws Exception {
-        // Given...
-        String tokenId = "id123";
-        String description = "test token";
-        String clientId = "my-client";
-        Instant creationTime = Instant.now();
-        IInternalUser owner = new InternalUser("username", "dexId");
-
-        List<IInternalAuthToken> tokens = List.of(
-            new MockInternalAuthToken(tokenId, description, creationTime, owner, clientId)
-        );
-        MockAuthStoreService authStoreService = new MockAuthStoreService(tokens);
-        MockAuthenticationServlet servlet = new MockAuthenticationServlet(new MockFramework(authStoreService));
-
-        MockHttpServletRequest mockRequest = new MockHttpServletRequest("/tokens", "", "GET");
-
-        mockRequest.setHeader("Accept", "not-a-supported-type");
-
-        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
-        ServletOutputStream outStream = servletResponse.getOutputStream();
-
-        // When...
-        servlet.init();
-        servlet.doGet(mockRequest, servletResponse);
-
-        // Then...
-        assertThat(servletResponse.getStatus()).isEqualTo(406);
-        assertThat(servletResponse.getContentType()).isEqualTo("application/json");
-        checkErrorStructure(outStream.toString(), 5406, "Unsupported 'Accept' header value set. Supported response types are: [application/json]");
-    }
-
-    @Test
     public void testGetAuthTokensWithAuthStoreExceptionThrowsInternalServletException() throws Exception {
         // Given...
         String tokenId = "id123";

--- a/galasa-parent/dev.galasa.framework.api.bootstrap/src/main/java/dev/galasa/framework/api/bootstrap/routes/BootstrapExternalRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.bootstrap/src/main/java/dev/galasa/framework/api/bootstrap/routes/BootstrapExternalRoute.java
@@ -12,7 +12,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import dev.galasa.framework.api.common.BaseRoute;
-import dev.galasa.framework.api.common.MimeType;
 import dev.galasa.framework.api.common.ResponseBuilder;
 import dev.galasa.framework.api.common.QueryParameters;
 
@@ -32,8 +31,6 @@ public class BootstrapExternalRoute extends BaseRoute {
     public HttpServletResponse handleGetRequest(String pathInfo, QueryParameters queryParams,
             HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException, FrameworkException {
-
-        validateAcceptHeader(request, MimeType.TEXT_PLAIN);
 
         Properties properties = new Properties();
         properties.store(response.getWriter(), "Galasa Bootstrap Properties");

--- a/galasa-parent/dev.galasa.framework.api.bootstrap/src/main/java/dev/galasa/framework/api/bootstrap/routes/BootstrapInternalRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.bootstrap/src/main/java/dev/galasa/framework/api/bootstrap/routes/BootstrapInternalRoute.java
@@ -16,7 +16,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import dev.galasa.framework.api.common.BaseRoute;
-import dev.galasa.framework.api.common.MimeType;
 import dev.galasa.framework.api.common.QueryParameters;
 import dev.galasa.framework.api.common.ResponseBuilder;
 import dev.galasa.framework.spi.FrameworkException;
@@ -37,8 +36,6 @@ public class BootstrapInternalRoute extends BaseRoute {
     public HttpServletResponse handleGetRequest(String pathInfo, QueryParameters queryParams,
             HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException, FrameworkException {
-
-        validateAcceptHeader(request, MimeType.TEXT_PLAIN);
 
         Properties actualBootstrap = new Properties();
         synchronized (this.configurationProperties) {

--- a/galasa-parent/dev.galasa.framework.api.bootstrap/src/test/java/dev/galasa/framework/api/bootstrap/routes/TestBootstrapExternalRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.bootstrap/src/test/java/dev/galasa/framework/api/bootstrap/routes/TestBootstrapExternalRoute.java
@@ -65,30 +65,6 @@ public class TestBootstrapExternalRoute extends BootstrapServletTest {
     }
 
     @Test
-    public void TestGetBootstrapExternalRouteWithBadAcceptHeaderThrowsError() throws Exception {
-        // Given...
-        setServlet();
-        BootstrapServlet servlet = getServlet();
-
-        String pathInfo = "/external";
-        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
-        MockHttpServletRequest req = new MockHttpServletRequest(pathInfo);
-
-        req.setHeader("Accept", "not-a-supported-type");
-
-        ServletOutputStream outStream = servletResponse.getOutputStream();
-
-        // When...
-        servlet.init();
-        servlet.doGet(req, servletResponse);
-
-        // Then...
-        assertThat(servletResponse.getStatus()).isEqualTo(406);
-        assertThat(servletResponse.getContentType()).isEqualTo("application/json");
-        checkErrorStructure(outStream.toString(), 5406, "Unsupported 'Accept' header value set. Supported response types are: [text/plain]");
-    }
-
-    @Test
     public void TestBootstrapInternalRequestReturnsProperties() throws Exception{
         // Given...
         setServlet("/external");

--- a/galasa-parent/dev.galasa.framework.api.bootstrap/src/test/java/dev/galasa/framework/api/bootstrap/routes/TestBootstrapInternalRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.bootstrap/src/test/java/dev/galasa/framework/api/bootstrap/routes/TestBootstrapInternalRoute.java
@@ -117,33 +117,6 @@ public class TestBootstrapInternalRoute extends BootstrapServletTest {
     }
 
     @Test
-    public void TestBootstrapInternalRequestWithBadAcceptHeaderThrowsError() throws Exception {
-        // Given...
-        Map<String, Object> properties = Map.of(
-            "framework.config.store", "mystore",
-            "framework.testcatalog.url", "myeco.dev/testcatalog"
-        );
-
-        setServlet();
-        MockBootstrapServlet servlet = getServlet();
-		MockHttpServletRequest req = new MockHttpServletRequest("");
-
-        req.setHeader("Accept", "not-a-supported-type");
-
-		MockHttpServletResponse resp = new MockHttpServletResponse();
-        ServletOutputStream outStream = resp.getOutputStream();
-
-        // When...
-        servlet.activate(properties);
-        servlet.doGet(req, resp);
-
-        // Then...
-        assertThat(resp.getStatus()).isEqualTo(406);
-        assertThat(resp.getContentType()).isEqualTo("application/json");
-        checkErrorStructure(outStream.toString(), 5406, "Unsupported 'Accept' header value set. Supported response types are: [text/plain]");
-    }
-
-    @Test
     public void TestBootstrapInternalRequestWithNoPropertiesReturnsHeaderOnly() throws Exception {
         // Given...
         Map<String, Object> properties = new HashMap<>();

--- a/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/routes/AddPropertyInNamespaceRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/routes/AddPropertyInNamespaceRoute.java
@@ -20,7 +20,6 @@ import com.google.gson.JsonObject;
 
 import dev.galasa.framework.api.beans.GalasaProperty;
 import dev.galasa.framework.api.common.InternalServletException;
-import dev.galasa.framework.api.common.MimeType;
 import dev.galasa.framework.api.common.QueryParameters;
 import dev.galasa.framework.api.common.ResponseBuilder;
 import dev.galasa.framework.api.common.ServletError;
@@ -49,7 +48,6 @@ public class AddPropertyInNamespaceRoute extends CPSRoute {
     @Override
     public HttpServletResponse handlePutRequest(String pathInfo, QueryParameters queryParams,HttpServletRequest req, HttpServletResponse response)
             throws ServletException, FrameworkException, IOException {
-        validateAcceptHeader(req, MimeType.APPLICATION_JSON);
         getPropertyDetailsFromURL(pathInfo);
         checkNamespaceExists(namespaceName);
         checkRequestHasContent(req);

--- a/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/routes/AllNamespaceRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/routes/AllNamespaceRoute.java
@@ -12,7 +12,6 @@ import javax.servlet.http.HttpServletResponse;
 import com.google.gson.JsonArray;
 
 import dev.galasa.framework.api.common.InternalServletException;
-import dev.galasa.framework.api.common.MimeType;
 import dev.galasa.framework.api.common.QueryParameters;
 import dev.galasa.framework.api.common.ResponseBuilder;
 import dev.galasa.framework.api.common.ServletError;
@@ -42,7 +41,6 @@ public class AllNamespaceRoute extends CPSRoute {
 
     @Override
     public HttpServletResponse handleGetRequest(String pathInfo, QueryParameters queryParams,HttpServletRequest req, HttpServletResponse response) throws ServletException, FrameworkException {
-        validateAcceptHeader(req, MimeType.APPLICATION_JSON);
         String namespaces = getNamespaces();
 		return getResponseBuilder().buildResponse(req, response, "application/json", namespaces, HttpServletResponse.SC_OK); 
     }

--- a/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/routes/AllPropertiesInNamesapceFilteredRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/routes/AllPropertiesInNamesapceFilteredRoute.java
@@ -17,7 +17,6 @@ import javax.servlet.http.HttpServletResponse;
 import com.google.gson.JsonObject;
 
 import dev.galasa.framework.api.common.InternalServletException;
-import dev.galasa.framework.api.common.MimeType;
 import dev.galasa.framework.api.common.QueryParameters;
 import dev.galasa.framework.api.common.ResponseBuilder;
 import dev.galasa.framework.api.common.ServletError;
@@ -47,7 +46,6 @@ public class AllPropertiesInNamesapceFilteredRoute extends CPSRoute {
     @Override
     public HttpServletResponse handleGetRequest(String pathInfo, QueryParameters queryParams,HttpServletRequest req, HttpServletResponse response)
             throws ServletException, FrameworkException {
-        validateAcceptHeader(req, MimeType.APPLICATION_JSON);
         getPropertyDetailsFromURL(pathInfo);
         String properties = getNamespaceProperties(queryParams);
         checkNamespaceExists(namespaceName);

--- a/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/routes/AllPropertiesInNamespaceRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/routes/AllPropertiesInNamespaceRoute.java
@@ -10,7 +10,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import dev.galasa.framework.api.common.InternalServletException;
-import dev.galasa.framework.api.common.MimeType;
 import dev.galasa.framework.api.common.QueryParameters;
 import dev.galasa.framework.api.common.ResponseBuilder;
 import dev.galasa.framework.api.common.ServletError;
@@ -39,7 +38,6 @@ public class AllPropertiesInNamespaceRoute extends CPSRoute {
 
     @Override
     public HttpServletResponse handleGetRequest(String pathInfo, QueryParameters queryParams,HttpServletRequest req, HttpServletResponse response) throws ServletException, FrameworkException {
-        validateAcceptHeader(req, MimeType.APPLICATION_JSON);
         String namespace = getNamespaceNameFromURL(pathInfo);
         String properties = getNamespaceProperties(namespace);
         checkNamespaceExists(namespace);

--- a/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/routes/NamespacesRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/routes/NamespacesRoute.java
@@ -17,7 +17,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import dev.galasa.framework.api.common.InternalServletException;
-import dev.galasa.framework.api.common.MimeType;
 import dev.galasa.framework.api.common.QueryParameters;
 import dev.galasa.framework.api.common.ResponseBuilder;
 import dev.galasa.framework.api.common.ServletError;
@@ -49,7 +48,6 @@ public class NamespacesRoute extends CPSRoute {
 
     @Override
     public HttpServletResponse handleGetRequest(String pathInfo, QueryParameters queryParams,HttpServletRequest req, HttpServletResponse response) throws ServletException, IOException, FrameworkException {
-        validateAcceptHeader(req, MimeType.APPLICATION_JSON);
         String namespaces = getNamespaces(req.getRequestURI());
 		return getResponseBuilder().buildResponse(req, response, "application/json", namespaces, HttpServletResponse.SC_OK); 
     }

--- a/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/routes/PropertyRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/routes/PropertyRoute.java
@@ -16,7 +16,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import dev.galasa.framework.api.common.InternalServletException;
-import dev.galasa.framework.api.common.MimeType;
 import dev.galasa.framework.api.common.QueryParameters;
 import dev.galasa.framework.api.common.ResponseBuilder;
 import dev.galasa.framework.api.common.ServletError;
@@ -43,7 +42,6 @@ public class PropertyRoute extends CPSRoute{
     @Override
     public HttpServletResponse handleGetRequest(String pathInfo, QueryParameters queryParams,HttpServletRequest req, HttpServletResponse response)
             throws ServletException, IOException, FrameworkException {
-        validateAcceptHeader(req, MimeType.APPLICATION_JSON);
         String namespace = getNamespaceFromURL(pathInfo);
         String properties = getNamespaceProperties(namespace, queryParams);
         checkNamespaceExists(namespace);
@@ -81,7 +79,6 @@ public class PropertyRoute extends CPSRoute{
             throws  IOException, FrameworkException {
         String namespaceName = getNamespaceFromURL(pathInfo);
         checkRequestHasContent(request);
-        validateAcceptHeader(request, MimeType.APPLICATION_JSON);
         ServletInputStream body = request.getInputStream();
         String jsonString = new String (body.readAllBytes(),StandardCharsets.UTF_8);
         body.close();

--- a/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/routes/PropertyUpdateRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/routes/PropertyUpdateRoute.java
@@ -16,7 +16,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import dev.galasa.framework.api.common.InternalServletException;
-import dev.galasa.framework.api.common.MimeType;
 import dev.galasa.framework.api.common.QueryParameters;
 import dev.galasa.framework.api.common.ResponseBuilder;
 import dev.galasa.framework.api.common.ServletError;
@@ -45,7 +44,6 @@ public class PropertyUpdateRoute extends CPSRoute {
      */
     @Override
     public HttpServletResponse handleGetRequest(String pathInfo, QueryParameters queryParams,HttpServletRequest req, HttpServletResponse response) throws ServletException, IOException, FrameworkException {
-        validateAcceptHeader(req, MimeType.APPLICATION_JSON);
         String namespace = getNamespaceFromURL(pathInfo);
         String propertyName = getPropertyNameFromURL(pathInfo);
         checkNamespaceExists(namespace);
@@ -84,7 +82,6 @@ public class PropertyUpdateRoute extends CPSRoute {
             throws  IOException, FrameworkException {
         String namespaceName = getNamespaceFromURL(pathInfo);
         String name = getPropertyNameFromURL(pathInfo);
-        validateAcceptHeader(request, MimeType.TEXT_PLAIN);
         checkRequestHasContent(request);
         ServletInputStream body = request.getInputStream();
         String jsonString = new String (body.readAllBytes(),StandardCharsets.UTF_8);
@@ -103,7 +100,6 @@ public class PropertyUpdateRoute extends CPSRoute {
     public HttpServletResponse handleDeleteRequest(String pathInfo, QueryParameters queryParameters,
             HttpServletRequest request, HttpServletResponse response)
             throws FrameworkException {
-        validateAcceptHeader(request, MimeType.TEXT_PLAIN);
         String namespace = getNamespaceFromURL(pathInfo);
         String property = getPropertyNameFromURL(pathInfo);
         deleteProperty(namespace, property);

--- a/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestAddPropertyInNamespaceRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestAddPropertyInNamespaceRoute.java
@@ -340,46 +340,6 @@ public class TestAddPropertyInNamespaceRoute extends CpsServletTest {
 		); 
     }
 
-    @Test
-    public void TestGetNamespacesPUTRequestWithBadAcceptHeaderReturnsError() throws Exception{
-        // Given...
-        String namespace = "framework";
-        String propertyName = "property.6";
-        String value = "value6";
-        String json = "{\"name\":\""+propertyName+"\", \"value\":\""+value+"\"}";
-        Map<String, String> headerMap = new HashMap<String,String>();
-        headerMap.put("Accept", "text/html");
-        MockIConfigurationPropertyStoreService store = new MockIConfigurationPropertyStoreService(namespace){
-            @Override
-            public @Null String getProperty(@NotNull String prefix, @NotNull String suffix, String... infixes)
-            throws ConfigurationPropertyStoreException {
-            for (Map.Entry<String,String> property : properties.entrySet()){
-                String key = property.getKey();
-                String match = prefix+"."+suffix;
-                if (key.contains(match)){
-                    return property.getValue();
-                }
-            }
-            return null;
-            }
-        };
-        setServlet("/namespace/framework/property/"+propertyName, namespace, json, "PUT", store, headerMap);
-        MockCpsServlet servlet = getServlet();
-        HttpServletRequest req = getRequest();
-        HttpServletResponse resp = getResponse();
-        ServletOutputStream outStream = resp.getOutputStream();	
-                
-        // When...
-        servlet.init();
-        servlet.doPut(req,resp);
-
-        // Then...
-		assertThat(resp.getStatus()).isEqualTo(406);
-		assertThat(resp.getContentType()).isEqualTo("application/json");
-		checkErrorStructure(outStream.toString(), 5406,
-			"E: Unsupported 'Accept' header value set. Supported response types are: [application/json]");
-    }
-
 	/*
 	 * TEST - HANDLE POST REQUEST - should error as this method is not supported by this API end-point
 	 */

--- a/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestAllNamespaceRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestAllNamespaceRoute.java
@@ -246,27 +246,6 @@ public class TestAllNamespaceRoute extends CpsServletTest {
 		assertThat(outStream.toString()).isEqualTo("[\n  \"framework\",\n  \"secure\"\n]");
 	}
 
-	@Test
-	public void TestGetNamespacesWithBadAcceptHeaderWithFrameworkWithDataReturnsOk() throws Exception{
-		// Given...
-		Map<String, String> headerMap = new HashMap<String,String>();
-        headerMap.put("Accept", "application/yaml");
-		setServlet("/namespace","framework",null, "GET", new MockIConfigurationPropertyStoreService(), headerMap);
-		MockCpsServlet servlet = getServlet();
-		HttpServletRequest req = getRequest();
-		HttpServletResponse resp = getResponse();
-		ServletOutputStream outStream = resp.getOutputStream();	
-
-		// When...
-		servlet.init();
-		servlet.doGet(req,resp);
-	
-		// Then...
-		assertThat(resp.getStatus()).isEqualTo(406);
-		assertThat(resp.getContentType()).isEqualTo("application/json");
-		checkErrorStructure(outStream.toString(), 5406,
-			"E: Unsupported 'Accept' header value set. Supported response types are: [application/json]");
-	}
     @Test
 	public void TestGetNamespacesWithFrameworkNullNamespacesReturnsError() throws Exception{
 		// Given...

--- a/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestAllPropertiesInNamespaceFilteredRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestAllPropertiesInNamespaceFilteredRoute.java
@@ -289,28 +289,6 @@ public class TestAllPropertiesInNamespaceFilteredRoute extends CpsServletTest {
 		assertThat(outStream.toString()).isEqualTo("{}");
 	}
 
-	@Test
-	public void TestGetNamespacesWithFrameworkWithDataNoMatchBadAcceptHeaderReturnsOk() throws Exception{
-		// Given...
-		Map<String, String> headerMap = new HashMap<String,String>();
-        headerMap.put("Accept", "text/json");
-		setServlet("/namespace/framework/prefix/prop/suffix/erty","framework",null, "GET", new MockIConfigurationPropertyStoreService("framework"), headerMap);
-		MockCpsServlet servlet = getServlet();
-		HttpServletRequest req = getRequest();
-		HttpServletResponse resp = getResponse();
-		ServletOutputStream outStream = resp.getOutputStream();	
-
-		// When...
-		servlet.init();
-		servlet.doGet(req,resp);
-	
-		// Then...
-		assertThat(resp.getStatus()).isEqualTo(406);
-		assertThat(resp.getContentType()).isEqualTo("application/json");
-		checkErrorStructure(outStream.toString(), 5406,
-			"E: Unsupported 'Accept' header value set. Supported response types are: [application/json]");
-	}
-
     @Test
 	public void TestGetNamespacesWithFrameworkWithDataReturnsValue() throws Exception{
 		// Given...

--- a/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestAllPropertiesInNamespaceRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestAllPropertiesInNamespaceRoute.java
@@ -272,28 +272,6 @@ public class TestAllPropertiesInNamespaceRoute extends CpsServletTest {
 				"{\n    \"name\": \"property.4\",\n    \"value\": \"value4\"\n  },\n  "+
 				"{\n    \"name\": \"property.5\",\n    \"value\": \"value5\"\n  }\n]");
 	}
-
-	@Test
-	public void TestGetNamespacesWithFrameworkWithDataBadAcceptHeaderReturnsOk() throws Exception{
-		// Given...
-		Map<String, String> headerMap = new HashMap<String,String>();
-        headerMap.put("Accept", "text/plain");
-		setServlet("/namespace/framework","framework",null, "GET", new MockIConfigurationPropertyStoreService("framework"), headerMap);
-		MockCpsServlet servlet = getServlet();
-		HttpServletRequest req = getRequest();
-		HttpServletResponse resp = getResponse();
-		ServletOutputStream outStream = resp.getOutputStream();	
-
-		// When...
-		servlet.init();
-		servlet.doGet(req,resp);
-	
-		// Then...
-		assertThat(resp.getStatus()).isEqualTo(406);
-		assertThat(resp.getContentType()).isEqualTo("application/json");
-		checkErrorStructure(outStream.toString(), 5406,
-			"E: Unsupported 'Accept' header value set. Supported response types are: [application/json]");
-	}
    
     @Test
 	public void TestGetNamespacesWithFrameworkBadPathReturnsError() throws Exception{

--- a/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestNamespacesRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestNamespacesRoute.java
@@ -242,28 +242,6 @@ public class TestNamespacesRoute extends CpsServletTest{
 	}
 
 	@Test
-	public void TestGetNamespacesWithFrameworkWithDataBadAcceptHeaderReturnsOk() throws Exception{
-		// Given...
-		Map<String, String> headerMap = new HashMap<String,String>();
-        headerMap.put("Accept", "applctn/json");
-		setServlet("/","framework",null, "GET", new MockIConfigurationPropertyStoreService("framework"), headerMap);
-		MockCpsServlet servlet = getServlet();
-		HttpServletRequest req = getRequest();
-		HttpServletResponse resp = getResponse();
-		ServletOutputStream outStream = resp.getOutputStream();	
-
-		// When...
-		servlet.init();
-		servlet.doGet(req,resp);
-	
-		// Then...
-		assertThat(resp.getStatus()).isEqualTo(406);
-		assertThat(resp.getContentType()).isEqualTo("application/json");
-		checkErrorStructure(outStream.toString(), 5406,
-			"E: Unsupported 'Accept' header value set. Supported response types are: [application/json]");
-	}
-
-	@Test
 	public void TestGetNamespacesWithFrameworkWithDataEmptyPathReturnsOk() throws Exception{
 		// Given...
 		setServlet("","framework",new HashMap<String,String[]>());

--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RequestorRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RequestorRoute.java
@@ -18,7 +18,6 @@ import com.google.gson.JsonObject;
 
 import dev.galasa.framework.api.ras.internal.common.RasQueryParameters;
 import dev.galasa.framework.api.common.InternalServletException;
-import dev.galasa.framework.api.common.MimeType;
 import dev.galasa.framework.api.common.QueryParameters;
 import dev.galasa.framework.api.common.ResponseBuilder;
 import dev.galasa.framework.spi.FrameworkException;
@@ -44,7 +43,6 @@ public class RequestorRoute extends RunsRoute {
     @Override
     public HttpServletResponse handleGetRequest(String pathInfo, QueryParameters queryParams,HttpServletRequest req, HttpServletResponse response)
     throws ServletException, IOException, FrameworkException {
-        validateAcceptHeader(req, MimeType.APPLICATION_JSON);
         this.sortQueryParameterChecker = new RasQueryParameters(queryParams);
         String outputString = retrieveRequestors(queryParams);
         return getResponseBuilder().buildResponse(req, response, "application/json", outputString, HttpServletResponse.SC_OK); 

--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/ResultNamesRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/ResultNamesRoute.java
@@ -20,7 +20,6 @@ import com.google.gson.JsonObject;
 
 import dev.galasa.framework.api.ras.internal.common.RasQueryParameters;
 import dev.galasa.framework.api.common.InternalServletException;
-import dev.galasa.framework.api.common.MimeType;
 import dev.galasa.framework.api.common.QueryParameters;
 import dev.galasa.framework.api.common.ResponseBuilder;
 import dev.galasa.framework.api.common.ServletError;
@@ -46,7 +45,6 @@ public class ResultNamesRoute extends RunsRoute {
     @Override
     public HttpServletResponse handleGetRequest(String pathInfo, QueryParameters queryParams,HttpServletRequest req, HttpServletResponse response) 
 	throws ServletException, IOException, FrameworkException {
-		validateAcceptHeader(req, MimeType.APPLICATION_JSON);
         String outputString = retrieveResults(new RasQueryParameters(queryParams));
 		return getResponseBuilder().buildResponse(req, response, "application/json", outputString, HttpServletResponse.SC_OK);
     }

--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunArtifactsListRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunArtifactsListRoute.java
@@ -27,7 +27,6 @@ import dev.galasa.framework.api.ras.internal.common.IRunRootArtifact;
 import dev.galasa.framework.api.ras.internal.common.RunLogArtifact;
 import dev.galasa.framework.api.ras.internal.common.StructureJsonArtifact;
 import dev.galasa.framework.api.common.InternalServletException;
-import dev.galasa.framework.api.common.MimeType;
 import dev.galasa.framework.api.common.QueryParameters;
 import dev.galasa.framework.api.common.ResponseBuilder;
 import dev.galasa.framework.api.common.ServletError;
@@ -65,7 +64,6 @@ public class RunArtifactsListRoute extends RunArtifactsRoute {
 
     @Override
     public HttpServletResponse handleGetRequest(String pathInfo, QueryParameters queryParams, HttpServletRequest req, HttpServletResponse res) throws ServletException, IOException, FrameworkException {
-        validateAcceptHeader(req, MimeType.APPLICATION_JSON);
         Matcher matcher = Pattern.compile(this.getPath()).matcher(pathInfo);
         matcher.matches();
         String runId = matcher.group(1);

--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunDetailsRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunDetailsRoute.java
@@ -21,7 +21,6 @@ import dev.galasa.framework.api.ras.internal.common.RunActionJson;
 import dev.galasa.framework.api.ras.internal.common.RunActionStatus;
 import dev.galasa.framework.api.ras.internal.common.RunResultUtility;
 import dev.galasa.framework.api.common.InternalServletException;
-import dev.galasa.framework.api.common.MimeType;
 import dev.galasa.framework.api.common.QueryParameters;
 import dev.galasa.framework.api.common.ResponseBuilder;
 import dev.galasa.framework.api.common.ServletError;
@@ -52,7 +51,6 @@ public class RunDetailsRoute extends RunsRoute {
 
    @Override
    public HttpServletResponse handleGetRequest(String pathInfo, QueryParameters queryParams, HttpServletRequest req, HttpServletResponse res) throws ServletException, IOException, FrameworkException {
-      validateAcceptHeader(req, MimeType.APPLICATION_JSON);
       String runId = getRunIdFromPath(pathInfo);
       try{
          RasRunResult run = getRunFromFramework(runId);
@@ -66,7 +64,6 @@ public class RunDetailsRoute extends RunsRoute {
 
    @Override
    public HttpServletResponse handlePutRequest(String pathInfo, QueryParameters queryParams, HttpServletRequest request, HttpServletResponse response) throws DynamicStatusStoreException, FrameworkException, IOException {
-      validateAcceptHeader(request, MimeType.TEXT_PLAIN);
       String runId = getRunIdFromPath(pathInfo);
       String runName = getRunNameFromRunId(runId);
 

--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunLogRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunLogRoute.java
@@ -16,7 +16,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import dev.galasa.framework.api.common.InternalServletException;
-import dev.galasa.framework.api.common.MimeType;
 import dev.galasa.framework.api.common.QueryParameters;
 import dev.galasa.framework.api.common.ResponseBuilder;
 import dev.galasa.framework.api.common.ServletError;
@@ -39,7 +38,6 @@ public class RunLogRoute extends RunsRoute {
 
     @Override
     public HttpServletResponse handleGetRequest(String pathInfo, QueryParameters queryParams, HttpServletRequest req, HttpServletResponse res) throws ServletException, IOException, FrameworkException {
-        validateAcceptHeader(req, MimeType.TEXT_PLAIN);
         Matcher matcher = Pattern.compile(this.getPath()).matcher(pathInfo);
         matcher.matches();
         String runId = matcher.group(1);

--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunQueryRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunQueryRoute.java
@@ -12,7 +12,6 @@ import com.google.gson.JsonObject;
 
 import dev.galasa.api.ras.RasRunResult;
 import dev.galasa.framework.api.common.InternalServletException;
-import dev.galasa.framework.api.common.MimeType;
 import dev.galasa.framework.api.common.ResponseBuilder;
 import dev.galasa.framework.api.common.ServletError;
 import dev.galasa.framework.api.common.QueryParameters;
@@ -68,7 +67,6 @@ public class RunQueryRoute extends RunsRoute {
 	@Override
 	public HttpServletResponse handleGetRequest(String pathInfo, QueryParameters generalQueryParams, HttpServletRequest req, HttpServletResponse res) throws ServletException, IOException, FrameworkException {
 		RasQueryParameters queryParams = new RasQueryParameters(generalQueryParams);
-		validateAcceptHeader(req, MimeType.APPLICATION_JSON);
 		String outputString = retrieveResults(queryParams);
 		return getResponseBuilder().buildResponse(req, res, "application/json", outputString, HttpServletResponse.SC_OK);
 	}

--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/TestClassesRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/TestClassesRoute.java
@@ -18,7 +18,6 @@ import com.google.gson.JsonObject;
 
 import dev.galasa.framework.api.ras.internal.common.RasQueryParameters;
 import dev.galasa.framework.api.common.InternalServletException;
-import dev.galasa.framework.api.common.MimeType;
 import dev.galasa.framework.api.common.QueryParameters;
 import dev.galasa.framework.api.common.ResponseBuilder;
 import dev.galasa.framework.api.common.ServletError;
@@ -48,7 +47,6 @@ public class TestClassesRoute extends RunsRoute {
     @Override
     public HttpServletResponse handleGetRequest(String pathInfo, QueryParameters queryParams,HttpServletRequest req, HttpServletResponse response)
     throws ServletException, IOException, FrameworkException {
-        validateAcceptHeader(req, MimeType.APPLICATION_JSON);
         this.sortQueryParameterChecker = new RasQueryParameters(queryParams);
         String outputString = TestClasses();
         return getResponseBuilder().buildResponse(req, response, "application/json", outputString, HttpServletResponse.SC_OK); 

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRequestorsRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRequestorsRoute.java
@@ -481,34 +481,4 @@ public class TestRequestorsRoute extends RasServletTest{
 		assertThat( outStream.toString() ).isEqualTo(expectedJson);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
 	}
-
-	@Test
-	public void testRequestorsWithBadAcceptHeaderReturnsError() throws Exception {
-		//Given..
-		List<IRunResult> mockInputRunResults = generateTestData(10);
-		//Build Http query parameters
-
-        Map<String, String[]> parameterMap = new HashMap<String,String[]>();
-        parameterMap.put("sort", new String[] {"requestor:desc"});
-
-		Map<String, String> headerMap = new HashMap<String,String>();
-        headerMap.put("Accept", "text/json");
-		MockHttpServletRequest mockRequest = new MockHttpServletRequest(parameterMap, "/requestors", headerMap);
-		MockRasServletEnvironment mockServletEnvironment = new MockRasServletEnvironment( mockInputRunResults,mockRequest);
-
-		RasServlet servlet = mockServletEnvironment.getServlet();
-		HttpServletRequest req = mockServletEnvironment.getRequest();
-		HttpServletResponse resp = mockServletEnvironment.getResponse();
-		ServletOutputStream outStream = resp.getOutputStream();
-
-		//When...
-		servlet.init();
-		servlet.doGet(req,resp);
-
-		//Then...
-		assertThat(resp.getStatus()).isEqualTo(406);
-		assertThat(resp.getContentType()).isEqualTo("application/json");
-		checkErrorStructure(outStream.toString(), 5406,
-			"E: Unsupported 'Accept' header value set. Supported response types are: [application/json]");
-	}
 }

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestResultNamesRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestResultNamesRoute.java
@@ -557,33 +557,4 @@ public class TestResultNamesRoute extends RasServletTest{
 		assertThat( outStream.toString() ).isEqualTo(expectedJson);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
 	}
-
-	@Test
-	public void testResultNamesWithBadAcceptheaderReturnsError() throws Exception {
-		//Given..
-		List<IRunResult> mockInputRunResults = generateTestData(10);
-		//Build Http query parameters
-
-        Map<String, String[]> parameterMap = new HashMap<String,String[]>();
-		parameterMap.put("sort", new String[] {"resultnames:asc"});
-		Map<String, String> headerMap = new HashMap<String,String>();
-        headerMap.put("Accept", "plain/json");
-		MockHttpServletRequest mockRequest = new MockHttpServletRequest(parameterMap, "/resultnames", headerMap);
-		MockRasServletEnvironment mockServletEnvironment = new MockRasServletEnvironment( mockInputRunResults,mockRequest);
-
-		RasServlet servlet = mockServletEnvironment.getServlet();
-		HttpServletRequest req = mockServletEnvironment.getRequest();
-		HttpServletResponse resp = mockServletEnvironment.getResponse();
-		ServletOutputStream outStream = resp.getOutputStream();
-
-		//When...
-		servlet.init();
-		servlet.doGet(req,resp);
-
-		//Then...
-		assertThat(resp.getStatus()).isEqualTo(406);
-		assertThat(resp.getContentType()).isEqualTo("application/json");
-		checkErrorStructure(outStream.toString(), 5406,
-			"E: Unsupported 'Accept' header value set. Supported response types are: [application/json]");
-	}
 }

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunArtifactsListServlet.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunArtifactsListServlet.java
@@ -601,38 +601,4 @@ public class TestRunArtifactsListServlet extends RasServletTest {
 
 		assertThat(resp.getContentType()).isEqualTo("application/json");
 	}
-
-	@Test
-	public void testNoArtifactsToListWithBadAcceptHeaderReturnsError() throws Exception {
-		//Given..
-		String runName = "testA";
-		MockFileSystem mockFileSystem = new MockFileSystem();
-		MockPath mockArtifactsPath = new MockPath("/" + runName + "/artifacts",mockFileSystem);
-		mockFileSystem.createDirectories(mockArtifactsPath);
-
-		String runId = "xxxxx678xxxxx";
-        String runLog = "log";
-		List<IRunResult> mockInputRunResults = generateTestData(runId, runName, runLog);
-
-		Map<String, String[]> parameterMap = new HashMap<String,String[]>();
-		Map<String, String> headerMap = new HashMap<String,String>();
-        headerMap.put("Accept", "random/*");
-		MockHttpServletRequest mockRequest = new MockHttpServletRequest(parameterMap, "/runs/" + runId + "/artifacts", headerMap);
-		MockRasServletEnvironment mockServletEnvironment = new MockRasServletEnvironment(mockInputRunResults, mockRequest, mockFileSystem);
-
-		RasServlet servlet = mockServletEnvironment.getServlet();
-		HttpServletRequest req = mockServletEnvironment.getRequest();
-		HttpServletResponse resp = mockServletEnvironment.getResponse();
-		ServletOutputStream outStream = resp.getOutputStream();
-
-		//When...
-		servlet.init();
-		servlet.doGet(req,resp);
-
-		// Then...
-		assertThat(resp.getStatus()).isEqualTo(406);
-		assertThat(resp.getContentType()).isEqualTo("application/json");
-		checkErrorStructure(outStream.toString(), 5406,
-			"E: Unsupported 'Accept' header value set. Supported response types are: [application/json]");
-	}
 }

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunDetailsRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunDetailsRoute.java
@@ -292,36 +292,6 @@ public class TestRunDetailsRoute extends RasServletTest {
 		assertThat(resp.getContentType()).isEqualTo("application/json");
 	}
 
-	@Test
-    public void testGoodRunIdBadAcceptHeaderReturnsError() throws Exception {
-		//Given..
-		String runId = "xx12345xx";
-        String runName = "U123";
-
-		List<IRunResult> mockInputRunResults = generateTestData(runId, runName, null);
-
-		Map<String, String[]> parameterMap = new HashMap<String,String[]>();
-		Map<String, String> headerMap = new HashMap<String,String>();
-        headerMap.put("Accept", "app/lication");
-		MockHttpServletRequest mockRequest = new MockHttpServletRequest(parameterMap, "/runs/" + runId, headerMap);
-		MockRasServletEnvironment mockServletEnvironment = new MockRasServletEnvironment(mockInputRunResults, mockRequest, mockFileSystem);
-
-		RasServlet servlet = mockServletEnvironment.getServlet();
-		HttpServletRequest req = mockServletEnvironment.getRequest();
-		HttpServletResponse resp = mockServletEnvironment.getResponse();
-		ServletOutputStream outStream = resp.getOutputStream();
-
-		//When...
-		servlet.init();
-		servlet.doGet(req,resp);
-
-		// Then...
-		assertThat(resp.getStatus()).isEqualTo(406);
-		assertThat(resp.getContentType()).isEqualTo("application/json");
-		checkErrorStructure(outStream.toString(), 5406,
-			"E: Unsupported 'Accept' header value set. Supported response types are: [application/json]");
-	}
-
     @Test
     public void testBadRunIdReturnsError() throws Exception {
 		//Given..
@@ -568,44 +538,6 @@ public class TestRunDetailsRoute extends RasServletTest {
 		checkErrorStructure(outStream.toString(), 
 			5045, 
 			"E: Error occured. The field 'status' in the request body is invalid. The 'status' value 'submitted' supplied is not supported. Supported values are: 'queued' and 'finished'.");
-	}
-
-	@Test
-	public void testRequestToResetRunBadAcceptHeaderReturnsOK() throws Exception {
-		// Given...
-		String runId = "xx12345xx";
-		String runName = "U123";
-
-		List<IRunResult> mockInputRunResults = generateTestData(runId, runName, null);
-
-		String content = generateStatusUpdateJson("queued", "");
-		Map<String, String> headerMap = new HashMap<String,String>();
-        headerMap.put("Accept", "air/plane");
-		MockHttpServletRequest mockRequest = new MockHttpServletRequest("/runs/" + runId, content, "PUT",headerMap);
-		
-		List<IRun> runs = new ArrayList<IRun>();
-		runs.add(new MockIRun(runName, "type1", "requestor1", "test1", "BUILDING", "bundle1", "testClass1", "group1"));
-		IFrameworkRuns frameworkRuns = new MockIFrameworkRuns(runs);
-		MockResultArchiveStoreDirectoryService mockrasService = new MockResultArchiveStoreDirectoryService(mockInputRunResults);
-		List<IResultArchiveStoreDirectoryService> directoryServices = new ArrayList<IResultArchiveStoreDirectoryService>();
-		directoryServices.add(mockrasService);
-		MockFramework mockFramework = new MockFramework(new MockArchiveStore(directoryServices), frameworkRuns);
-		MockRasServletEnvironment mockServletEnvironment = new MockRasServletEnvironment(mockFramework, mockInputRunResults, mockRequest);
-
-		RasServlet servlet = mockServletEnvironment.getRasServlet();
-		HttpServletRequest req = mockServletEnvironment.getRequest();
-		HttpServletResponse resp = mockServletEnvironment.getResponse();
-		ServletOutputStream outStream = resp.getOutputStream();
-
-		// When...
-		servlet.init();
-		servlet.doPut(req, resp);
-
-		// Then...
-		assertThat(resp.getStatus()).isEqualTo(406);
-		assertThat(resp.getContentType()).isEqualTo("application/json");
-		checkErrorStructure(outStream.toString(), 5406,
-			"E: Unsupported 'Accept' header value set. Supported response types are: [text/plain]");
 	}
 	
 	@Test

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunLogRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunLogRoute.java
@@ -315,33 +315,6 @@ public class TestRunLogRoute extends RasServletTest {
 	}
 
 	@Test
-	public void testRunResultWithLogBadAcceptHeaderReturnsError() throws Exception {
-		//Given..
-		String runId = "runA";
-        String runLog = "hello world";
-		List<IRunResult> mockRunResults = generateTestData(runId, "testName", runLog);
-		Map<String, String> headerMap = new HashMap<String,String>();
-        headerMap.put("Accept", "*/json");
-		MockHttpServletRequest mockRequest = new MockHttpServletRequest(new HashMap<>(), "/runs/" + runId + "/runlog", headerMap);
-		MockRasServletEnvironment mockServletEnvironment = new MockRasServletEnvironment(mockRunResults, mockRequest);
-
-		RasServlet servlet = mockServletEnvironment.getServlet();
-		HttpServletRequest req = mockServletEnvironment.getRequest();
-		HttpServletResponse resp = mockServletEnvironment.getResponse();
-		ServletOutputStream outStream = resp.getOutputStream();
-
-		//When...
-		servlet.init();
-		servlet.doGet(req,resp);
-
-		// Then...
-		assertThat(resp.getStatus()).isEqualTo(406);
-		assertThat(resp.getContentType()).isEqualTo("application/json");
-		checkErrorStructure(outStream.toString(), 5406,
-			"E: Unsupported 'Accept' header value set. Supported response types are: [text/plain]");
-	}
-
-	@Test
 	public void testRunResultWithNullLogReturnsNotFoundError() throws Exception {
 		//Given..
 		String runId = "runA";

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunQuery.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunQuery.java
@@ -2095,33 +2095,4 @@ public class TestRunQuery extends RasServletTest {
 		assertThat( outStream.toString() ).isEqualTo(expectedJson);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
 	}
-
-	@Test
-	public void testNoQueryNotSortedWithBadAcceptHeaderWithDBServiceReturnsOK() throws Exception {
-		// Given...
-		Map<String, String[]> parameterMap = new HashMap<String,String[]>();
-
-		Map<String, String> headerMap = new HashMap<String,String>();
-		headerMap.put("Accept","text/plain");
-
-		List<IRunResult> mockInputRunResults= new ArrayList<IRunResult>();
-
-		MockHttpServletRequest mockRequest = new MockHttpServletRequest(parameterMap, "/runs", headerMap);
-		MockRasServletEnvironment mockServletEnvironment = new MockRasServletEnvironment(mockInputRunResults,mockRequest);
-
-		RasServlet servlet = mockServletEnvironment.getServlet();
-		HttpServletRequest req = mockServletEnvironment.getRequest();
-		HttpServletResponse resp = mockServletEnvironment.getResponse();
-		ServletOutputStream outStream = resp.getOutputStream();
-
-		// When...
-		servlet.init();
-		servlet.doGet(req,resp);
-
-		// Then...
-		assertThat(resp.getStatus()).isEqualTo(406);
-		assertThat(resp.getContentType()).isEqualTo("application/json");
-		checkErrorStructure(outStream.toString(), 5406,
-			"E: Unsupported 'Accept' header value set. Supported response types are: [application/json]");
-	}
 }

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestTestClassesRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestTestClassesRoute.java
@@ -514,31 +514,4 @@ public class TestTestClassesRoute extends RasServletTest{
 		assertThat( outStream.toString() ).isEqualTo(expectedJson);
 		assertThat( resp.getContentType()).isEqualTo("application/json");
 	}
-
-	@Test
-	public void testTestClassesWithTenTestBadAcceptHeaderReturnsOK() throws Exception {
-		//Given..
-		List<IRunResult> mockInputRunResults = generateTestData(10);
-		//Build Http query parameters
-		Map<String, String> headerMap = new HashMap<String,String>();
-		headerMap.put("Accept","*/json");
-        Map<String, String[]> parameterMap = new HashMap<String,String[]>();
-		MockHttpServletRequest mockRequest = new MockHttpServletRequest(parameterMap, "/testclasses", headerMap);
-		MockRasServletEnvironment mockServletEnvironment = new MockRasServletEnvironment( mockInputRunResults,mockRequest);
-
-		RasServlet servlet = mockServletEnvironment.getServlet();
-		HttpServletRequest req = mockServletEnvironment.getRequest();
-		HttpServletResponse resp = mockServletEnvironment.getResponse();
-		ServletOutputStream outStream = resp.getOutputStream();
-
-		//When...
-		servlet.init();
-		servlet.doGet(req,resp);
-
-		//Then...
-		assertThat(resp.getStatus()).isEqualTo(406);
-		assertThat(resp.getContentType()).isEqualTo("application/json");
-		checkErrorStructure(outStream.toString(), 5406,
-			"E: Unsupported 'Accept' header value set. Supported response types are: [application/json]");
-	}
 }

--- a/galasa-parent/dev.galasa.framework.api.resources/src/main/java/dev/galasa/framework/api/resources/routes/ResourcesRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.resources/src/main/java/dev/galasa/framework/api/resources/routes/ResourcesRoute.java
@@ -26,7 +26,6 @@ import com.google.gson.JsonObject;
 import dev.galasa.framework.api.beans.GalasaProperty;
 import dev.galasa.framework.api.common.BaseRoute;
 import dev.galasa.framework.api.common.InternalServletException;
-import dev.galasa.framework.api.common.MimeType;
 import dev.galasa.framework.api.common.QueryParameters;
 import dev.galasa.framework.api.common.ResponseBuilder;
 import dev.galasa.framework.api.common.ServletError;
@@ -61,7 +60,6 @@ public class ResourcesRoute  extends BaseRoute{
     @Override
      public HttpServletResponse handlePostRequest(String pathInfo, QueryParameters queryParameters, 
             HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException, FrameworkException {  
-        validateAcceptHeader(request, MimeType.APPLICATION_JSON);
         checkRequestHasContent(request);
         ServletInputStream body = request.getInputStream();
         String jsonBody = new String (body.readAllBytes(),StandardCharsets.UTF_8);

--- a/galasa-parent/dev.galasa.framework.api.resources/src/test/java/dev/galasa/framework/api/resources/routes/TestResourcesRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.resources/src/test/java/dev/galasa/framework/api/resources/routes/TestResourcesRoute.java
@@ -1349,40 +1349,6 @@ public class TestResourcesRoute extends ResourcesServletTest{
     }
 
     @Test
-    public void TestHandlePOSTwithDataBadAcceptReturnsOK() throws Exception {
-        // Given...
-		String namespace = "framework";
-        String propertyname = "property.5";
-        String value = "value5";
-        String propertynametwo = "property.17";
-        String valuetwo = "value1";
-        String apiVersion = "galasa-dev/v1alpha1";
-        String action = "delete";
-        String propertyone = generatePropertyJSON(namespace, propertyname, value, apiVersion);
-        String propertytwo = generatePropertyJSON(namespace, propertynametwo, valuetwo, apiVersion);
-		String propertyJSON = "{\n \"action\":\""+action+"\", \"data\":["+propertyone+","+propertytwo+"]\n}";
-        Map<String, String> headers = new HashMap<String,String>();
-        headers.put("Accept", "application/xml");
-		setServlet("/", "framework", propertyJSON , "POST", headers);
-		MockResourcesServlet servlet = getServlet();
-		HttpServletRequest req = getRequest();
-		HttpServletResponse resp = getResponse();
-        ServletOutputStream outStream = resp.getOutputStream();
-
-        // When...
-        servlet.init();
-        servlet.doPost(req, resp);
-
-        // Then...
-		assertThat(resp.getStatus()).isEqualTo(406);
-		assertThat(resp.getContentType()).isEqualTo("application/json");
-		checkErrorStructure(outStream.toString(), 5406,
-			"E: Unsupported 'Accept' header value set. Supported response types are: [application/json]");
-        checkPropertyNotInNamespace(namespace, propertyname, value);
-        checkPropertyNotInNamespace(namespace, propertynametwo, valuetwo);
-    }
-
-    @Test
     public void TestGetErrorsAsJsonReturnsJsonString() throws Exception{
         // Given...
         List<String> errors = new ArrayList<String>();

--- a/galasa-parent/dev.galasa.framework.api.runs/src/main/java/dev/galasa/framework/api/runs/routes/GroupRunsRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.runs/src/main/java/dev/galasa/framework/api/runs/routes/GroupRunsRoute.java
@@ -17,7 +17,6 @@ import dev.galasa.api.runs.ScheduleRequest;
 import dev.galasa.api.runs.ScheduleStatus;
 import dev.galasa.framework.api.common.Environment;
 import dev.galasa.framework.api.common.InternalServletException;
-import dev.galasa.framework.api.common.MimeType;
 import dev.galasa.framework.api.common.QueryParameters;
 import dev.galasa.framework.api.common.ResponseBuilder;
 import dev.galasa.framework.api.common.ServletError;
@@ -45,7 +44,6 @@ public class GroupRunsRoute extends GroupRuns{
 
     public HttpServletResponse handleGetRequest(String groupName, QueryParameters queryParams, HttpServletRequest request, HttpServletResponse response)
     throws ServletException, IOException, FrameworkException{
-        validateAcceptHeader(request, MimeType.APPLICATION_JSON);
         List<IRun> runs = getRuns(groupName.substring(1));
         if (runs != null){
             ScheduleStatus serializedRuns = serializeRuns(runs);
@@ -59,7 +57,6 @@ public class GroupRunsRoute extends GroupRuns{
     public HttpServletResponse handlePostRequest(String groupName, QueryParameters queryParameters, HttpServletRequest request , HttpServletResponse response)
     throws ServletException, IOException, FrameworkException {
         String requestor;
-        validateAcceptHeader(request, MimeType.APPLICATION_JSON);
         checkRequestHasContent(request);
         ScheduleRequest scheduleRequest = getScheduleRequestfromRequest(request);
         try {

--- a/galasa-parent/dev.galasa.framework.api.runs/src/test/java/dev/galasa/framework/api/runs/routes/TestGroupRunsRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.runs/src/test/java/dev/galasa/framework/api/runs/routes/TestGroupRunsRoute.java
@@ -7,7 +7,6 @@ package dev.galasa.framework.api.runs.routes;
 
 import static org.assertj.core.api.Assertions.*;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 
@@ -268,31 +267,6 @@ public class TestGroupRunsRoute extends RunsServletTest {
         String expectedJson = generateExpectedJson(runs, "true");
         assertThat(resp.getStatus()).isEqualTo(200);
         assertThat(outStream.toString()).isEqualTo(expectedJson);
-    }
-
-    @Test
-    public void TestGetUUIDGroupNameRunsWithValidBodyAndBadAcceptHeaderReturnsError() throws Exception {
-        // Given...
-		String groupName = "framework";
-        addRun("name1", "type1", "requestor1", "test1", "FINISHED","bundle1", "testClass1", groupName);
-        Map<String, String> headers = new HashMap<String,String>();
-        headers.put("Accept", "text/html");
-
-        setServlet("/"+groupName, groupName, runs,null, "GET", headers);
-		MockRunsServlet servlet = getServlet();
-		HttpServletRequest req = getRequest();
-		HttpServletResponse resp = getResponse();
-        ServletOutputStream outStream = resp.getOutputStream();
-
-        // When...
-        servlet.init();
-        servlet.doGet(req, resp);
-
-        // Then...
-		assertThat(resp.getStatus()).isEqualTo(406);
-		assertThat(resp.getContentType()).isEqualTo("application/json");
-		checkErrorStructure(outStream.toString(), 5406,
-			"E: Unsupported 'Accept' header value set. Supported response types are: [application/json]");
     }
 
     @Test
@@ -658,31 +632,6 @@ public class TestGroupRunsRoute extends RunsServletTest {
         String expectedJson = generateExpectedJson(runs, "false");
         assertThat(resp.getStatus()).isEqualTo(201);
         assertThat(outStream.toString()).isEqualTo(expectedJson);
-    }
-
-    @Test
-    public void TestPostUUIDGroupNameRunsWithValidBodyAndBadAcceptHeaderReturnsError() throws Exception {
-        // Given...
-		String groupName = "8149dc91-dabc-461a-b9e8-6f11a4455f59";
-        String[] classes = new String[]{"Class1/name", "Class2/name"};
-        String payload = generatePayload(classes, "requestorType", "user1", "this.test.stream", groupName, "testRequestor");
-        Map<String, String> headers = new HashMap<String,String>();
-        headers.put("Accept", "text/html");
-
-        setServlet("/"+groupName, groupName, payload, "POST", headers);
-		MockRunsServlet servlet = getServlet();
-		HttpServletRequest req = getRequest();
-		HttpServletResponse resp = getResponse();
-        ServletOutputStream outStream = resp.getOutputStream();
-
-        // When...
-        servlet.init();
-        servlet.doPost(req, resp);
-
-        // Then...
-        assertThat(resp.getStatus()).isEqualTo(406);
-        assertThat(outStream.toString()).contains("GAL5406",
-            "E: Unsupported 'Accept' header value set. Supported response types are: [application/json]");
     }
 
     /*


### PR DESCRIPTION
## Why?
Related to https://github.com/galasa-dev/projectmanagement/issues/1925

The auto-generated OpenAPI client in the CLI only sets `application/json` in the "Accept" header for requests to the Galasa API server despite some endpoints serving `text/plain`. This prevented the CLI from communicating with the API server since it would always respond with a 406 Not Acceptable - this PR removes this validation for now.