### PR TITLE
added name validator to property update endpoints

### DIFF
--- a/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/routes/CPSRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/routes/CPSRoute.java
@@ -146,10 +146,12 @@ public abstract class CPSRoute extends BaseRoute {
         GalasaProperty galasaProperty = beanSerialiser.getPropertyFromJsonString(jsonString);
         CPSFacade cps = new CPSFacade(framework);
         CPSNamespace namespace = cps.getNamespace(galasaProperty.getNamespace());
+        nameValidator.assertNamespaceCharPatternIsValid(galasaProperty.getNamespace());
         if (namespace.isHidden()) {
             ServletError error = new ServletError(GAL5016_INVALID_NAMESPACE_ERROR,namespaceName);  
             throw new InternalServletException(error, HttpServletResponse.SC_NOT_FOUND);
         }
+        nameValidator.assertPropertyNameCharPatternIsValid(galasaProperty.getName());
         CPSProperty property = namespace.getPropertyFromStore(galasaProperty.getName());
         if(!checkPropertyNamespaceMatchesURLNamespace(property, namespaceName)){
             ServletError error = new ServletError(GAL5028_PROPERTY_NAMESPACE_DOES_NOT_MATCH_ERROR,property.getNamespace(), namespaceName);  

--- a/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/routes/PropertyUpdateRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/main/java/dev/galasa/framework/api/cps/internal/routes/PropertyUpdateRoute.java
@@ -87,6 +87,8 @@ public class PropertyUpdateRoute extends CPSRoute {
         String jsonString = new String (body.readAllBytes(),StandardCharsets.UTF_8);
         body.close();
         checkNameMatchesRequest(name, jsonString);
+        nameValidator.assertNamespaceCharPatternIsValid(namespaceName);
+        nameValidator.assertPropertyNameCharPatternIsValid(name);
         checkNamespaceExists(namespaceName);
         CPSProperty property = applyPropertyToStore(jsonString, namespaceName, true);
         String responseBody = String.format("Successfully updated property %s in %s",property.getName(), property.getNamespace());
@@ -102,6 +104,8 @@ public class PropertyUpdateRoute extends CPSRoute {
             throws FrameworkException {
         String namespace = getNamespaceFromURL(pathInfo);
         String property = getPropertyNameFromURL(pathInfo);
+        nameValidator.assertNamespaceCharPatternIsValid(namespace);
+        nameValidator.assertPropertyNameCharPatternIsValid(property);
         deleteProperty(namespace, property);
         String responseBody = String.format("Successfully deleted property %s in %s",property, namespace);
         return getResponseBuilder().buildResponse(request, response, "text/plain", responseBody, HttpServletResponse.SC_OK);

--- a/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestPropertyUpdateRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestPropertyUpdateRoute.java
@@ -712,7 +712,7 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
     @Test
     public void TestPropertyRouteDELETENoFrameworkReturnsError() throws Exception{
         // Given...
-		setServlet("/namespace1/properties/property1", null, null, "DELETE");
+		setServlet("/namespace1/properties/property.1", null, null, "DELETE");
 		MockCpsServlet servlet = getServlet();
 		HttpServletRequest req = getRequest();
 		HttpServletResponse resp = getResponse();
@@ -746,7 +746,7 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
 
         // When...
         servlet.init();
-        servlet.doGet(req, resp);
+        servlet.doDelete(req, resp);
 
         // Then...
         // We expect data back
@@ -764,7 +764,7 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
     @Test
     public void TestPropertyRouteDELETEBadNamespaceReturnsError() throws Exception{
         // Given...
-		setServlet("/error/properties/property1", null, null, "DELETE");
+		setServlet("/error/properties/property.1", null, null, "DELETE");
 		MockCpsServlet servlet = getServlet();
 		HttpServletRequest req = getRequest();
 		HttpServletResponse resp = getResponse();


### PR DESCRIPTION
## Why?

This is to ensure that data that is sent to the property update endpoints is validated before being actioned, so that a bad request is flagged to the user and not a generic error