### PR TITLE
added upload artifact to capture unit test output for checking unit test outputs

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -46,7 +46,16 @@ jobs:
           -Dorg.gradle.jvmargs=-Xmx5120M \
           -PsourceMaven=https://development.galasa.dev/gh/maven-repo/maven/ \
           -PcentralMaven=https://repo.maven.apache.org/maven2/ \
-          -PtargetMaven=${{ github.workspace }}/repo 
+          -PtargetMaven=${{ github.workspace }}/repo \
+          --info
+      
+      - name: Upload test output as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: unit-tests
+          path: /home/runner/work/framework/framework/galasa-parent/*/index.html
+          retention-days: 7
+          if-no-files-found: ignore
           
       - name: Build Framework image for testing
         uses: docker/build-push-action@v5


### PR DESCRIPTION
## Why?

This is to improve the ability of a galasa developer to check the reason unit tests have failed by being able to access the JaCoCo reports from the pipeline run, so that issues are easier to diagnose