### PR TITLE
bump galasa boot version to prepare for jvm uplift

### DIFF
--- a/galasa-parent/galasa-boot/build.gradle
+++ b/galasa-parent/galasa-boot/build.gradle
@@ -15,7 +15,7 @@ configurations {
 
 }
 
-version = '0.36.0'
+version = '0.37.0'
 
 jar {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE

--- a/release.yaml
+++ b/release.yaml
@@ -105,7 +105,7 @@ framework:
     codecoverage: true
 
   - artifact: galasa-boot
-    version: 0.36.0
+    version: 0.37.0
     obr:          false
     mvp:          true
     bom:          false
@@ -259,4 +259,3 @@ api:
     bom:          false
     javadoc:      false
     isolated:     true
-    codecoverage: true

--- a/release.yaml
+++ b/release.yaml
@@ -259,3 +259,4 @@ api:
     bom:          false
     javadoc:      false
     isolated:     true
+    codecoverage: true


### PR DESCRIPTION
## Why?
bump galasa boot version to prepare for jvm uplift as changes are required to the launcher