### PR TITLE
Add cursor-based pagination to /ras/runs

### DIFF
--- a/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/QueryParameters.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/QueryParameters.java
@@ -103,21 +103,27 @@ public class QueryParameters {
 		return returnedValue;
 	}
 
-	/**
-	 * @param queryParameterName
-	 * @param defaultValue Returned if there are no occurrances of the query parameter.
-	 * @return the value of the given query parameter as a boolean
-	 * @throws InternalServletException when there are multiple values of this query parameter
-	 */
+    /**
+     * @param queryParameterName
+     * @param defaultValue Returned if there are no occurrances of the query parameter.
+     * @return the value of the given query parameter as a boolean
+     * @throws InternalServletException when there are multiple values of this query parameter
+     */
     public boolean getSingleBoolean(String queryParameterName, boolean defaultValue) throws InternalServletException {
-		boolean returnedValue = defaultValue;
-		String paramValueStr = getSingleString(queryParameterName, Boolean.toString(defaultValue));
+        boolean returnedValue = defaultValue;
+        String paramValueStr = getSingleString(queryParameterName, Boolean.toString(defaultValue));
 
-		if (paramValueStr != null) {
-            returnedValue = Boolean.parseBoolean(paramValueStr.trim());
-		}
-		return returnedValue;
-	}
+        if (paramValueStr != null) {
+            String trimmedParamValue = paramValueStr.trim();
+            if (!trimmedParamValue.equalsIgnoreCase("true") && !trimmedParamValue.equalsIgnoreCase("false")) {
+                ServletError error = new ServletError(GAL5090_INVALID_QUERY_PARAM_NOT_BOOLEAN, queryParameterName, paramValueStr);
+                throw new InternalServletException(error, HttpServletResponse.SC_BAD_REQUEST);
+            } else {
+                returnedValue = Boolean.parseBoolean(paramValueStr.trim());
+            }
+        }
+        return returnedValue;
+    }
 
 	/**
 	 * @param queryParameterName

--- a/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/QueryParameters.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/QueryParameters.java
@@ -104,7 +104,7 @@ public class QueryParameters {
 	}
 
     /**
-     * @param queryParameterName
+     * @param queryParameterName the query parameter to retrieve the value of
      * @param defaultValue Returned if there are no occurrances of the query parameter.
      * @return the value of the given query parameter as a boolean
      * @throws InternalServletException when there are multiple values of this query parameter
@@ -119,7 +119,7 @@ public class QueryParameters {
                 ServletError error = new ServletError(GAL5090_INVALID_QUERY_PARAM_NOT_BOOLEAN, queryParameterName, paramValueStr);
                 throw new InternalServletException(error, HttpServletResponse.SC_BAD_REQUEST);
             } else {
-                returnedValue = Boolean.parseBoolean(paramValueStr.trim());
+                returnedValue = Boolean.parseBoolean(trimmedParamValue);
             }
         }
         return returnedValue;

--- a/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/QueryParameters.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/QueryParameters.java
@@ -106,6 +106,22 @@ public class QueryParameters {
 	/**
 	 * @param queryParameterName
 	 * @param defaultValue Returned if there are no occurrances of the query parameter.
+	 * @return the value of the given query parameter as a boolean
+	 * @throws InternalServletException when there are multiple values of this query parameter
+	 */
+    public boolean getSingleBoolean(String queryParameterName, boolean defaultValue) throws InternalServletException {
+		boolean returnedValue = defaultValue;
+		String paramValueStr = getSingleString(queryParameterName, Boolean.toString(defaultValue));
+
+		if (paramValueStr != null) {
+            returnedValue = Boolean.parseBoolean(paramValueStr.trim());
+		}
+		return returnedValue;
+	}
+
+	/**
+	 * @param queryParameterName
+	 * @param defaultValue Returned if there are no occurrances of the query parameter.
 	 * @return
 	 * @throws InternalServletException when there are multiple values of this query parameter, or
 	 * when the value of the query parameter is not a valid date-time.

--- a/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
@@ -14,6 +14,7 @@ public enum ServletErrorMessage {
     GAL5004_ERROR_RETRIEVING_PAGE                     (5004,"E: Error retrieving page. Report the problem to your Galasa Ecosystem owner."),
     GAL5005_INVALID_QUERY_PARAM_NOT_INTEGER           (5005,"E: Error parsing the query parameter ''{0}'' in the request URL. Invalid value ''{1}''. Expecting an integer."),
     GAL5006_INVALID_QUERY_PARAM_DUPLICATES            (5006,"E: Error parsing the query parameters. Duplicate instances of query parameter ''{0}'' found in the request URL. Expecting only one."),
+    GAL5090_INVALID_QUERY_PARAM_NOT_BOOLEAN           (5090,"E: Error parsing the query parameter ''{0}'' in the request URL. Invalid value ''{1}''. Expecting a boolean."),
 
     GAL5010_FROM_DATE_IS_REQUIRED                     (5010,"E: Error parsing the query parameters. 'from' time is a mandatory field if no 'runname' is supplied."),
     GAL5011_SORT_VALUE_NOT_RECOGNIZED                 (5011,"E: Error parsing the query parameters. 'sort' value ''{0}'' not recognised. Expected query parameter in the format 'sort={fieldName}:{order}' where order is 'asc' for ascending or 'desc' for descending."),

--- a/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -1096,10 +1096,6 @@ paths:
 
             Use '{FIELD-NAME}:asc' to sort in ascending order.
             Use '{FIELD-NAME}:desc' to sort in descending order.
-
-            You can use multiple instances of this query parameter, or specify
-            multiple sort orders using one query parameter, and a comma-separated
-            list of sort orders.
           required: true
           schema:
             type: string
@@ -1200,6 +1196,26 @@ paths:
           schema:
             type: string
           example: U1578
+        
+        # Temporary feature flag to enable cursor-based pagination
+        - name: includeCursor
+          in: query
+          description: |
+            A boolean flag to enable cursor-based pagination and return the next page cursor
+            in the response. If omitted, it will default to false.
+          schema:
+            type: string
+          example: 'true'
+        - name: cursor
+          in: query
+          description: |
+            The cursor representing the page of runs to be retrieved. This is a unique value that is specific
+            to a query and is included in responses, allowing you to navigate through pages of runs.
+            If omitted, the first page of runs for the given query will be returned and the response
+            will display the cursor for the next page of runs.
+          schema:
+            type: string
+          example: g2wAAAACaAJkAA5zdGFydG
       responses:
         '200':
           description: Array of Run Objects
@@ -2036,6 +2052,8 @@ components:
           type: integer
         amountOfRuns:
           type: integer
+        nextCursor:
+          type: string
         runs:
           type: array
           items:

--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/common/RasQueryParameters.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/common/RasQueryParameters.java
@@ -98,47 +98,36 @@ public class RasQueryParameters {
         return generalQueryParams.getSingleString("runname", null);
     }
 
-    public String getPageToken() throws InternalServletException {
-        return generalQueryParams.getSingleString("pageToken", null);
+    public String getPageCursor() throws InternalServletException {
+        return generalQueryParams.getSingleString("cursor", null);
     }
 
-    public boolean getIncludePageToken() throws InternalServletException {
-        return generalQueryParams.getSingleBoolean("includePageToken", false);
+    public boolean getIncludeCursor() throws InternalServletException {
+        return generalQueryParams.getSingleBoolean("includeCursor", false);
     }
 
-    public List<RasSortField> getSortValues() throws InternalServletException {
-        return getSortValues(null);
+    public RasSortField getSortValue() throws InternalServletException {
+        return getSortValue(null);
     }
 
-    public List<RasSortField> getSortValues(List<String> defaultSortValues) throws InternalServletException {
-        List<String> sortValues = generalQueryParams.getMultipleString("sort", defaultSortValues);
-        List<RasSortField> rasSortValues = null;
-        if (sortValues != null) {
-            rasSortValues = new ArrayList<>();
-            validateSortValues(sortValues);
-    
-            for (String sortValuePair : sortValues) {
-                String[] sortValueParts = sortValuePair.split(":");
-    
-                rasSortValues.add(new RasSortField(sortValueParts[0].toLowerCase(), sortValueParts[1].toLowerCase()));
-            }
+    public RasSortField getSortValue(String defaultSortValue) throws InternalServletException {
+        String sortValue = generalQueryParams.getSingleString("sort", defaultSortValue);
+        RasSortField rasSortValue = null;
+        if (sortValue != null) {
+            validateSortValue(sortValue);
+
+            String[] sortValueParts = sortValue.split(":");
+            rasSortValue = new RasSortField(sortValueParts[0].toLowerCase(), sortValueParts[1].toLowerCase());
         }
-        return rasSortValues;
+        return rasSortValue;
     }
 
     public RasSortField getSortValueByName(String sortFieldName) throws InternalServletException {
-        List<RasSortField> sortValues = getSortValues();
-        RasSortField fieldToReturn = null;
-
-        if (sortValues != null) {
-            for (RasSortField sortField : sortValues) {
-                if (sortField.getFieldName().equals(sortFieldName)) {
-                    fieldToReturn = sortField;
-                    break;
-                }
-            }
+        RasSortField sortValue = getSortValue();
+        if (sortValue != null && !sortValue.getFieldName().equals(sortFieldName)) {
+            sortValue = null;
         }
-        return fieldToReturn;
+        return sortValue;
     }
 
     public List<String> getRunIds() {
@@ -196,19 +185,13 @@ public class RasQueryParameters {
         return sortDirectionMap.get(sortField.getSortDirection());
 	}
 
-    private boolean isSortValueValid(String sortValue) {
+    private void validateSortValue(String sortValue) throws InternalServletException {
         String[] sortValueParts = sortValue.split(":");
 
-        return (sortValueParts.length == 2) && (sortDirectionMap.containsKey(sortValueParts[1].toLowerCase()));
-    }
-
-    public void validateSortValues(List<String> sortValues) throws InternalServletException {
-        for (String sortValuePair : sortValues) {
-            if (!isSortValueValid(sortValuePair)) {
-                ServletError error = new ServletError(GAL5011_SORT_VALUE_NOT_RECOGNIZED, sortValuePair);
-                throw new InternalServletException(error, HttpServletResponse.SC_BAD_REQUEST);
-            }
+        if (sortValueParts.length != 2 || !sortDirectionMap.containsKey(sortValueParts[1].toLowerCase())) {
+            ServletError error = new ServletError(GAL5011_SORT_VALUE_NOT_RECOGNIZED, sortValue);
+            throw new InternalServletException(error, HttpServletResponse.SC_BAD_REQUEST);
         }
-	}
+    }
 
 }

--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/common/RasQueryParameters.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/common/RasQueryParameters.java
@@ -98,6 +98,14 @@ public class RasQueryParameters {
         return generalQueryParams.getSingleString("runname", null);
     }
 
+    public String getPageToken() throws InternalServletException {
+        return generalQueryParams.getSingleString("pageToken", null);
+    }
+
+    public boolean getIncludePageToken() throws InternalServletException {
+        return generalQueryParams.getSingleBoolean("includePageToken", false);
+    }
+
     public List<RasSortField> getSortValues() throws InternalServletException {
         return getSortValues(null);
     }

--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/common/RasQueryParameters.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/common/RasQueryParameters.java
@@ -114,10 +114,7 @@ public class RasQueryParameters {
         String sortValue = generalQueryParams.getSingleString("sort", defaultSortValue);
         RasSortField rasSortValue = null;
         if (sortValue != null) {
-            validateSortValue(sortValue);
-
-            String[] sortValueParts = sortValue.split(":");
-            rasSortValue = new RasSortField(sortValueParts[0].toLowerCase(), sortValueParts[1].toLowerCase());
+            rasSortValue = getValidatedSortValue(sortValue);
         }
         return rasSortValue;
     }
@@ -185,13 +182,14 @@ public class RasQueryParameters {
         return sortDirectionMap.get(sortField.getSortDirection());
 	}
 
-    private void validateSortValue(String sortValue) throws InternalServletException {
+    private RasSortField getValidatedSortValue(String sortValue) throws InternalServletException {
         String[] sortValueParts = sortValue.split(":");
 
         if (sortValueParts.length != 2 || !sortDirectionMap.containsKey(sortValueParts[1].toLowerCase())) {
             ServletError error = new ServletError(GAL5011_SORT_VALUE_NOT_RECOGNIZED, sortValue);
             throw new InternalServletException(error, HttpServletResponse.SC_BAD_REQUEST);
         }
+        return new RasSortField(sortValueParts[0].toLowerCase(), sortValueParts[1].toLowerCase());
     }
 
 }

--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/ResultNamesRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/ResultNamesRoute.java
@@ -53,7 +53,7 @@ public class ResultNamesRoute extends RunsRoute {
         List<String> resultsList = getResultNames();
 
 		try {
-            if (queryParams.getSortValue() != null ) {
+            if (queryParams.getSortValue() !=null ){
 			    if (!queryParams.isAscending("resultnames")) {
 				    Collections.reverse(resultsList);
                 }

--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/ResultNamesRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/ResultNamesRoute.java
@@ -53,7 +53,7 @@ public class ResultNamesRoute extends RunsRoute {
         List<String> resultsList = getResultNames();
 
 		try {
-            if (queryParams.getSortValues() != null ) {
+            if (queryParams.getSortValue() != null ) {
 			    if (!queryParams.isAscending("resultnames")) {
 				    Collections.reverse(resultsList);
                 }

--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/ResultNamesRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/ResultNamesRoute.java
@@ -53,7 +53,7 @@ public class ResultNamesRoute extends RunsRoute {
         List<String> resultsList = getResultNames();
 
 		try {
-            if (queryParams.getSortValue() !=null ){
+            if (queryParams.getSortValues() != null ) {
 			    if (!queryParams.isAscending("resultnames")) {
 				    Collections.reverse(resultsList);
                 }

--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunQueryRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunQueryRoute.java
@@ -85,7 +85,6 @@ public class RunQueryRoute extends RunsRoute {
 		/* Get list of Run Ids from the URL -
 		If a Run ID parameter list is present in the URL then only return that run / those runs
 		Do not filter as well */
-
 		List<String> runIds = queryParams.getRunIds();
 
         // Default to sorting in descending order based on the "end time" of runs
@@ -122,8 +121,10 @@ public class RunQueryRoute extends RunsRoute {
 	}
 
     private RasSortField formatSortField(RasSortField sortValue) {
-        RasSortField sortField = sortValue;
+        RasSortField sortField = null;
         if (sortValue != null) {
+            sortField = new RasSortField(sortValue.getFieldName(), sortValue.getSortDirection());
+
             // The "to" sort parameter corresponds to a run's "endTime" field
             if (sortValue.getFieldName().equals("to")) {
                 sortField.setFieldName("endTime");

--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/TestClassesRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/TestClassesRoute.java
@@ -20,14 +20,11 @@ import dev.galasa.framework.api.ras.internal.common.RasQueryParameters;
 import dev.galasa.framework.api.common.InternalServletException;
 import dev.galasa.framework.api.common.QueryParameters;
 import dev.galasa.framework.api.common.ResponseBuilder;
-import dev.galasa.framework.api.common.ServletError;
 import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.IFramework;
 import dev.galasa.framework.spi.ResultArchiveStoreException;
 import dev.galasa.framework.spi.ras.RasTestClass;
 import dev.galasa.framework.spi.utils.GalasaGson;
-
-import static dev.galasa.framework.api.common.ServletErrorMessage.*;
 
 public class TestClassesRoute extends RunsRoute {
 
@@ -56,16 +53,13 @@ public class TestClassesRoute extends RunsRoute {
 
         List<RasTestClass> classArray = getTestClasses();
 
-		classArray.sort(Comparator.comparing(RasTestClass::getTestClass));
+        Comparator<RasTestClass> testClassComparator = Comparator.comparing(RasTestClass::getTestClass);
 
-        try {
-			if(!sortQueryParameterChecker.isAscending("testclass")) {
-				classArray.sort(Comparator.comparing(RasTestClass::getTestClass).reversed());
-			}
-		} catch (InternalServletException e) {
-			ServletError error = new ServletError(GAL5011_SORT_VALUE_NOT_RECOGNIZED, "testclass");
-			throw new InternalServletException(error, HttpServletResponse.SC_BAD_REQUEST, e);
-		}
+        if (!sortQueryParameterChecker.isAscending("testclass")) {
+            testClassComparator = testClassComparator.reversed();
+        }
+
+        classArray.sort(testClassComparator);
 
         /* converting data to json */
 		JsonElement json = gson.toJsonTree(classArray);

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/common/TestRasQueryParameters.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/common/TestRasQueryParameters.java
@@ -361,18 +361,17 @@ public class TestRasQueryParameters extends RasServletTest{
     }
 
     @Test
-    public void testSortFieldNoValueThrowsError() throws Exception {
+    public void testSortFieldNoValueReturnsDefaultNull() throws Exception {
         // Given...
         Map<String,String[]> map = new HashMap<String,String[]>();
         map.put("sort", new String[] {""} );
         RasQueryParameters params = new RasQueryParameters(new QueryParameters(map));
 
         // When...
-        InternalServletException thrown = catchThrowableOfType(() -> params.getSortValues(), InternalServletException.class);
+        RasSortField sortField = params.getSortValue();
 
         // Then...
-        assertThat(thrown).isNotNull();
-        assertThat(thrown.getMessage()).contains("GAL5011E: Error parsing the query parameters", "sort value '' not recognised");
+        assertThat(sortField).isNull();
     }
 
     @Test
@@ -390,26 +389,5 @@ public class TestRasQueryParameters extends RasServletTest{
 
         // Then...
         assertThat(returnedParameters).isEqualTo(queryParams);
-    }
-
-    @Test
-    public void testGetCommaSeparatedSortValuesReturnsValuesOk() throws Exception {
-        // Given...
-        Map<String,String[]> map = new HashMap<String,String[]>();
-        map.put("sort", new String[] { "to:asc,runname:desc,result:asc" });
-        RasQueryParameters params = new RasQueryParameters(new QueryParameters(map));
-
-        // When...
-        List<RasSortField> sortValues = params.getSortValues();
-
-        // Then...
-        List<RasSortField> expectedSortValues = List.of(
-            new RasSortField("to", "asc"),
-            new RasSortField("runname", "desc"),
-            new RasSortField("result", "asc")
-        );
-
-        assertThat(sortValues).hasSize(3);
-        assertThat(sortValues).usingRecursiveComparison().isEqualTo(expectedSortValues);
     }
 }

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/common/TestRasQueryParameters.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/common/TestRasQueryParameters.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 
 import dev.galasa.framework.TestRunLifecycleStatus;
 import dev.galasa.framework.api.ras.internal.RasServletTest;
+import dev.galasa.framework.spi.ras.RasSortField;
 import dev.galasa.framework.api.common.InternalServletException;
 import dev.galasa.framework.api.common.QueryParameters;
 
@@ -301,88 +302,82 @@ public class TestRasQueryParameters extends RasServletTest{
     //-----------------------------------------------------------------
     @Test
     public void testSortFieldAscendingReturnsTrue() throws Exception {
+        // Given...
         Map<String,String[]> map = new HashMap<String,String[]>();
         map.put("sort", new String[] {"runname:asc"} );
         RasQueryParameters params = new RasQueryParameters(new QueryParameters(map));
 
+        // When...
         boolean isAscending = params.isAscending("runname");
 
+        // Then...
         assertThat(isAscending).isTrue();
     }
 
     @Test
     public void testSortFieldNoAscOrDescValueThrowsInvalidValueError() throws Exception {
+        // Given...
         Map<String,String[]> map = new HashMap<String,String[]>();
         map.put("sort", new String[] {"runname:"} );
         RasQueryParameters params = new RasQueryParameters(new QueryParameters(map));
 
-
+        // When...
         Throwable thrown = catchThrowable( () -> {
             params.isAscending("runname");
         });
 
+        // Then...
         assertThat(thrown.getMessage()).contains("GAL5011","runname","sort");
     }
 
     @Test
     public void testSortFieldManySortValuePartsThrowsInvalidValueError() throws Exception {
+        // Given...
         Map<String,String[]> map = new HashMap<String,String[]>();
         map.put("sort", new String[] {"runname:asc:desc:asc"} );
         RasQueryParameters params = new RasQueryParameters(new QueryParameters(map));
 
+        // When...
         Throwable thrown = catchThrowable( () -> {
             params.isAscending("runname");
         });
 
+        // Then...
         assertThat(thrown).isNotNull();
         assertThat(thrown.getMessage()).contains("GAL5011","runname:asc:desc:asc","sort");
     }
 
     @Test
     public void testSortFieldNoQueryDefaultFalse() throws Exception {
+        // Given...
         Map<String,String[]> map = new HashMap<String,String[]>();
         RasQueryParameters params = new RasQueryParameters(new QueryParameters(map));
 
+        // When...
         boolean isAscending = params.isAscending("runname");
 
+        // Then...
         assertThat(isAscending).isFalse();
     }
 
     @Test
-    public void testSortFieldNoValueReturnsDefaultFalse() throws Exception {
+    public void testSortFieldNoValueThrowsError() throws Exception {
+        // Given...
         Map<String,String[]> map = new HashMap<String,String[]>();
         map.put("sort", new String[] {""} );
         RasQueryParameters params = new RasQueryParameters(new QueryParameters(map));
 
-        boolean isAscending = params.isAscending("runname");
+        // When...
+        InternalServletException thrown = catchThrowableOfType(() -> params.getSortValues(), InternalServletException.class);
 
-        assertThat(isAscending).isFalse();
+        // Then...
+        assertThat(thrown).isNotNull();
+        assertThat(thrown.getMessage()).contains("GAL5011E: Error parsing the query parameters", "sort value '' not recognised");
     }
 
     @Test
-    public void testSortFieldNoValueReturnsDefaultFalseValidate() throws Exception {
-        Map<String,String[]> map = new HashMap<String,String[]>();
-        map.put("sort", new String[] {""} );
-        RasQueryParameters params = new RasQueryParameters(new QueryParameters(map));
-
-        boolean validateSortValue = params.validateSortValue();
-
-        assertThat(validateSortValue).isFalse();
-    }
-
-    @Test
-    public void testSortFieldValueReturnsTrueValidate() throws Exception {
-        Map<String,String[]> map = new HashMap<String,String[]>();
-        map.put("sort", new String[] {"to:asc"} );
-        RasQueryParameters params = new RasQueryParameters(new QueryParameters(map));
-
-        boolean validateSortValue = params.validateSortValue();
-
-        assertThat(validateSortValue).isTrue();
-    }
-
-    @Test
-    public void testgetGeneralQueryParameters() throws Exception {
+    public void testGetGeneralQueryParameters() throws Exception {
+        // Given...
         Map<String,String[]> map = new HashMap<String,String[]>();
         map.put("sort", new String[] {"to:asc"} );
         map.put("runname", new String[] {"C1234"} );
@@ -390,8 +385,31 @@ public class TestRasQueryParameters extends RasServletTest{
         QueryParameters queryParams = new QueryParameters(map);
         RasQueryParameters params = new RasQueryParameters(queryParams);
 
+        // When...
         QueryParameters returnedParameters = params.getGeneralQueryParameters();
 
+        // Then...
         assertThat(returnedParameters).isEqualTo(queryParams);
+    }
+
+    @Test
+    public void testGetCommaSeparatedSortValuesReturnsValuesOk() throws Exception {
+        // Given...
+        Map<String,String[]> map = new HashMap<String,String[]>();
+        map.put("sort", new String[] { "to:asc,runname:desc,result:asc" });
+        RasQueryParameters params = new RasQueryParameters(new QueryParameters(map));
+
+        // When...
+        List<RasSortField> sortValues = params.getSortValues();
+
+        // Then...
+        List<RasSortField> expectedSortValues = List.of(
+            new RasSortField("to", "asc"),
+            new RasSortField("runname", "desc"),
+            new RasSortField("result", "asc")
+        );
+
+        assertThat(sortValues).hasSize(3);
+        assertThat(sortValues).usingRecursiveComparison().isEqualTo(expectedSortValues);
     }
 }

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/mocks/MockResultArchiveStoreDirectoryService.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/mocks/MockResultArchiveStoreDirectoryService.java
@@ -54,6 +54,11 @@ public class MockResultArchiveStoreDirectoryService implements IResultArchiveSto
 	}
 
 	@Override
+	public @NotNull List<IRunResult> getRuns(int maxResults, @NotNull IRasSearchCriteria... searchCriterias) throws ResultArchiveStoreException {
+        return getRuns(searchCriterias);
+	}
+
+	@Override
 	public @NotNull List<String> getRequestors() throws ResultArchiveStoreException {
 		List<String> requestors = new ArrayList<>();
 		for (IRunResult run : this.getRunsResults){

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/mocks/MockResultArchiveStoreDirectoryService.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/mocks/MockResultArchiveStoreDirectoryService.java
@@ -20,7 +20,7 @@ import dev.galasa.framework.spi.teststructure.TestStructure;
 public class MockResultArchiveStoreDirectoryService implements IResultArchiveStoreDirectoryService {
 
     private List<IRunResult> getRunsResults ;
-    private String nextPageToken;
+    private String nextCursor;
 
     public MockResultArchiveStoreDirectoryService(List<IRunResult> getRunsResults) {
         this.getRunsResults = getRunsResults ;
@@ -47,8 +47,8 @@ public class MockResultArchiveStoreDirectoryService implements IResultArchiveSto
 	}
 
 	@Override
-	public @NotNull RasRunResultPage getRunsPage(int maxResults, List<RasSortField> sortFields, String pageToken, @NotNull IRasSearchCriteria... searchCriterias) throws ResultArchiveStoreException {
-        return new RasRunResultPage(getRuns(searchCriterias), nextPageToken);
+	public @NotNull RasRunResultPage getRunsPage(int maxResults, RasSortField primarySort, String pageCursor, @NotNull IRasSearchCriteria... searchCriterias) throws ResultArchiveStoreException {
+        return new RasRunResultPage(getRuns(searchCriterias), nextCursor);
 	}
 
 	@Override
@@ -107,8 +107,8 @@ public class MockResultArchiveStoreDirectoryService implements IResultArchiveSto
 		throw new ResultArchiveStoreException("Run id not found in mock getRunById().");
 	}
 
-    public void setNextPageToken(String nextPageToken) {
-        this.nextPageToken = nextPageToken;
+    public void setNextCursor(String nextCursor) {
+        this.nextCursor = nextCursor;
     }
 
 	@Override

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/mocks/MockResultArchiveStoreDirectoryService.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/mocks/MockResultArchiveStoreDirectoryService.java
@@ -12,26 +12,19 @@ import dev.galasa.framework.spi.IResultArchiveStoreDirectoryService;
 import dev.galasa.framework.spi.IRunResult;
 import dev.galasa.framework.spi.ResultArchiveStoreException;
 import dev.galasa.framework.spi.ras.IRasSearchCriteria;
+import dev.galasa.framework.spi.ras.RasRunResultPage;
+import dev.galasa.framework.spi.ras.RasSortField;
 import dev.galasa.framework.spi.ras.RasTestClass;
 import dev.galasa.framework.spi.teststructure.TestStructure;
 
 public class MockResultArchiveStoreDirectoryService implements IResultArchiveStoreDirectoryService {
 
     private List<IRunResult> getRunsResults ;
+    private String nextPageToken;
 
     public MockResultArchiveStoreDirectoryService(List<IRunResult> getRunsResults) {
         this.getRunsResults = getRunsResults ;
     }
-
-	@Override
-	public @NotNull String getName() {
-		throw new UnsupportedOperationException("Unimplemented method 'getName'");
-	}
-
-	@Override
-	public boolean isLocal() {
-		throw new UnsupportedOperationException("Unimplemented method 'isLocal'");
-	}
 
 	private void applySearchCriteria( IRasSearchCriteria searchCriteria) throws ResultArchiveStoreException{
 		List<IRunResult> returnRuns = new ArrayList<IRunResult>() ;
@@ -54,8 +47,8 @@ public class MockResultArchiveStoreDirectoryService implements IResultArchiveSto
 	}
 
 	@Override
-	public @NotNull List<IRunResult> getRuns(int maxResults, @NotNull IRasSearchCriteria... searchCriterias) throws ResultArchiveStoreException {
-        return getRuns(searchCriterias);
+	public @NotNull RasRunResultPage getRunsPage(int maxResults, List<RasSortField> sortFields, String pageToken, @NotNull IRasSearchCriteria... searchCriterias) throws ResultArchiveStoreException {
+        return new RasRunResultPage(getRuns(searchCriterias), nextPageToken);
 	}
 
 	@Override
@@ -113,5 +106,18 @@ public class MockResultArchiveStoreDirectoryService implements IResultArchiveSto
 		}
 		throw new ResultArchiveStoreException("Run id not found in mock getRunById().");
 	}
-    
+
+    public void setNextPageToken(String nextPageToken) {
+        this.nextPageToken = nextPageToken;
+    }
+
+	@Override
+	public @NotNull String getName() {
+		throw new UnsupportedOperationException("Unimplemented method 'getName'");
+	}
+
+	@Override
+	public boolean isLocal() {
+		throw new UnsupportedOperationException("Unimplemented method 'isLocal'");
+	}
 }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/ras/directory/DirectoryRASDirectoryService.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/ras/directory/DirectoryRASDirectoryService.java
@@ -71,7 +71,7 @@ public class DirectoryRASDirectoryService implements IResultArchiveStoreDirector
     }
 
     @Override
-    public @NotNull RasRunResultPage getRunsPage(int maxResults, List<RasSortField> sortFields, String pageToken, @NotNull IRasSearchCriteria... searchCriteria)
+    public @NotNull RasRunResultPage getRunsPage(int maxResults, RasSortField primarySort, String pageToken, @NotNull IRasSearchCriteria... searchCriteria)
             throws ResultArchiveStoreException {
         return new RasRunResultPage(getRuns(searchCriteria), null);
     }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/ras/directory/DirectoryRASDirectoryService.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/ras/directory/DirectoryRASDirectoryService.java
@@ -69,6 +69,12 @@ public class DirectoryRASDirectoryService implements IResultArchiveStoreDirector
     }
 
     @Override
+    public @NotNull List<IRunResult> getRuns(int maxResults, @NotNull IRasSearchCriteria... searchCriteria)
+            throws ResultArchiveStoreException {
+        return getRuns(searchCriteria);
+    }
+
+    @Override
     public @NotNull String getName() {
         return "Local " + this.baseDirectory.toString();
     }
@@ -219,6 +225,4 @@ public class DirectoryRASDirectoryService implements IResultArchiveStoreDirector
             return null; // Ignore errors as this run id may not belong to this RAS  
         }
     }
-
-
 }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/ras/directory/DirectoryRASDirectoryService.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/ras/directory/DirectoryRASDirectoryService.java
@@ -27,6 +27,8 @@ import dev.galasa.framework.spi.IResultArchiveStoreDirectoryService;
 import dev.galasa.framework.spi.IRunResult;
 import dev.galasa.framework.spi.ResultArchiveStoreException;
 import dev.galasa.framework.spi.ras.IRasSearchCriteria;
+import dev.galasa.framework.spi.ras.RasRunResultPage;
+import dev.galasa.framework.spi.ras.RasSortField;
 import dev.galasa.framework.spi.ras.RasTestClass;
 import dev.galasa.framework.spi.teststructure.TestStructure;
 import dev.galasa.framework.spi.utils.GalasaGson;
@@ -69,9 +71,9 @@ public class DirectoryRASDirectoryService implements IResultArchiveStoreDirector
     }
 
     @Override
-    public @NotNull List<IRunResult> getRuns(int maxResults, @NotNull IRasSearchCriteria... searchCriteria)
+    public @NotNull RasRunResultPage getRunsPage(int maxResults, List<RasSortField> sortFields, String pageToken, @NotNull IRasSearchCriteria... searchCriteria)
             throws ResultArchiveStoreException {
-        return getRuns(searchCriteria);
+        return new RasRunResultPage(getRuns(searchCriteria), null);
     }
 
     @Override

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IResultArchiveStoreDirectoryService.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IResultArchiveStoreDirectoryService.java
@@ -10,6 +10,8 @@ import java.util.List;
 import javax.validation.constraints.NotNull;
 
 import dev.galasa.framework.spi.ras.IRasSearchCriteria;
+import dev.galasa.framework.spi.ras.RasRunResultPage;
+import dev.galasa.framework.spi.ras.RasSortField;
 import dev.galasa.framework.spi.ras.RasTestClass;
 
 /**
@@ -28,7 +30,7 @@ public interface IResultArchiveStoreDirectoryService {
     List<IRunResult> getRuns(@NotNull IRasSearchCriteria... searchCriteria) throws ResultArchiveStoreException;
     
     @NotNull
-    List<IRunResult> getRuns(int maxResults, @NotNull IRasSearchCriteria... searchCriteria) throws ResultArchiveStoreException;
+    RasRunResultPage getRunsPage(int maxResults, List<RasSortField> sortFields, String pageToken, @NotNull IRasSearchCriteria... searchCriteria) throws ResultArchiveStoreException;
 
     /**
      * Get requestors

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IResultArchiveStoreDirectoryService.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IResultArchiveStoreDirectoryService.java
@@ -30,7 +30,7 @@ public interface IResultArchiveStoreDirectoryService {
     List<IRunResult> getRuns(@NotNull IRasSearchCriteria... searchCriteria) throws ResultArchiveStoreException;
     
     @NotNull
-    RasRunResultPage getRunsPage(int maxResults, List<RasSortField> sortFields, String pageToken, @NotNull IRasSearchCriteria... searchCriteria) throws ResultArchiveStoreException;
+    RasRunResultPage getRunsPage(int maxResults, RasSortField primarySort, String pageCursor, @NotNull IRasSearchCriteria... searchCriteria) throws ResultArchiveStoreException;
 
     /**
      * Get requestors

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IResultArchiveStoreDirectoryService.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IResultArchiveStoreDirectoryService.java
@@ -26,6 +26,9 @@ public interface IResultArchiveStoreDirectoryService {
     
     @NotNull
     List<IRunResult> getRuns(@NotNull IRasSearchCriteria... searchCriteria) throws ResultArchiveStoreException;
+    
+    @NotNull
+    List<IRunResult> getRuns(int maxResults, @NotNull IRasSearchCriteria... searchCriteria) throws ResultArchiveStoreException;
 
     /**
      * Get requestors

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasRunResultPage.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasRunResultPage.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.spi.ras;
+
+import java.util.List;
+
+import dev.galasa.framework.spi.IRunResult;
+
+/**
+ * An internal bean class representing a page of runs stored in the RAS,
+ * which includes a token pointing to the next page of runs for 
+ * cursor-based pagination
+ */
+public class RasRunResultPage {
+    
+    private List<IRunResult> runs;
+    private String nextPageToken;
+
+    public RasRunResultPage(List<IRunResult> runs, String nextPageToken) {
+        this.runs = runs;
+        this.nextPageToken = nextPageToken;
+    }
+
+    public List<IRunResult> getRuns() {
+        return runs;
+    }
+
+    public void setRuns(List<IRunResult> runs) {
+        this.runs = runs;
+    }
+
+    public String getNextPageToken() {
+        return nextPageToken;
+    }
+
+    public void setNextPageToken(String nextPageToken) {
+        this.nextPageToken = nextPageToken;
+    }
+}

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasRunResultPage.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasRunResultPage.java
@@ -17,11 +17,11 @@ import dev.galasa.framework.spi.IRunResult;
 public class RasRunResultPage {
     
     private List<IRunResult> runs;
-    private String nextPageToken;
+    private String nextCursor;
 
-    public RasRunResultPage(List<IRunResult> runs, String nextPageToken) {
+    public RasRunResultPage(List<IRunResult> runs, String nextCursor) {
         this.runs = runs;
-        this.nextPageToken = nextPageToken;
+        this.nextCursor = nextCursor;
     }
 
     public List<IRunResult> getRuns() {
@@ -32,11 +32,11 @@ public class RasRunResultPage {
         this.runs = runs;
     }
 
-    public String getNextPageToken() {
-        return nextPageToken;
+    public String getNextCursor() {
+        return nextCursor;
     }
 
-    public void setNextPageToken(String nextPageToken) {
-        this.nextPageToken = nextPageToken;
+    public void setNextCursor(String nextCursor) {
+        this.nextCursor = nextCursor;
     }
 }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSortField.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/ras/RasSortField.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.spi.ras;
+
+public class RasSortField {
+
+    private String fieldName;
+    private String sortDirection;
+
+    public RasSortField(String fieldName, String sortOrder) {
+        this.fieldName = fieldName;
+        this.sortDirection = sortOrder;
+    }
+
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    public void setFieldName(String fieldName) {
+        this.fieldName = fieldName;
+    }
+
+    public String getSortDirection() {
+        return sortDirection;
+    }
+
+    public void setSortDirection(String sortOrder) {
+        this.sortDirection = sortOrder;
+    }
+}


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1921

## Changes
- Added `includeCursor` query parameter to act as a feature flag enabling cursor-based pagination in `/ras/runs`
- Added cursor-based pagination to return an individual page of runs for a given query, which includes a `cursor` pointing to the next page of runs for the given query to be used in subsequent requests
  - This should improve the current performance of the `/ras/runs` endpoint as it'll no longer collect all the runs for a query and then discard all but the runs for the requested page
  - The API server now passes the sort query parameter value to CouchDB to sort