### PR TITLE
Compile regex patterns for REST API paths on server initialisation

### DIFF
--- a/galasa-parent/dev.galasa.framework.api.authentication/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api.authentication/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 description = 'Galasa Authentication API'
 
-version = '0.36.0'
+version = '0.37.0'
 
 dependencies {
     implementation project(':dev.galasa.framework')

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthTokensDetailsRouteTest.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthTokensDetailsRouteTest.java
@@ -34,7 +34,7 @@ public class AuthTokensDetailsRouteTest extends BaseServletTest {
     @Test
     public void testAuthTokensDetailsRouteRegexMatchesExpectedPaths() throws Exception {
         //Given...
-        String tokensDetailsRoutePath = new AuthTokensDetailsRoute(null, null, null).getPath();
+        String tokensDetailsRoutePath = new AuthTokensDetailsRoute(null, null, null).getPath().toString();
 
         //When...
         Pattern routePattern = Pattern.compile(tokensDetailsRoutePath);

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthTokensRouteTest.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthTokensRouteTest.java
@@ -103,7 +103,7 @@ public class AuthTokensRouteTest extends BaseServletTest {
     @Test
     public void testAuthTokensRouteRegexMatchesOnlyTokens(){
         //Given...
-        String tokensRoutePath = new AuthTokensRoute(null, null, null, null, null).getPath();
+        String tokensRoutePath = new AuthTokensRoute(null, null, null, null, null).getPath().toString();
 
         //When...
         Pattern tokensRoutePattern = Pattern.compile(tokensRoutePath);

--- a/galasa-parent/dev.galasa.framework.api.common/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api.common/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 description = 'Framework API - Common Packages'
 
-version = '0.36.0'
+version = '0.37.0'
 
 dependencies {
     implementation project(':dev.galasa.framework')

--- a/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/BaseRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/BaseRoute.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public abstract class BaseRoute implements IRoute {
@@ -35,14 +36,14 @@ public abstract class BaseRoute implements IRoute {
 
 	private final ResponseBuilder responseBuilder ;
 
-    private final String path;
+    private final Pattern path;
 
     public BaseRoute(ResponseBuilder responseBuilder, String path) {
-        this.path = path;
+        this.path = Pattern.compile(path);
 		this.responseBuilder = responseBuilder;
     }
 
-    public String getPath() {
+    public Pattern getPath() {
         return path;
     }
 

--- a/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/BaseServlet.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/BaseServlet.java
@@ -31,12 +31,12 @@ public class BaseServlet extends HttpServlet {
 
     static final GalasaGson gson = new GalasaGson();
 
-    private final Map<String, IRoute> routes = new HashMap<>();
+    private final Map<Pattern, IRoute> routes = new HashMap<>();
 
     private ResponseBuilder responseBuilder = new ResponseBuilder();
 
     protected void addRoute(IRoute route) {
-        String path = route.getPath();
+        Pattern path = route.getPath();
         logger.info("Base servlet adding route " + path);
         routes.put(path, route);
     }
@@ -107,12 +107,12 @@ public class BaseServlet extends HttpServlet {
         QueryParameters queryParameters = new QueryParameters(req.getParameterMap());
 
         boolean pathMatched = false;
-        for (Map.Entry<String, IRoute> entry : routes.entrySet()) {
+        for (Map.Entry<Pattern, IRoute> entry : routes.entrySet()) {
 
-            String routePattern = entry.getKey();
+            Pattern routePattern = entry.getKey();
             IRoute route = entry.getValue();
 
-            Matcher matcher = Pattern.compile(routePattern).matcher(url);
+            Matcher matcher = routePattern.matcher(url);
 
             if (matcher.matches()) {
                 pathMatched = true;

--- a/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/IRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/IRoute.java
@@ -6,6 +6,7 @@
 package dev.galasa.framework.api.common;
 
 import java.io.IOException;
+import java.util.regex.Pattern;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -20,7 +21,7 @@ import dev.galasa.framework.spi.FrameworkException;
  * Route paths represent the regex patterns that are used to match request paths against.
  */
 public interface IRoute {
-    String getPath();
+    Pattern getPath();
 
     HttpServletResponse handleGetRequest(String pathInfo, QueryParameters queryParams, HttpServletRequest request, HttpServletResponse response)
         throws ServletException, IOException, FrameworkException;

--- a/galasa-parent/dev.galasa.framework.api.ras/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api.ras/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 description = 'Galasa API - RAS'
 
-version '0.36.0'
+version '0.37.0'
 
 dependencies {
     implementation project(':dev.galasa.framework')

--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunArtifactsDownloadRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunArtifactsDownloadRoute.java
@@ -21,7 +21,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -72,7 +71,7 @@ public class RunArtifactsDownloadRoute extends RunArtifactsRoute {
 
     @Override
     public HttpServletResponse handleGetRequest(String pathInfo, QueryParameters queryParams,HttpServletRequest req, HttpServletResponse response) throws ServletException, IOException, FrameworkException {
-        Matcher matcher = Pattern.compile(this.getPath()).matcher(pathInfo);
+        Matcher matcher = this.getPath().matcher(pathInfo);
         matcher.matches();
         String runId = matcher.group(1);
         String artifactPath = matcher.group(2);

--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunArtifactsListRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunArtifactsListRoute.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -64,7 +63,7 @@ public class RunArtifactsListRoute extends RunArtifactsRoute {
 
     @Override
     public HttpServletResponse handleGetRequest(String pathInfo, QueryParameters queryParams, HttpServletRequest req, HttpServletResponse res) throws ServletException, IOException, FrameworkException {
-        Matcher matcher = Pattern.compile(this.getPath()).matcher(pathInfo);
+        Matcher matcher = this.getPath().matcher(pathInfo);
         matcher.matches();
         String runId = matcher.group(1);
         return getResponseBuilder().buildResponse(req, res, "application/json", retrieveResults(runId), HttpServletResponse.SC_OK);

--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunDetailsRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunDetailsRoute.java
@@ -10,7 +10,6 @@ import static dev.galasa.framework.api.common.ServletErrorMessage.*;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import javax.servlet.ServletException;
 import javax.servlet.ServletInputStream;
@@ -105,7 +104,7 @@ public class RunDetailsRoute extends RunsRoute {
    }
 
    private String getRunIdFromPath(String pathInfo) throws InternalServletException {
-      Matcher matcher = Pattern.compile(this.getPath()).matcher(pathInfo);
+      Matcher matcher = this.getPath().matcher(pathInfo);
       matcher.matches();
       String runId = matcher.group(1);
       return runId;

--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunLogRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunLogRoute.java
@@ -9,7 +9,6 @@ import static dev.galasa.framework.api.common.ServletErrorMessage.*;
 
 import java.io.IOException;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -38,7 +37,7 @@ public class RunLogRoute extends RunsRoute {
 
     @Override
     public HttpServletResponse handleGetRequest(String pathInfo, QueryParameters queryParams, HttpServletRequest req, HttpServletResponse res) throws ServletException, IOException, FrameworkException {
-        Matcher matcher = Pattern.compile(this.getPath()).matcher(pathInfo);
+        Matcher matcher = this.getPath().matcher(pathInfo);
         matcher.matches();
         String runId = matcher.group(1);
         String runLog = getRunlog(runId);

--- a/release.yaml
+++ b/release.yaml
@@ -136,7 +136,7 @@ api:
     codecoverage: true
 
   - artifact: dev.galasa.framework.api.authentication
-    version: 0.36.0
+    version: 0.37.0
     obr:          true
     mvp:          false
     bom:          false
@@ -163,7 +163,7 @@ api:
     codecoverage: true
 
   - artifact: dev.galasa.framework.api.common
-    version: 0.36.0
+    version: 0.37.0
     obr:          true
     mvp:          false
     bom:          false
@@ -217,7 +217,7 @@ api:
     codecoverage: true
 
   - artifact: dev.galasa.framework.api.ras
-    version: 0.36.0
+    version: 0.37.0
     obr:          true
     mvp:          false
     bom:          false


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1962

## Changes
The REST API no longer compiles regex patterns for routes on every request, and instead compiles the regex patterns in the constructor of a route.

This PR is intended to be delivered after the 0.36.0 release is complete.