### PR TITLE
mcobbett gherkin unit tests 2

### DIFF
--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/AbstractTestRunner.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/AbstractTestRunner.java
@@ -364,4 +364,34 @@ public class AbstractTestRunner {
         }
     }
 
+    protected void incrimentMetric(IDynamicStatusStoreService dss, IRun run) {
+        if (run.isLocal()) {
+            logger.debug("It's a local test");
+            DssUtils.incrementMetric(dss, "metrics.runs.local");
+        } else {
+            logger.debug("It's an automated test");
+            DssUtils.incrementMetric(dss, "metrics.runs.automated");
+        }
+    }
+
+
+    protected void storeRasRunIdInDss(IDynamicStatusStoreService dss, String rasRunId) throws TestRunException {
+        try {
+            this.dss.put("run." + run.getName() + ".rasrunid", rasRunId);
+        } catch (DynamicStatusStoreException e) {
+            throw new TestRunException("Failed to update rasrunid", e);
+        }
+    }
+
+    public static class GalasaStream {
+        private String testRepository ;
+        private String testOBR ;
+        private String name ;
+
+        public GalasaStream(String streamName) {
+            this.name = streamName ;
+        }
+
+    }
+
 }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/AbstractTestRunner.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/AbstractTestRunner.java
@@ -319,7 +319,7 @@ public class AbstractTestRunner {
         return this.cps;
     }
 
-    protected void updateStatus(TestRunLifecycleStatus status, String timestamp) throws TestRunException {
+    protected void updateStatus(TestRunLifecycleStatus status, String dssTimePropSuffix) throws TestRunException {
         Instant time = Instant.now();
 
         this.testStructure.setStatus(status.toString());
@@ -332,8 +332,8 @@ public class AbstractTestRunner {
 
         try {
             this.dss.put(getDSSKeyString("status"), status.toString());
-            if (timestamp != null) {
-                this.dss.put(getDSSKeyString(timestamp), time.toString());
+            if (dssTimePropSuffix != null) {
+                this.dss.put(getDSSKeyString(dssTimePropSuffix), time.toString());
             }
         } catch (DynamicStatusStoreException e) {
             throw new TestRunException("Failed to update status", e);

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/AbstractTestRunner.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/AbstractTestRunner.java
@@ -12,11 +12,17 @@ import org.osgi.framework.BundleContext;
 import java.nio.file.Path;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.Map.Entry;
 
 import dev.galasa.ResultArchiveStoreContentType;
+import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
+import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
+import dev.galasa.framework.spi.IDynamicStatusStoreService;
 import dev.galasa.framework.spi.IFramework;
 import dev.galasa.framework.spi.IResultArchiveStore;
+import dev.galasa.framework.spi.IRun;
 import dev.galasa.framework.spi.IShuttableFramework;
+import dev.galasa.framework.spi.teststructure.TestStructure;
 
 public class AbstractTestRunner {
 
@@ -27,6 +33,41 @@ public class AbstractTestRunner {
     protected IShuttableFramework framework;
     protected IBundleManager bundleManager;
     protected IFileSystem fileSystem;
+
+    protected IConfigurationPropertyStoreService cps;
+    protected IDynamicStatusStoreService dss;
+    protected IResultArchiveStore ras;
+    protected IRun run;
+
+    protected TestStructure testStructure = new TestStructure();
+
+    protected TestRunHeartbeat heartbeat;
+
+    protected boolean isRunOK = true;
+    protected boolean isResourcesAvailable = true;
+
+    protected boolean isProduceEventsEnabled;
+
+    protected Properties overrideProperties;
+
+
+    protected void init(ITestRunnerDataProvider dataProvider) throws TestRunException {
+        this.run = dataProvider.getRun() ;
+        this.framework = dataProvider.getFramework();
+        this.cps = dataProvider.getCPS();
+        this.ras = dataProvider.getRAS();
+        this.dss = dataProvider.getDSS();
+        this.bundleManager = dataProvider.getBundleManager();
+        this.fileSystem = dataProvider.getFileSystem();
+
+        this.overrideProperties = dataProvider.getOverrideProperties();
+
+        this.isProduceEventsEnabled = isProduceEventsFeatureFlagTrue();
+
+        checkRunIsSet(this.run);
+
+        loadOverrideProperties(this.overrideProperties, this.run, this.dss);
+    }
 
     protected void shutdownFramework(IShuttableFramework framework) {
         try {
@@ -76,6 +117,43 @@ public class AbstractTestRunner {
             fileSystem.write(rasProperties, sb.toString().getBytes(StandardCharsets.UTF_8));
         } catch (Exception e) {
             logger.error("Failed to save the recorded properties", e);
+        }
+    }
+
+    private boolean isProduceEventsFeatureFlagTrue() throws TestRunException {
+        boolean produceEvents = false;
+        try {
+            String produceEventsProp = this.cps.getProperty("produce", "events");
+            if (produceEventsProp != null) {
+                logger.debug("CPS property framework.produce.events was found and is set to: " + produceEventsProp);
+                produceEvents = Boolean.parseBoolean(produceEventsProp);
+            }
+        } catch (ConfigurationPropertyStoreException ex) {
+            throw new TestRunException("Problem reading the CPS property to check if framework event production has been activated.",ex);
+        }
+        return produceEvents;
+    }
+
+    private void checkRunIsSet(IRun run) throws TestRunException {
+        if (run == null) {
+            throw new TestRunException("Unable to locate run properties");
+        }
+    }
+
+    private void loadOverrideProperties(Properties overrideProperties,
+                                        IRun run, 
+                                        IDynamicStatusStoreService dss) throws TestRunException {
+        //*** Load the overrides if present
+        try {
+            String prefix = "run." + run.getName() + ".override.";
+            Map<String, String> runOverrides = dss.getPrefix(prefix);
+            for(Entry<String, String> entry : runOverrides.entrySet()) {
+                String key = entry.getKey().substring(prefix.length());
+                String value = entry.getValue();
+                overrideProperties.put(key, value);
+            }
+        } catch(Exception e) {
+            throw new TestRunException("Problem loading overrides from the run properties", e);
         }
     }
 }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/AbstractTestRunner.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/AbstractTestRunner.java
@@ -246,7 +246,7 @@ public class AbstractTestRunner {
         }
     }
 
-        private void produceTestHeartbeatStoppedEvent() throws TestRunException {
+    private void produceTestHeartbeatStoppedEvent() throws TestRunException {
         if (this.isProduceEventsEnabled) {
             logger.debug("Producing a test heartbeat stopped event.");
 

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GherkinTestRunner.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GherkinTestRunner.java
@@ -29,8 +29,6 @@ import dev.galasa.framework.spi.Result;
 import dev.galasa.framework.spi.language.GalasaTest;
 import dev.galasa.framework.spi.language.gherkin.GherkinMethod;
 import dev.galasa.framework.spi.language.gherkin.GherkinTest;
-import dev.galasa.framework.spi.utils.DssUtils;
-
 
 /**
  * Run the supplied test class
@@ -70,23 +68,23 @@ public class GherkinTestRunner extends AbstractTestRunner {
 
         gherkinTest = new GherkinTest(run, testStructure,this.fileSystem);
 
-        String testRepository = null;
-        String testOBR = null;
-        String stream = AbstractManager.nulled(run.getStream());
-
         this.testStructure = createNewTestStructure(run);
         this.testStructure.setTestName(gherkinTest.getName());
         writeTestStructure();
 
         try {
 
-            if (stream != null) {
-                logger.debug("Loading test stream " + stream);
+            String testRepository = null;
+            String testOBR = null;
+            String streamName = AbstractManager.nulled(run.getStream());
+
+            if (streamName != null) {
+                logger.debug("Loading test streamName " + streamName);
                 try {
-                    testRepository = this.cps.getProperty("test.stream", "repo", stream);
-                    testOBR = this.cps.getProperty("test.stream", "obr", stream);
+                    testRepository = this.cps.getProperty("test.streamName", "repo", streamName);
+                    testOBR = this.cps.getProperty("test.streamName", "obr", streamName);
                 } catch (Exception e) {
-                    logger.error("Unable to load stream " + stream + " settings", e);
+                    logger.error("Unable to load streamName " + streamName + " settings", e);
                     updateStatus(TestRunLifecycleStatus.FINISHED, "finished");
                     return;
                 }
@@ -150,11 +148,7 @@ public class GherkinTestRunner extends AbstractTestRunner {
                 throw new TestRunException("Unable to initialise the heartbeat");
             }
 
-            if (run.isLocal()) {
-                DssUtils.incrementMetric(dss, "metrics.runs.local");
-            } else {
-                DssUtils.incrementMetric(dss, "metrics.runs.automated");
-            }
+            incrimentMetric(dss,run);
 
             updateStatus(TestRunLifecycleStatus.STARTED, "started");
 

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GherkinTestRunner.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GherkinTestRunner.java
@@ -7,12 +7,7 @@ package dev.galasa.framework;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.HashMap;
 import java.util.Properties;
-
-import javax.validation.constraints.NotNull;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -29,7 +24,6 @@ import dev.galasa.framework.spi.AbstractManager;
 import dev.galasa.framework.spi.DynamicStatusStoreException;
 import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.FrameworkResourceUnavailableException;
-import dev.galasa.framework.spi.IFramework;
 import dev.galasa.framework.spi.IGherkinExecutable;
 import dev.galasa.framework.spi.Result;
 import dev.galasa.framework.spi.language.GalasaTest;
@@ -309,29 +303,27 @@ public class GherkinTestRunner extends AbstractTestRunner {
 
 
     private void runEnvironment(GherkinTest testObject, ITestRunManagers managers) throws TestRunException {
-        if (!isRunOK) {
-            return;
-        }
-
-        try {
+        if (isRunOK) {
             try {
-                updateStatus(TestRunLifecycleStatus.PROVSTART, null);
-                logger.info("Starting Provision Start phase");
-                managers.provisionStart();
-            } catch (FrameworkException e) {
-                this.isRunOK = false;
-                logger.error("Provision start failed",e);
-                if (e instanceof FrameworkResourceUnavailableException) {
-                    isResourcesAvailable = false;
+                try {
+                    updateStatus(TestRunLifecycleStatus.PROVSTART, null);
+                    logger.info("Starting Provision Start phase");
+                    managers.provisionStart();
+                } catch (FrameworkException e) {
+                    this.isRunOK = false;
+                    logger.error("Provision start failed",e);
+                    if (e instanceof FrameworkResourceUnavailableException) {
+                        isResourcesAvailable = false;
+                    }
+                    testObject.setResult(Result.envfail(e));
+                    testStructure.setResult(testObject.getResult().getName());
+                    return;
                 }
-                testObject.setResult(Result.envfail(e));
-                testStructure.setResult(testObject.getResult().getName());
-                return;
-            }
 
-            runGherkinTest(testObject, managers);
-        } finally {
-            stopEnvironment(managers);
+                runGherkinTest(testObject, managers);
+            } finally {
+                stopEnvironment(managers);
+            }
         }
     }
 

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
@@ -9,10 +9,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.HashMap;
 import java.util.Properties;
-
-import javax.validation.constraints.NotNull;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -31,15 +28,11 @@ import dev.galasa.framework.maven.repository.spi.IMavenRepository;
 import dev.galasa.framework.spi.AbstractManager;
 import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
 import dev.galasa.framework.spi.DynamicStatusStoreException;
-import dev.galasa.framework.spi.EventsException;
 import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.FrameworkResourceUnavailableException;
-import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
-import dev.galasa.framework.spi.IFramework;
 import dev.galasa.framework.spi.IManager;
 import dev.galasa.framework.spi.Result;
 import dev.galasa.framework.spi.SharedEnvironmentRunType;
-import dev.galasa.framework.spi.events.TestRunLifecycleStatusChangedEvent;
 import dev.galasa.framework.spi.language.GalasaTest;
 import dev.galasa.framework.spi.utils.DssUtils;
 

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
@@ -37,11 +37,8 @@ import dev.galasa.framework.spi.FrameworkResourceUnavailableException;
 import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
 import dev.galasa.framework.spi.IFramework;
 import dev.galasa.framework.spi.IManager;
-import dev.galasa.framework.spi.IRun;
 import dev.galasa.framework.spi.Result;
-import dev.galasa.framework.spi.ResultArchiveStoreException;
 import dev.galasa.framework.spi.SharedEnvironmentRunType;
-import dev.galasa.framework.spi.events.TestHeartbeatStoppedEvent;
 import dev.galasa.framework.spi.events.TestRunLifecycleStatusChangedEvent;
 import dev.galasa.framework.spi.language.GalasaTest;
 import dev.galasa.framework.spi.utils.DssUtils;
@@ -96,322 +93,316 @@ public class TestRunner extends AbstractTestRunner {
 
         this.testStructure = createNewTestStructure(run);
         writeTestStructure();
-        
-        String rasRunId = this.ras.calculateRasRunId();
-        try {
-            this.dss.put("run." + run.getName() + ".rasrunid", rasRunId);
-        } catch (DynamicStatusStoreException e) {
-            throw new TestRunException("Failed to update rasrunid", e);
-        }
-
-        if (stream != null) {
-            logger.debug("Loading test stream " + stream);
-            try {
-                testRepository = this.cps.getProperty("test.stream", "repo", stream);
-                testOBR = this.cps.getProperty("test.stream", "obr", stream);
-            } catch (Exception e) {
-                logger.error("Unable to load stream " + stream + " settings", e);
-                updateStatus(TestRunLifecycleStatus.FINISHED, "finished");
-                shutdownFramework(framework);
-                return;
-            }
-        }
-
-        testRepository = getOverriddenValue(testRepository, run.getRepository());
-        testOBR = getOverriddenValue(testOBR, run.getOBR());
-
-        if (testRepository != null) {
-            logger.debug("Loading test maven repository " + testRepository);
-            try {
-                String[] repos = testRepository.split("\\,");
-                for(String repo : repos) {
-                    repo = repo.trim();
-                    if (!repo.isEmpty()) {
-                        this.mavenRepository.addRemoteRepository(new URL(repo));
-                    }
-                }
-            } catch (MalformedURLException e) {
-                logger.error("Unable to add remote maven repository " + testRepository, e);
-                updateStatus(TestRunLifecycleStatus.FINISHED, "finished");
-                shutdownFramework(framework);
-                return;
-            }
-        }
-
-        if (testOBR != null) {
-            logger.debug("Loading test obr repository " + testOBR);
-            try {
-                String[] testOBRs = testOBR.split("\\,");
-                for(String obr : testOBRs) {
-                    obr = obr.trim();
-                    if (!obr.isEmpty()) {
-                        repositoryAdmin.addRepository(obr);
-                    }
-                }
-            } catch (Exception e) {
-                logger.error("Unable to load specified OBR " + testOBR, e);
-                updateStatus(TestRunLifecycleStatus.FINISHED, "finished");
-                shutdownFramework(this.framework);
-                return;
-            }
-        }
-
-        try {
-            this.bundleManager.loadBundle(repositoryAdmin, bundleContext, testBundleName);
-        } catch (Exception e) {
-            logger.error("Unable to load the test bundle " + testBundleName, e);
-            updateStatus(TestRunLifecycleStatus.FINISHED, "finished");
-            shutdownFramework(framework);
-            return;
-        }
-        
-        Class<?> testClass;
-        try {
-            logger.debug("Loading test class... " + testClassName);
-            testClass = getTestClass(testBundleName, testClassName);
-            logger.debug("Test class " + testClassName + " loaded OK.");
-        } catch(Throwable t) {
-            logger.error("Problem locating test " + testBundleName + "/" + testClassName, t);
-            updateStatus(TestRunLifecycleStatus.FINISHED, "finished");
-            shutdownFramework(framework);
-            return;
-        }
-
-        logger.debug("Getting test annotations..");
-        IAnnotationExtractor annotationExtractor = dataProvider.getAnnotationExtractor();
-        Test testAnnotation = annotationExtractor.getAnnotation( testClass , Test.class);
-        logger.debug("Test annotations.. got");
-
-        SharedEnvironment sharedEnvironmentAnnotation = annotationExtractor.getAnnotation( testClass, SharedEnvironment.class);
-
-        logger.debug("Checking testAnnotation and sharedEnvironmentAnnotation");
-        if (testAnnotation == null && sharedEnvironmentAnnotation == null) {
-            logger.debug("Test annotation is null and it's not a shared environment. Throwing TestRunException...");
-            throw new TestRunException("Class " + testBundleName + "/" + testClassName + " is not annotated with either the dev.galasa @Test or @SharedEnvironment annotations");
-        } else if (testAnnotation != null && sharedEnvironmentAnnotation != null) {
-            logger.debug("Test annotation is non-null and shared environment annotation is non-null. Throwing TestRunException...");
-            throw new TestRunException("Class " + testBundleName + "/" + testClassName + " is annotated with both the dev.galasa @Test and @SharedEnvironment annotations");
-        }
-        
-
-        if (testAnnotation != null) {
-            logger.info("Run test: " + testBundleName + "/" + testClassName);
-            this.runType = RunType.TEST;
-        } else {
-            logger.info("Shared Environment class: " + testBundleName + "/" + testClassName);
-        }
-
-
-        if (sharedEnvironmentAnnotation != null) {
-            try {
-                SharedEnvironmentRunType seType = this.framework.getSharedEnvironmentRunType();
-                if (seType != null) {
-                    switch(seType) {
-                        case BUILD:
-                            this.runType = RunType.SHARED_ENVIRONMENT_BUILD;
-                            break;
-                        case DISCARD:
-                            this.runType = RunType.SHARED_ENVIRONMENT_DISCARD;
-                            break;
-                        default:
-                            String msg = "Unknown Shared Environment phase, '" + seType + "', needs to be BUILD or DISCARD";
-                            logger.error(msg);
-                            throw new TestRunException(msg);
-                    }
-                } else {
-                    String msg = "Unknown Shared Environment phase, needs to be BUILD or DISCARD";
-                    logger.error(msg);
-                    throw new TestRunException(msg);
-                }
-            } catch(TestRunException e) {
-                String msg = "TestRunException caught. "+e.getMessage()+" Re-throwing.";
-                logger.error(msg);
-                throw e;
-            } catch(Exception e) {
-                String msg = "Exception caught. "+e.getMessage()+" Re-throwing.";
-                logger.error(msg);
-                throw new TestRunException("Unable to determine the phase of the shared environment", e);
-            }
-        }
-
-        logger.debug("Test runType is "+this.runType.toString());
-        if (this.runType == RunType.TEST) {
-            try {
-                heartbeat = new TestRunHeartbeat(this.framework);
-                logger.debug("starting heartbeat");
-                heartbeat.start();
-                logger.debug("heartbeat started ok");
-            } catch (DynamicStatusStoreException e1) {
-                String msg = "DynamicStatusStoreException Exception caught. "+e1.getMessage()+" Shutting down and Re-throwing.";
-                logger.error(msg);
-                shutdownFramework(framework);
-                throw new TestRunException("Unable to initialise the heartbeat");
-            }
-
-            if (run.isLocal()) {
-                logger.debug("It's a local test");
-                DssUtils.incrementMetric(dss, "metrics.runs.local");
-            } else {
-                logger.debug("It's an automated test");
-                DssUtils.incrementMetric(dss, "metrics.runs.automated");
-            }
-        } else if (this.runType == RunType.SHARED_ENVIRONMENT_BUILD) {
-            int expireHours = sharedEnvironmentAnnotation.expireAfterHours();
-            Instant expire = Instant.now().plus(expireHours, ChronoUnit.HOURS);
-            try {
-                this.dss.put("run." + this.run.getName() + ".shared.environment.expire", expire.toString());
-            } catch (DynamicStatusStoreException e) {
-                String msg = "DynamicStatusStoreException Exception caught. "+e.getMessage()+" Shutting down and Re-throwing.";
-                logger.error(msg);
-                deleteRunProperties(this.framework);
-                shutdownFramework(framework);
-                throw new TestRunException("Unable to set the shared environment expire time",e);
-            }
-        }
-
-        logger.debug("state changing to started.");
-        updateStatus(TestRunLifecycleStatus.STARTED, "started");
-
-        // *** Try to load the Core Manager bundle, even if the test doesn't use it, and if not already active
-        if (!bundleManager.isBundleActive(bundleContext, "dev.galasa.core.manager")) {
-            try {
-                bundleManager.loadBundle(repositoryAdmin, bundleContext, "dev.galasa.core.manager");
-            } catch (FrameworkException e) {
-                logger.warn("Tried to load the Core Manager bundle, but failed, test can continue without it",e);
-            }
-        }
-
-        logger.debug("Bundle is loaded ok.");
-
-        // *** Initialise the Managers ready for the test run
-        ITestRunManagers managers = null;
-        try {
-            GalasaTest galasaTest = new GalasaTest(testClass);
-            managers = dataProvider.createTestRunManagers(galasaTest);
-        } catch (TestRunException e) {
-            String msg = "Exception Exception caught. "+e.getMessage()+" Shutting down and Re-throwing.";
-            logger.error(msg);
-            shutdownFramework(framework);
-            throw new TestRunException("Problem initialising the Managers for a test run", e);
-        }
-
-        logger.debug("Test managers ok.");
-
-        try {
-            if (managers.anyReasonTestClassShouldBeIgnored()) {
-                logger.debug("managers.anyReasonTestClassShouldBeIgnored() is true. Shutting down.");
-                stopHeartbeat();
-                updateStatus(TestRunLifecycleStatus.FINISHED, "finished");
-                shutdownFramework(framework);
-                return; // TODO handle ignored classes
-            }
-        } catch (FrameworkException e) {
-            String msg = "Problem asking Managers for an ignore reason";
-            logger.error(msg+" "+e.getMessage());
-            throw new TestRunException(msg, e);
-        }
-        logger.debug("Test class should not be ignored.");
-
-        
-        TestClassWrapper testClassWrapper;
-        try { 
             
-            testClassWrapper = new TestClassWrapper(this, testBundleName, testClass, testStructure);
-        } catch(ConfigurationPropertyStoreException e) {
-            String msg = "Problem with the CPS when adding a wrapper";
-            logger.error(msg+" "+e.getMessage());
-            throw new TestRunException(msg,e);
-        }
+        try {
+            String rasRunId = this.ras.calculateRasRunId();
+            try {
+                this.dss.put("run." + run.getName() + ".rasrunid", rasRunId);
+            } catch (DynamicStatusStoreException e) {
+                throw new TestRunException("Failed to update rasrunid", e);
+            }
 
-        logger.debug("Parsing test class...");
-        testClassWrapper.parseTestClass();
-
-        logger.debug("Instantiating test class...");
-        testClassWrapper.instantiateTestClass();
-
-        if (this.runType == RunType.SHARED_ENVIRONMENT_BUILD) {
-            logger.debug("Checking active managers to see if they support shared env build...");
-            //*** Check all the active Managers to see if they support a shared environment build
-            boolean invalidManager = false;
-            for(IManager manager : managers.getActiveManagers()) {
-                if (!manager.doYouSupportSharedEnvironments()) {
-                    logger.error("Manager " + manager.getClass().getName() + " does not support Shared Environments");
-                    invalidManager = true;
+            if (stream != null) {
+                logger.debug("Loading test stream " + stream);
+                try {
+                    testRepository = this.cps.getProperty("test.stream", "repo", stream);
+                    testOBR = this.cps.getProperty("test.stream", "obr", stream);
+                } catch (Exception e) {
+                    logger.error("Unable to load stream " + stream + " settings", e);
+                    updateStatus(TestRunLifecycleStatus.FINISHED, "finished");
+                    return;
                 }
             }
 
-            if (invalidManager) {
-                logger.error("There are Managers that do not support Shared Environment builds");
-                testClassWrapper.setResult(Result.failed("Invalid Shared Environment build"));
-                testStructure.setResult(testClassWrapper.getResult().getName());
-                isRunOK = false;
+            testRepository = getOverriddenValue(testRepository, run.getRepository());
+            testOBR = getOverriddenValue(testOBR, run.getOBR());
+
+            if (testRepository != null) {
+                logger.debug("Loading test maven repository " + testRepository);
+                try {
+                    String[] repos = testRepository.split("\\,");
+                    for(String repo : repos) {
+                        repo = repo.trim();
+                        if (!repo.isEmpty()) {
+                            this.mavenRepository.addRemoteRepository(new URL(repo));
+                        }
+                    }
+                } catch (MalformedURLException e) {
+                    logger.error("Unable to add remote maven repository " + testRepository, e);
+                    updateStatus(TestRunLifecycleStatus.FINISHED, "finished");
+                    return;
+                }
             }
-        }
-        logger.debug("isRunOK: "+Boolean.toString(isRunOK));
 
-        logger.debug("Generating environment...");
-        try {
-            generateEnvironment(testClassWrapper, managers);
-        } catch(Exception e) {
-            logger.fatal("Error within test runner",e);
-            this.isRunOK = false;
-        }
+            if (testOBR != null) {
+                logger.debug("Loading test obr repository " + testOBR);
+                try {
+                    String[] testOBRs = testOBR.split("\\,");
+                    for(String obr : testOBRs) {
+                        obr = obr.trim();
+                        if (!obr.isEmpty()) {
+                            repositoryAdmin.addRepository(obr);
+                        }
+                    }
+                } catch (Exception e) {
+                    logger.error("Unable to load specified OBR " + testOBR, e);
+                    updateStatus(TestRunLifecycleStatus.FINISHED, "finished");
+                    return;
+                }
+            }
 
-        logger.debug("isRunOK: "+Boolean.toString(isRunOK)+" runType: "+runType.toString());
+            try {
+                this.bundleManager.loadBundle(repositoryAdmin, bundleContext, testBundleName);
+            } catch (Exception e) {
+                logger.error("Unable to load the test bundle " + testBundleName, e);
+                updateStatus(TestRunLifecycleStatus.FINISHED, "finished");
+                return;
+            }
+            
+            Class<?> testClass;
+            try {
+                logger.debug("Loading test class... " + testClassName);
+                testClass = getTestClass(testBundleName, testClassName);
+                logger.debug("Test class " + testClassName + " loaded OK.");
+            } catch(Throwable t) {
+                logger.error("Problem locating test " + testBundleName + "/" + testClassName, t);
+                updateStatus(TestRunLifecycleStatus.FINISHED, "finished");
+                return;
+            }
 
-        if (!isRunOK || this.runType == RunType.TEST || this.runType == RunType.SHARED_ENVIRONMENT_DISCARD) {
-            logger.debug("Test did not run OK... or runtype is not "+RunType.SHARED_ENVIRONMENT_BUILD.toString());
-            updateStatus(TestRunLifecycleStatus.ENDING, null);
-            managers.endOfTestRun();
+            logger.debug("Getting test annotations..");
+            IAnnotationExtractor annotationExtractor = dataProvider.getAnnotationExtractor();
+            Test testAnnotation = annotationExtractor.getAnnotation( testClass , Test.class);
+            logger.debug("Test annotations.. got");
 
-            boolean markedWaiting = false;
+            SharedEnvironment sharedEnvironmentAnnotation = annotationExtractor.getAnnotation( testClass, SharedEnvironment.class);
 
-            if (!isResourcesAvailable && !run.isLocal()) {
-                markWaiting(this.framework);
-                logger.info("Placing queue on the waiting list");
-                markedWaiting = true;
+            logger.debug("Checking testAnnotation and sharedEnvironmentAnnotation");
+            if (testAnnotation == null && sharedEnvironmentAnnotation == null) {
+                logger.debug("Test annotation is null and it's not a shared environment. Throwing TestRunException...");
+                throw new TestRunException("Class " + testBundleName + "/" + testClassName + " is not annotated with either the dev.galasa @Test or @SharedEnvironment annotations");
+            } else if (testAnnotation != null && sharedEnvironmentAnnotation != null) {
+                logger.debug("Test annotation is non-null and shared environment annotation is non-null. Throwing TestRunException...");
+                throw new TestRunException("Class " + testBundleName + "/" + testClassName + " is annotated with both the dev.galasa @Test and @SharedEnvironment annotations");
+            }
+            
+
+            if (testAnnotation != null) {
+                logger.info("Run test: " + testBundleName + "/" + testClassName);
+                this.runType = RunType.TEST;
             } else {
-                if (this.runType == RunType.SHARED_ENVIRONMENT_DISCARD) {
-                    this.testStructure.setResult("Discarded");
-                    try {
-                        this.dss.deletePrefix("run." + this.run.getName() + ".shared.environment");
-                    } catch (DynamicStatusStoreException e) {
-                        logger.error("Problem cleaning shared environment properties", e);
+                logger.info("Shared Environment class: " + testBundleName + "/" + testClassName);
+            }
+
+
+            if (sharedEnvironmentAnnotation != null) {
+                try {
+                    SharedEnvironmentRunType seType = this.framework.getSharedEnvironmentRunType();
+                    if (seType != null) {
+                        switch(seType) {
+                            case BUILD:
+                                this.runType = RunType.SHARED_ENVIRONMENT_BUILD;
+                                break;
+                            case DISCARD:
+                                this.runType = RunType.SHARED_ENVIRONMENT_DISCARD;
+                                break;
+                            default:
+                                String msg = "Unknown Shared Environment phase, '" + seType + "', needs to be BUILD or DISCARD";
+                                logger.error(msg);
+                                throw new TestRunException(msg);
+                        }
+                    } else {
+                        String msg = "Unknown Shared Environment phase, needs to be BUILD or DISCARD";
+                        logger.error(msg);
+                        throw new TestRunException(msg);
+                    }
+                } catch(TestRunException e) {
+                    String msg = "TestRunException caught. "+e.getMessage()+" Re-throwing.";
+                    logger.error(msg);
+                    throw e;
+                } catch(Exception e) {
+                    String msg = "Exception caught. "+e.getMessage()+" Re-throwing.";
+                    logger.error(msg);
+                    throw new TestRunException("Unable to determine the phase of the shared environment", e);
+                }
+            }
+
+            logger.debug("Test runType is "+this.runType.toString());
+            if (this.runType == RunType.TEST) {
+                try {
+                    heartbeat = new TestRunHeartbeat(this.framework);
+                    logger.debug("starting heartbeat");
+                    heartbeat.start();
+                    logger.debug("heartbeat started ok");
+                } catch (DynamicStatusStoreException e1) {
+                    String msg = "DynamicStatusStoreException Exception caught. "+e1.getMessage()+" Shutting down and Re-throwing.";
+                    logger.error(msg);
+                    throw new TestRunException("Unable to initialise the heartbeat");
+                }
+
+                if (run.isLocal()) {
+                    logger.debug("It's a local test");
+                    DssUtils.incrementMetric(dss, "metrics.runs.local");
+                } else {
+                    logger.debug("It's an automated test");
+                    DssUtils.incrementMetric(dss, "metrics.runs.automated");
+                }
+            } else if (this.runType == RunType.SHARED_ENVIRONMENT_BUILD) {
+                int expireHours = sharedEnvironmentAnnotation.expireAfterHours();
+                Instant expire = Instant.now().plus(expireHours, ChronoUnit.HOURS);
+                try {
+                    this.dss.put("run." + this.run.getName() + ".shared.environment.expire", expire.toString());
+                } catch (DynamicStatusStoreException e) {
+                    String msg = "DynamicStatusStoreException Exception caught. "+e.getMessage()+" Shutting down and Re-throwing.";
+                    logger.error(msg);
+                    deleteRunProperties(this.framework);
+                    throw new TestRunException("Unable to set the shared environment expire time",e);
+                }
+            }
+
+            logger.debug("state changing to started.");
+            updateStatus(TestRunLifecycleStatus.STARTED, "started");
+
+            // *** Try to load the Core Manager bundle, even if the test doesn't use it, and if not already active
+            if (!bundleManager.isBundleActive(bundleContext, "dev.galasa.core.manager")) {
+                try {
+                    bundleManager.loadBundle(repositoryAdmin, bundleContext, "dev.galasa.core.manager");
+                } catch (FrameworkException e) {
+                    logger.warn("Tried to load the Core Manager bundle, but failed, test can continue without it",e);
+                }
+            }
+
+            logger.debug("Bundle is loaded ok.");
+
+            // *** Initialise the Managers ready for the test run
+            ITestRunManagers managers = null;
+            try {
+                GalasaTest galasaTest = new GalasaTest(testClass);
+                managers = dataProvider.createTestRunManagers(galasaTest);
+            } catch (TestRunException e) {
+                String msg = "Exception Exception caught. "+e.getMessage()+" Shutting down and Re-throwing.";
+                logger.error(msg);
+                throw new TestRunException("Problem initialising the Managers for a test run", e);
+            }
+
+            logger.debug("Test managers ok.");
+
+            try {
+                if (managers.anyReasonTestClassShouldBeIgnored()) {
+                    logger.debug("managers.anyReasonTestClassShouldBeIgnored() is true. Shutting down.");
+                    stopHeartbeat();
+                    updateStatus(TestRunLifecycleStatus.FINISHED, "finished");
+                    return; // TODO handle ignored classes
+                }
+            } catch (FrameworkException e) {
+                String msg = "Problem asking Managers for an ignore reason";
+                logger.error(msg+" "+e.getMessage());
+                throw new TestRunException(msg, e);
+            }
+            logger.debug("Test class should not be ignored.");
+
+            
+            TestClassWrapper testClassWrapper;
+            try { 
+                
+                testClassWrapper = new TestClassWrapper(this, testBundleName, testClass, testStructure);
+            } catch(ConfigurationPropertyStoreException e) {
+                String msg = "Problem with the CPS when adding a wrapper";
+                logger.error(msg+" "+e.getMessage());
+                throw new TestRunException(msg,e);
+            }
+
+            logger.debug("Parsing test class...");
+            testClassWrapper.parseTestClass();
+
+            logger.debug("Instantiating test class...");
+            testClassWrapper.instantiateTestClass();
+
+            if (this.runType == RunType.SHARED_ENVIRONMENT_BUILD) {
+                logger.debug("Checking active managers to see if they support shared env build...");
+                //*** Check all the active Managers to see if they support a shared environment build
+                boolean invalidManager = false;
+                for(IManager manager : managers.getActiveManagers()) {
+                    if (!manager.doYouSupportSharedEnvironments()) {
+                        logger.error("Manager " + manager.getClass().getName() + " does not support Shared Environments");
+                        invalidManager = true;
                     }
                 }
-                updateStatus(TestRunLifecycleStatus.FINISHED, "finished");
+
+                if (invalidManager) {
+                    logger.error("There are Managers that do not support Shared Environment builds");
+                    testClassWrapper.setResult(Result.failed("Invalid Shared Environment build"));
+                    testStructure.setResult(testClassWrapper.getResult().getName());
+                    isRunOK = false;
+                }
+            }
+            logger.debug("isRunOK: "+Boolean.toString(isRunOK));
+
+            logger.debug("Generating environment...");
+            try {
+                generateEnvironment(testClassWrapper, managers);
+            } catch(Exception e) {
+                logger.fatal("Error within test runner",e);
+                this.isRunOK = false;
             }
 
-            logger.debug("Stopping heartbeat...");
-            stopHeartbeat();
+            logger.debug("isRunOK: "+Boolean.toString(isRunOK)+" runType: "+runType.toString());
 
-            // *** Record all the CPS properties that were accessed
-            recordCPSProperties(this.fileSystem, this.framework, this.ras);
+            if (!isRunOK || this.runType == RunType.TEST || this.runType == RunType.SHARED_ENVIRONMENT_DISCARD) {
+                logger.debug("Test did not run OK... or runtype is not "+RunType.SHARED_ENVIRONMENT_BUILD.toString());
+                updateStatus(TestRunLifecycleStatus.ENDING, null);
+                managers.endOfTestRun();
 
-            // *** If this was a local run, then we will want to remove the run properties
-            // from the DSS immediately
-            // *** for automation, we will let the core manager clean up after a while
-            // *** Local runs will have access to the run details via a view,
-            // *** But automation runs will only exist in the RAS if we delete them, so need
-            // to give
-            // *** time for things like jenkins and other run requesters to obtain the
-            // result and RAS id before
-            // *** deleting, default is to keep the automation run properties for 5 minutes
-            if (!markedWaiting) {
-                deleteRunProperties(this.framework);
+                boolean markedWaiting = false;
+
+                if (!isResourcesAvailable && !run.isLocal()) {
+                    markWaiting(this.framework);
+                    logger.info("Placing queue on the waiting list");
+                    markedWaiting = true;
+                } else {
+                    if (this.runType == RunType.SHARED_ENVIRONMENT_DISCARD) {
+                        this.testStructure.setResult("Discarded");
+                        try {
+                            this.dss.deletePrefix("run." + this.run.getName() + ".shared.environment");
+                        } catch (DynamicStatusStoreException e) {
+                            logger.error("Problem cleaning shared environment properties", e);
+                        }
+                    }
+                    updateStatus(TestRunLifecycleStatus.FINISHED, "finished");
+                }
+
+                logger.debug("Stopping heartbeat...");
+                stopHeartbeat();
+
+                // *** Record all the CPS properties that were accessed
+                recordCPSProperties(this.fileSystem, this.framework, this.ras);
+
+                // *** If this was a local run, then we will want to remove the run properties
+                // from the DSS immediately
+                // *** for automation, we will let the core manager clean up after a while
+                // *** Local runs will have access to the run details via a view,
+                // *** But automation runs will only exist in the RAS if we delete them, so need
+                // to give
+                // *** time for things like jenkins and other run requesters to obtain the
+                // result and RAS id before
+                // *** deleting, default is to keep the automation run properties for 5 minutes
+                if (!markedWaiting) {
+                    deleteRunProperties(this.framework);
+                }
+            } else if (this.runType == RunType.SHARED_ENVIRONMENT_BUILD) {
+                recordCPSProperties(this.fileSystem, this.framework, this.ras);
+                updateStatus(TestRunLifecycleStatus.UP, "built");
+            } else {
+                logger.error("Unrecognised end condition");
             }
-        } else if (this.runType == RunType.SHARED_ENVIRONMENT_BUILD) {
-            recordCPSProperties(this.fileSystem, this.framework, this.ras);
-            updateStatus(TestRunLifecycleStatus.UP, "built");
-        } else {
-            logger.error("Unrecognised end condition");
+
+            logger.debug("Cleaning up managers...");
+            managers.shutdown();
+
+        } finally {
+            logger.debug("Cleaning up framework...");
+            shutdownFramework(framework);
         }
-
-        logger.debug("Cleaning up managers...");
-        managers.shutdown();
-
-        logger.debug("Cleaning up framework...");
-        shutdownFramework(framework);
     }
 
 

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockTestRunnerDataProvider.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockTestRunnerDataProvider.java
@@ -1,5 +1,6 @@
 package dev.galasa.framework.mocks;
 
+import java.util.List;
 import java.util.Properties;
 
 import dev.galasa.framework.IAnnotationExtractor;
@@ -10,6 +11,7 @@ import dev.galasa.framework.ITestRunnerDataProvider;
 import dev.galasa.framework.TestRunException;
 import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
 import dev.galasa.framework.spi.IDynamicStatusStoreService;
+import dev.galasa.framework.spi.IGherkinExecutable;
 import dev.galasa.framework.spi.IResultArchiveStore;
 import dev.galasa.framework.spi.IRun;
 import dev.galasa.framework.spi.IShuttableFramework;


### PR DESCRIPTION
# Why ?

General refactoring of some bad code smells in the test runners.

- **move some methods from java and gherkin test runner to the abstract runner**
- **move some common methods into the abstract test runner**
- **framework shutdown only called from one place**
- **[Moving the updatestatus and kafka publishing routines into a common abstract test runner](https://github.com/galasa-dev/framework/pull/631/commits/22ee923f483b07993f4d0c2a991fc70791cd3319)**
- **[runTest is now 330 lines long](https://github.com/galasa-dev/framework/pull/631/commits/c586a26afa3fe7fb0ea46b3ec301b7402735965d)**
