### PR TITLE
updated launcher to include jvm17 start-up validation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup JDK 
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'semeru'
       
       - name: Print githash
@@ -58,7 +58,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
         with:
-          gradle-version: 6.9.2
+          gradle-version: 8.9
       
       - name: Build servlet beans with openapi2beans
         run: |
@@ -152,7 +152,7 @@ jobs:
       - name: Setup JDK 
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'semeru'
       
       - name: Install Swagger CLI

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup JDK 
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'semeru'
       
       - name: Print githash
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
         with:
-          gradle-version: 6.9.2
+          gradle-version: 8.9
       
       - name: Build servlet beans with openapi2beans
         run: |
@@ -71,7 +71,7 @@ jobs:
       - name: Setup JDK 
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'semeru'
       
       - name: Install Swagger CLI

--- a/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/Launcher.java
+++ b/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/Launcher.java
@@ -555,8 +555,8 @@ public class Launcher {
             throw new LauncherException("Unable to determine Java version - will exit");
         }
 
-        if(version.startsWith("17")){
-            logger.trace("Java version 17 validated");
+        if(version.startsWith("17") || version.startsWith("11")){
+            logger.trace("Java version " + version + " validated");
             return;
         }
 

--- a/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/Launcher.java
+++ b/galasa-parent/galasa-boot/src/main/java/dev/galasa/boot/Launcher.java
@@ -555,8 +555,8 @@ public class Launcher {
             throw new LauncherException("Unable to determine Java version - will exit");
         }
 
-        if(version.startsWith("11")){
-            logger.trace("Java version 11 validated");
+        if(version.startsWith("17")){
+            logger.trace("Java version 17 validated");
             return;
         }
 

--- a/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/TestLauncher.java
+++ b/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/TestLauncher.java
@@ -167,6 +167,20 @@ public class TestLauncher {
     }
 
     @Test
+    public void testJava17Passes() {
+        Launcher l  = new Launcher();
+        MockEnvironment me = new MockEnvironment();
+
+        me.setProperty("java.version","17");
+
+        try{
+            l.validateJavaLevel(me);
+        }catch(LauncherException le){
+            fail("LauncherException thrown");
+        }
+    }
+
+    @Test
     public void testJava16Fails() {
         Launcher l  = new Launcher();
         MockEnvironment me = new MockEnvironment();

--- a/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/TestLauncher.java
+++ b/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/TestLauncher.java
@@ -153,11 +153,11 @@ public class TestLauncher {
     }
 
     @Test
-    public void testJava11Passes() {
+    public void testJava17Passes() {
         Launcher l  = new Launcher();
         MockEnvironment me = new MockEnvironment();
 
-        me.setProperty("java.version","11");
+        me.setProperty("java.version","17");
 
         try{
             l.validateJavaLevel(me);

--- a/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/TestLauncher.java
+++ b/galasa-parent/galasa-boot/src/test/java/dev/galasa/boot/TestLauncher.java
@@ -167,20 +167,6 @@ public class TestLauncher {
     }
 
     @Test
-    public void testJava17Passes() {
-        Launcher l  = new Launcher();
-        MockEnvironment me = new MockEnvironment();
-
-        me.setProperty("java.version","17");
-
-        try{
-            l.validateJavaLevel(me);
-        }catch(LauncherException le){
-            fail("LauncherException thrown");
-        }
-    }
-
-    @Test
     public void testJava16Fails() {
         Launcher l  = new Launcher();
         MockEnvironment me = new MockEnvironment();


### PR DESCRIPTION
## Why?

This is to ensure that the framework can build on java 11 and java 17 JVMs
