### PR TITLE
Initialise test structure before passing it in when creating a gherkin test, fix test stream CPS prefix in GherkinTestRunner

### DIFF
--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GherkinTestRunner.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/GherkinTestRunner.java
@@ -66,10 +66,10 @@ public class GherkinTestRunner extends AbstractTestRunner {
 
         super.init(dataProvider);
 
+        this.testStructure = createNewTestStructure(run);
+
         gherkinTest = new GherkinTest(run, testStructure,this.fileSystem);
 
-        this.testStructure = createNewTestStructure(run);
-        this.testStructure.setTestName(gherkinTest.getName());
         writeTestStructure();
 
         try {
@@ -79,12 +79,12 @@ public class GherkinTestRunner extends AbstractTestRunner {
             String streamName = AbstractManager.nulled(run.getStream());
 
             if (streamName != null) {
-                logger.debug("Loading test streamName " + streamName);
+                logger.debug("Loading test stream " + streamName);
                 try {
-                    testRepository = this.cps.getProperty("test.streamName", "repo", streamName);
-                    testOBR = this.cps.getProperty("test.streamName", "obr", streamName);
+                    testRepository = this.cps.getProperty("test.stream", "repo", streamName);
+                    testOBR = this.cps.getProperty("test.stream", "obr", streamName);
                 } catch (Exception e) {
-                    logger.error("Unable to load streamName " + streamName + " settings", e);
+                    logger.error("Unable to load stream " + streamName + " settings", e);
                     updateStatus(TestRunLifecycleStatus.FINISHED, "finished");
                     return;
                 }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/TestRunner.java
@@ -94,12 +94,12 @@ public class TestRunner extends AbstractTestRunner {
             String streamName = AbstractManager.nulled(run.getStream());
 
             if (streamName != null) {
-                logger.debug("Loading test streamName " + streamName);
+                logger.debug("Loading test stream " + streamName);
                 try {
                     testRepository = this.cps.getProperty("test.stream", "repo", streamName);
                     testOBR = this.cps.getProperty("test.stream", "obr", streamName);
                 } catch (Exception e) {
-                    logger.error("Unable to load streamName " + streamName + " settings", e);
+                    logger.error("Unable to load stream " + streamName + " settings", e);
                     updateStatus(TestRunLifecycleStatus.FINISHED, "finished");
                     return;
                 }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/language/gherkin/GherkinTest.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/language/gherkin/GherkinTest.java
@@ -67,6 +67,7 @@ public class GherkinTest {
             structureMethods.add(scenario.getStructure());
         }
 
+        this.testStructure.setTestName(this.feature.getName());
         this.testStructure.setTestShortName(this.feature.getName());
         this.testStructure.setGherkinMethods(structureMethods);
     }


### PR DESCRIPTION
## Why?
Fixes defects in test runner code, including initialising Gherkin test structures before passing them in to the GherkinTest constructor.