### PR TITLE
Fix bundle name not showing in bundle activation error message

### DIFF
--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BundleManagement.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BundleManagement.java
@@ -176,7 +176,7 @@ public class BundleManagement {
             }
 
             if (!isBundleActive(bundleContext, bundleSymbolicName)) {
-                String msg = MessageFormat.format("Bundle %s failed to install and activate",bundleSymbolicName);
+                String msg = MessageFormat.format("Bundle ''{0}'' failed to install and activate",bundleSymbolicName);
                 throw new FrameworkException(msg);
             }
 

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunManagers.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunManagers.java
@@ -363,7 +363,7 @@ public class TestRunManagers {
             }
 
             if (!isBundleActive(bundleSymbolicName)) {
-                String msg = MessageFormat.format("Bundle %s failed to install and activate",bundleSymbolicName);
+                String msg = MessageFormat.format("Bundle ''{0}'' failed to install and activate",bundleSymbolicName);
                 throw new FrameworkException(msg);
             }
 

--- a/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/felix/FelixFramework.java
+++ b/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/felix/FelixFramework.java
@@ -910,7 +910,7 @@ public class FelixFramework {
             }
 
             if (!isBundleActive(bundleSymbolicName)) {
-                String msg = MessageFormat.format("Bundle %s failed to install and activate",bundleSymbolicName);
+                String msg = MessageFormat.format("Bundle ''{0}'' failed to install and activate",bundleSymbolicName);
                 throw new LauncherException(msg);
             }
 

--- a/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/felix/TestFelixFramework.java
+++ b/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/felix/TestFelixFramework.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 import org.osgi.framework.Bundle;
 
 import dev.galasa.boot.mocks.MockRunnableService;
+import dev.galasa.boot.LauncherException;
 import dev.galasa.boot.mocks.MockBundle;
 import dev.galasa.boot.mocks.MockBundleContext;
 import dev.galasa.boot.mocks.MockFelixFramework;
@@ -72,6 +73,54 @@ public class TestFelixFramework {
             .collect(Collectors.toList());
 
         assertThat(addedResourceIds).contains(extraBundleName);
+    }
+
+    @Test
+    public void testRunWebApiServerWithInactiveBundleThrowsException() throws Exception {
+        // Given...
+        String extraBundleName = "my.api.bundle";
+
+        MockResolver mockResolver = new MockResolver();
+        MockRepositoryAdmin mockRepoAdmin = new MockRepositoryAdmin(mockResolver);
+
+        Map<String, MockServiceReference<?>> services = new HashMap<>();
+        MockServiceReference<MockRunnableService> mockApiStartup = new MockServiceReference<>(new MockRunnableService(), null);
+        services.put("dev.galasa.framework.api.internal.ApiStartup", mockApiStartup);
+
+        MockBundleContext mockFrameworkBundleContext = new MockBundleContext(services);
+        MockBundle mockFrameworkBundle = new MockBundle("dev.galasa.framework", mockFrameworkBundleContext);
+
+        String frameworkApiBundleName = "dev.galasa.framework.api";
+        MockBundle inactiveBundle = new MockBundle(frameworkApiBundleName);
+        inactiveBundle.setState(Bundle.UNINSTALLED);
+
+        Bundle[] availableBundles = new Bundle[] {
+            mockFrameworkBundle,
+            new MockBundle("org.apache.felix.http.servlet-api"),
+            new MockBundle("org.apache.felix.http.jetty"),
+            new MockBundle("org.apache.felix.fileinstall"),
+            inactiveBundle,
+            new MockBundle(extraBundleName),
+        };
+
+        MockBundleContext mockBundleContext = new MockBundleContext(availableBundles);
+        MockOsgiFramework mockOsgiFramework = new MockOsgiFramework(mockBundleContext);
+
+        FelixFramework felixFramework = new MockFelixFramework(mockOsgiFramework, mockRepoAdmin);
+        Properties bootstrapProperties = new Properties();
+        Properties overridesProperties = new Properties();
+
+        bootstrapProperties.put("api.extra.bundles", extraBundleName);
+
+        // When...
+        LauncherException err = catchThrowableOfType(() -> {
+            felixFramework.runWebApiServer(bootstrapProperties, overridesProperties, new ArrayList<>(), 0, 0);
+        }, LauncherException.class);
+
+        // Then...
+        assertThat(err).isNotNull();
+        assertThat(err.getMessage()).contains("Unable to install bundle", frameworkApiBundleName, "from OBR repository");
+        assertThat(err.getCause().getMessage()).contains("Bundle '" + frameworkApiBundleName + "' failed to install and activate");
     }
 
     @Test

--- a/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/mocks/MockBundle.java
+++ b/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/mocks/MockBundle.java
@@ -25,6 +25,7 @@ public class MockBundle implements Bundle {
 
     private String symbolicName;
     private BundleContext bundleContext;
+    private int bundleState = Bundle.ACTIVE;
 
     public MockBundle(String symbolicName) {
         this.symbolicName = symbolicName;
@@ -42,7 +43,11 @@ public class MockBundle implements Bundle {
 
     @Override
     public int getState() {
-        return Bundle.ACTIVE;
+        return bundleState;
+    }
+
+    public void setState(int bundleState) {
+        this.bundleState = bundleState;
     }
 
     @Override


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1955

## Changes
- Fixed incorrect error message templates to correctly display a bundle name when it fails to activate (i.e. replacing `%s` with the actual bundle name in error messages)
- Added a unit test to check that the error message is displayed correctly

(the `dev.galasa.framework` and `galasa-boot` bundles have already been bumped to 0.36.0)