### PR TITLE
Add 'from' sort key to sort by queued time, set default sort to 'from:desc'

### DIFF
--- a/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -1091,7 +1091,13 @@ paths:
           in: query
           description: |
             Sorts the returned runs based on the sort field.
-            Supports sorting fields 'to','result' and 'testclass'.
+            Supports sorting fields 'from', 'to', 'result' and 'testclass'.
+            
+            If omitted, runs will be sorted in descending order based on their 'queued' time,
+            which is equivalent to specifying 'from:desc' (i.e. latest queued run first, oldest last).
+
+            When sorting with 'to' or 'result', runs that have not yet finished will not
+            be included in responses from this endpoint.
 
             Use '{FIELD-NAME}:asc' to sort in ascending order.
             Use '{FIELD-NAME}:desc' to sort in descending order.
@@ -1100,9 +1106,7 @@ paths:
             type: string
           examples:
             single:
-              value: result:asc
-            multiple:
-              value: result:asc,testclass:desc
+              value: from:asc
         - name: result
           in: query
           description: |

--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunQueryRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunQueryRoute.java
@@ -337,19 +337,19 @@ public class RunQueryRoute extends RunsRoute {
 
 		@Override
 		public int compare(RasRunResult a, RasRunResult b) {
-			Instant aEndTime = a.getTestStructure().getQueued();
-			Instant bEndTime = b.getTestStructure().getQueued();
+			Instant aQueuedTime = a.getTestStructure().getQueued();
+			Instant bQueuedTime = b.getTestStructure().getQueued();
 
-			if (aEndTime == null) {
-				if (bEndTime == null) {
+			if (aQueuedTime == null) {
+				if (bQueuedTime == null) {
 					return 0;
 				}
 				return -1;
 			}
-			if (bEndTime == null) {
+			if (bQueuedTime == null) {
 				return 1;
 			}
-			return aEndTime.compareTo(bEndTime);
+			return aQueuedTime.compareTo(bQueuedTime);
 		}
 	}
 

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunQuery.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunQuery.java
@@ -2261,4 +2261,110 @@ public class TestRunQuery extends RasServletTest {
 		assertThat(outStream.toString()).contains("GAL5011E", "Error parsing the query parameters", "sort value 'unknown' not recognised");
 		assertThat(resp.getContentType()).isEqualTo("application/json");
 	}
+
+    @Test
+	public void testQueryWithSortByQueuedTimeAscendingReturnsRunsOk() throws Exception {
+		// Given..
+        Instant time1 = Instant.EPOCH;
+        Instant time2 = Instant.ofEpochSecond(10);
+        Instant time3 = Instant.ofEpochSecond(20);
+
+        String runId1 = "test1";
+        String runId2 = "test2";
+        String runId3 = "test3";
+
+        IRunResult testRun1 = createTestRun(runId1, time1, time1, time1);
+        IRunResult testRun2 = createTestRun(runId2, time2, time2, time2);
+        IRunResult testRun3 = createTestRun(runId3, time3, time3, time3);
+
+		List<IRunResult> mockInputRunResults = List.of(
+            testRun3,
+            testRun1,
+            testRun2
+        );
+
+        // Build query parameters
+        int pageSize = 100;
+        int pageNum = 1;
+        String sort = "from:asc";
+		Map<String, String[]> parameterMap = setQueryParameter(pageNum, pageSize, sort, null,null, 72, null);
+        parameterMap.put("runId", new String[] { runId1 + "," + runId2 + "," + runId3 });
+
+		MockHttpServletRequest mockRequest = new MockHttpServletRequest(parameterMap, "/runs");
+		MockRasServletEnvironment mockServletEnvironment = new MockRasServletEnvironment(mockInputRunResults,mockRequest);
+
+		RasServlet servlet = mockServletEnvironment.getServlet();
+		HttpServletRequest req = mockServletEnvironment.getRequest();
+		HttpServletResponse resp = mockServletEnvironment.getResponse();
+		ServletOutputStream outStream = resp.getOutputStream();
+
+		// When...
+		servlet.init();
+		servlet.doGet(req,resp);
+
+		// Then...
+        List<IRunResult> expectedOrderedRunResults = List.of(
+            testRun1,
+            testRun2,
+            testRun3
+        );
+
+        String expectedJson = generateExpectedJson(expectedOrderedRunResults, pageSize, pageNum);
+		assertThat(resp.getStatus()).isEqualTo(200);
+		assertThat(outStream.toString()).isEqualTo(expectedJson);
+		assertThat(resp.getContentType()).isEqualTo("application/json");
+	}
+
+    @Test
+	public void testQueryWithSortByQueuedTimeDescendingReturnsRunsOk() throws Exception {
+		// Given..
+        Instant time1 = Instant.EPOCH;
+        Instant time2 = Instant.ofEpochSecond(10);
+        Instant time3 = Instant.ofEpochSecond(20);
+
+        String runId1 = "test1";
+        String runId2 = "test2";
+        String runId3 = "test3";
+
+        IRunResult testRun1 = createTestRun(runId1, time1, time1, time1);
+        IRunResult testRun2 = createTestRun(runId2, time2, time2, time2);
+        IRunResult testRun3 = createTestRun(runId3, time3, time3, time3);
+
+		List<IRunResult> mockInputRunResults = List.of(
+            testRun3,
+            testRun1,
+            testRun2
+        );
+
+        // Build query parameters
+        int pageSize = 100;
+        int pageNum = 1;
+        String sort = "from:desc";
+		Map<String, String[]> parameterMap = setQueryParameter(pageNum, pageSize, sort, null,null, 72, null);
+        parameterMap.put("runId", new String[] { runId1 + "," + runId2 + "," + runId3 });
+
+		MockHttpServletRequest mockRequest = new MockHttpServletRequest(parameterMap, "/runs");
+		MockRasServletEnvironment mockServletEnvironment = new MockRasServletEnvironment(mockInputRunResults,mockRequest);
+
+		RasServlet servlet = mockServletEnvironment.getServlet();
+		HttpServletRequest req = mockServletEnvironment.getRequest();
+		HttpServletResponse resp = mockServletEnvironment.getResponse();
+		ServletOutputStream outStream = resp.getOutputStream();
+
+		// When...
+		servlet.init();
+		servlet.doGet(req,resp);
+
+		// Then...
+        List<IRunResult> expectedOrderedRunResults = List.of(
+            testRun3,
+            testRun2,
+            testRun1
+        );
+
+        String expectedJson = generateExpectedJson(expectedOrderedRunResults, pageSize, pageNum);
+		assertThat(resp.getStatus()).isEqualTo(200);
+		assertThat(outStream.toString()).isEqualTo(expectedJson);
+		assertThat(resp.getContentType()).isEqualTo("application/json");
+	}
 }


### PR DESCRIPTION
## Why?
Related to story https://github.com/galasa-dev/projectmanagement/issues/1921

CouchDB omits documents that do not have an `endTime` or a `result` when sorting on either of those fields. Therefore, instead of defaulting to sort by `endTime` descending (`to:desc`), this PR adds a `from` sort key to sort by a run's queued time and sets that as the default sort since all runs are guaranteed to have a queued time.

## Changes
- Added `from` sort key support to sort by queued time for both the new cursor-based pagination and existing page-based pagination
- Updated the OpenAPI description of the `sort` query parameter to point out that sorting by `to` or `result` will omit runs that are yet to finish since an active run has no result or end time