### PR TITLE
Felix framework 7.0.5 uplift

### DIFF
--- a/galasa-parent/galasa-boot/build.gradle
+++ b/galasa-parent/galasa-boot/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     implementation project (':dev.galasa.framework.maven.repository')
     embedImplementation project (':dev.galasa.framework.maven.repository.spi')
 
-    embedImplementation 'org.apache.felix:org.apache.felix.framework:7.0.0'
+    embedImplementation 'org.apache.felix:org.apache.felix.framework:7.0.5'
     embedImplementation 'org.apache.felix:org.apache.felix.bundlerepository:2.0.2'
     implementation 'org.apache.felix:org.apache.felix.scr:2.1.14'
 


### PR DESCRIPTION
## Why?

bumped felix framework to the latest version as it contains fixes to java reflections to resolve compatibility with java17