### PR TITLE
Fix test stream CPS property prefix to look for test.stream instead of test.streamName

### DIFF
--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
@@ -96,8 +96,8 @@ public class TestRunner extends AbstractTestRunner {
             if (streamName != null) {
                 logger.debug("Loading test streamName " + streamName);
                 try {
-                    testRepository = this.cps.getProperty("test.streamName", "repo", streamName);
-                    testOBR = this.cps.getProperty("test.streamName", "obr", streamName);
+                    testRepository = this.cps.getProperty("test.stream", "repo", streamName);
+                    testOBR = this.cps.getProperty("test.stream", "obr", streamName);
                 } catch (Exception e) {
                     logger.error("Unable to load streamName " + streamName + " settings", e);
                     updateStatus(TestRunLifecycleStatus.FINISHED, "finished");


### PR DESCRIPTION
## Why?
Fixes an issue where test streams weren't being loaded properly due to incorrect CPS property prefixes.