### PR TITLE
Add a bundle manager to avoid a concrete class being used statically inside the test runners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ temp/
 # Ignore the OpenAPI spec that is automatically placed into the 
 # resources folder to be served up by the OpenAPI servlet
 **/dev.galasa.framework.api.openapi.servlet/**/openapi.yaml
+
+run-test.sh

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BundleManager.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BundleManager.java
@@ -1,0 +1,27 @@
+package dev.galasa.framework;
+
+import org.apache.felix.bundlerepository.RepositoryAdmin;
+import org.osgi.framework.BundleContext;
+
+import dev.galasa.framework.spi.FrameworkException;
+
+public class BundleManager implements IBundleManager {
+
+    @Override
+    public boolean isBundleActive(BundleContext bundleContext, String bundleSymbolicName) {
+        return BundleManagement.isBundleActive(bundleContext, bundleSymbolicName);
+    }
+
+    @Override
+    public void loadAllGherkinManagerBundles(RepositoryAdmin repositoryAdmin, BundleContext bundleContext)
+            throws FrameworkException {
+        BundleManagement.loadAllGherkinManagerBundles(repositoryAdmin, bundleContext);
+    }
+
+    @Override
+    public void loadBundle(RepositoryAdmin repositoryAdmin, BundleContext bundleContext, String bundleSymbolicName)
+            throws FrameworkException {
+        BundleManagement.loadBundle(repositoryAdmin, bundleContext, bundleSymbolicName);
+    }
+    
+}

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GherkinTestRunner.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GherkinTestRunner.java
@@ -60,6 +60,7 @@ public class GherkinTestRunner {
     private Log logger = LogFactory.getLog(GherkinTestRunner.class);
 
     private BundleContext bundleContext;
+    private IBundleManager bundleManager = new BundleManager();
 
     @Reference(cardinality = ReferenceCardinality.OPTIONAL)
     private RepositoryAdmin repositoryAdmin;
@@ -202,7 +203,7 @@ public class GherkinTestRunner {
         }
 
         try {
-            BundleManagement.loadAllGherkinManagerBundles(repositoryAdmin, bundleContext);
+            bundleManager.loadAllGherkinManagerBundles(repositoryAdmin, bundleContext);
         } catch (Exception e) {
             logger.error("Unable to load the managers obr", e);
             updateStatus(TestRunLifecycleStatus.FINISHED, "finished");

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/IBundleManager.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/IBundleManager.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework;
+
+import org.apache.felix.bundlerepository.RepositoryAdmin;
+import org.osgi.framework.BundleContext;
+
+import dev.galasa.framework.spi.FrameworkException;
+
+/**
+ * Allows for some control over loading extra bundles, and seeing if bundles are already loaded.
+ */
+public interface IBundleManager {
+    /**
+     * Is the supplied active in the OSGi framework
+     * @param bundleContext
+     * @param bundleSymbolicName
+     * @return true if it is ib the or false
+     */
+    public boolean isBundleActive(BundleContext bundleContext, String bundleSymbolicName);
+
+    public void loadAllGherkinManagerBundles(RepositoryAdmin repositoryAdmin, BundleContext bundleContext) throws FrameworkException;
+
+    public void loadBundle(RepositoryAdmin repositoryAdmin, BundleContext bundleContext, String bundleSymbolicName) throws FrameworkException;
+
+}

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
@@ -72,6 +72,7 @@ public class TestRunner {
     private Log                                logger        = LogFactory.getLog(TestRunner.class);
 
     private BundleContext                      bundleContext;
+    private IBundleManager bundleManager = new BundleManager();
 
     @Reference(cardinality = ReferenceCardinality.OPTIONAL)
     private RepositoryAdmin                    repositoryAdmin;
@@ -232,7 +233,7 @@ public class TestRunner {
         }
 
         try {
-            BundleManagement.loadBundle(repositoryAdmin, bundleContext, testBundleName);
+            bundleManager.loadBundle(repositoryAdmin, bundleContext, testBundleName);
         } catch (Exception e) {
             logger.error("Unable to load the test bundle " + testBundleName, e);
             updateStatus(TestRunLifecycleStatus.FINISHED, "finished");
@@ -347,9 +348,9 @@ public class TestRunner {
         updateStatus(TestRunLifecycleStatus.STARTED, "started");
 
         // *** Try to load the Core Manager bundle, even if the test doesn't use it, and if not already active
-        if (!BundleManagement.isBundleActive(bundleContext, "dev.galasa.core.manager")) {
+        if (!bundleManager.isBundleActive(bundleContext, "dev.galasa.core.manager")) {
             try {
-                BundleManagement.loadBundle(repositoryAdmin, bundleContext, "dev.galasa.core.manager");
+                bundleManager.loadBundle(repositoryAdmin, bundleContext, "dev.galasa.core.manager");
             } catch (FrameworkException e) {
                 logger.warn("Tried to load the Core Manager bundle, but failed, test can continue without it",e);
             }


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>
