### PR TITLE
Remove unnecessary calls to etcd when getting a specific CPS namespace

### DIFF
--- a/galasa-parent/dev.galasa.framework.api.resources/src/main/java/dev/galasa/framework/api/resources/ResourcesServlet.java
+++ b/galasa-parent/dev.galasa.framework.api.resources/src/main/java/dev/galasa/framework/api/resources/ResourcesServlet.java
@@ -18,6 +18,7 @@ import org.osgi.service.component.annotations.ServiceScope;
 import dev.galasa.framework.FileSystem;
 import dev.galasa.framework.IFileSystem;
 import dev.galasa.framework.api.common.BaseServlet;
+import dev.galasa.framework.api.common.resources.CPSFacade;
 import dev.galasa.framework.api.resources.routes.ResourcesRoute;
 import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
 import dev.galasa.framework.spi.IFramework;
@@ -47,16 +48,17 @@ public class ResourcesServlet extends BaseServlet {
 
 	@Override
 	public void init() throws ServletException {
-		logger.info("Resources Servlet initialising");
+		logger.info("Resources servlet initialising");
 
 		super.init();
 
 		try {
-            addRoute(new ResourcesRoute(getResponseBuilder(), framework));
+            addRoute(new ResourcesRoute(getResponseBuilder(), new CPSFacade(framework)));
         } catch (ConfigurationPropertyStoreException e) {
-            throw new ServletException("Failed to initialise Resources Servlet", e);
+            logger.error("Failed to initialise the Resources servlet", e);
+            throw new ServletException("Failed to initialise the Resources servlet", e);
         }
-        logger.info("Resources Servlet initialised");
+        logger.info("Resources servlet initialised");
 	}
 
     

--- a/galasa-parent/dev.galasa.framework.api.resources/src/main/java/dev/galasa/framework/api/resources/ResourcesServlet.java
+++ b/galasa-parent/dev.galasa.framework.api.resources/src/main/java/dev/galasa/framework/api/resources/ResourcesServlet.java
@@ -19,6 +19,7 @@ import dev.galasa.framework.FileSystem;
 import dev.galasa.framework.IFileSystem;
 import dev.galasa.framework.api.common.BaseServlet;
 import dev.galasa.framework.api.resources.routes.ResourcesRoute;
+import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
 import dev.galasa.framework.spi.IFramework;
 /*
  * Proxy Servlet for the /resources/* endpoints
@@ -50,8 +51,12 @@ public class ResourcesServlet extends BaseServlet {
 
 		super.init();
 
-		addRoute(new ResourcesRoute(getResponseBuilder(),framework));
-
+		try {
+            addRoute(new ResourcesRoute(getResponseBuilder(), framework));
+        } catch (ConfigurationPropertyStoreException e) {
+            throw new ServletException("Failed to initialise Resources Servlet", e);
+        }
+        logger.info("Resources Servlet initialised");
 	}
 
     

--- a/galasa-parent/dev.galasa.framework.api.resources/src/main/java/dev/galasa/framework/api/resources/routes/ResourcesRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.resources/src/main/java/dev/galasa/framework/api/resources/routes/ResourcesRoute.java
@@ -8,14 +8,12 @@ package dev.galasa.framework.api.resources.routes;
 import static dev.galasa.framework.api.common.ServletErrorMessage.*;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
 import javax.servlet.ServletException;
-import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -61,12 +59,8 @@ public class ResourcesRoute  extends BaseRoute{
      public HttpServletResponse handlePostRequest(String pathInfo, QueryParameters queryParameters, 
             HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException, FrameworkException {  
         logger.info("ResourcesRoute - handlePostRequest() entered");
-        checkRequestHasContent(request);
 
-        ServletInputStream body = request.getInputStream();
-        String jsonBody = new String (body.readAllBytes(),StandardCharsets.UTF_8);
-        body.close();
-
+        JsonObject jsonBody = parseRequestBody(request, JsonObject.class);
         List<String> errorsList = processRequest(jsonBody);
         if (errorsList.size() >0){
             response = getResponseBuilder().buildResponse(request, response, "application/json", getErrorsAsJson(errorsList), HttpServletResponse.SC_BAD_REQUEST);
@@ -80,8 +74,7 @@ public class ResourcesRoute  extends BaseRoute{
 
     }
 
-    protected List<String> processRequest(String jsonBody) throws InternalServletException{
-        JsonObject body = gson.fromJson(jsonBody, JsonObject.class);
+    protected List<String> processRequest(JsonObject body) throws InternalServletException{
         String action = body.get("action").getAsString().toLowerCase().trim();
         if (validActions.contains(action)){
             JsonArray jsonArray = body.get("data").getAsJsonArray();

--- a/galasa-parent/dev.galasa.framework.api.resources/src/main/java/dev/galasa/framework/api/resources/routes/ResourcesRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.resources/src/main/java/dev/galasa/framework/api/resources/routes/ResourcesRoute.java
@@ -33,7 +33,6 @@ import dev.galasa.framework.api.common.resources.CPSProperty;
 import dev.galasa.framework.api.common.resources.ResourceNameValidator;
 import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
 import dev.galasa.framework.spi.FrameworkException;
-import dev.galasa.framework.spi.IFramework;
 import dev.galasa.framework.spi.utils.GalasaGson;
 
 public class ResourcesRoute  extends BaseRoute{
@@ -50,9 +49,9 @@ public class ResourcesRoute  extends BaseRoute{
 
     private CPSFacade cps;
 
-    public ResourcesRoute(ResponseBuilder responseBuilder, IFramework framework) throws ConfigurationPropertyStoreException {
+    public ResourcesRoute(ResponseBuilder responseBuilder, CPSFacade cps) {
         super(responseBuilder, path);
-        this.cps = new CPSFacade(framework);
+        this.cps = cps;
     }
 
     @Override

--- a/galasa-parent/dev.galasa.framework.api.resources/src/main/java/dev/galasa/framework/api/resources/routes/ResourcesRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.resources/src/main/java/dev/galasa/framework/api/resources/routes/ResourcesRoute.java
@@ -60,10 +60,13 @@ public class ResourcesRoute  extends BaseRoute{
     @Override
      public HttpServletResponse handlePostRequest(String pathInfo, QueryParameters queryParameters, 
             HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException, FrameworkException {  
+        logger.info("ResourcesRoute - handlePostRequest() entered");
         checkRequestHasContent(request);
+
         ServletInputStream body = request.getInputStream();
         String jsonBody = new String (body.readAllBytes(),StandardCharsets.UTF_8);
         body.close();
+
         List<String> errorsList = processRequest(jsonBody);
         if (errorsList.size() >0){
             response = getResponseBuilder().buildResponse(request, response, "application/json", getErrorsAsJson(errorsList), HttpServletResponse.SC_BAD_REQUEST);
@@ -71,12 +74,13 @@ public class ResourcesRoute  extends BaseRoute{
             response = getResponseBuilder().buildResponse(request, response, "application/json", "", HttpServletResponse.SC_OK);
         }
         errors.clear();
+
+        logger.info("ResourcesRoute - handlePostRequest() exiting");
         return response;
 
     }
 
     protected List<String> processRequest(String jsonBody) throws InternalServletException{
-
         JsonObject body = gson.fromJson(jsonBody, JsonObject.class);
         String action = body.get("action").getAsString().toLowerCase().trim();
         if (validActions.contains(action)){
@@ -149,7 +153,7 @@ public class ResourcesRoute  extends BaseRoute{
                     }
 
             } else {
-                String message = "The 'metadata' field can not be empty. The fields 'name' and 'namespace' are mandaotry for the type GalasaProperty.";
+                String message = "The 'metadata' field cannot be empty. The fields 'name' and 'namespace' are mandatory for the type GalasaProperty.";
                 ServletError error = new ServletError(GAL5024_INVALID_GALASAPROPERTY, message);
                 validationErrors.add(new InternalServletException(error, HttpServletResponse.SC_BAD_REQUEST).getMessage());
             }
@@ -160,13 +164,13 @@ public class ResourcesRoute  extends BaseRoute{
                 if (data.has("value")){
                     String value = data.get("value").getAsString();
                     if (value == null || value.isBlank()) {
-                        String message = "The 'value' field can not be empty. The field 'value' is mandaotry for the type GalasaProperty.";
+                        String message = "The 'value' field cannot be empty. The field 'value' is mandatory for the type GalasaProperty.";
                         ServletError error = new ServletError(GAL5024_INVALID_GALASAPROPERTY, message);
                         validationErrors.add(new InternalServletException(error, HttpServletResponse.SC_BAD_REQUEST).getMessage());
                     }
                 }
             } else {
-                String message = "The 'data' field can not be empty. The field 'value' is mandaotry for the type GalasaProperty.";
+                String message = "The 'data' field cannot be empty. The field 'value' is mandatory for the type GalasaProperty.";
                 ServletError error = new ServletError(GAL5024_INVALID_GALASAPROPERTY, message);
                 validationErrors.add(new InternalServletException(error, HttpServletResponse.SC_BAD_REQUEST).getMessage());
             }

--- a/galasa-parent/dev.galasa.framework.api.resources/src/main/java/dev/galasa/framework/api/resources/routes/ResourcesRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.resources/src/main/java/dev/galasa/framework/api/resources/routes/ResourcesRoute.java
@@ -50,11 +50,11 @@ public class ResourcesRoute  extends BaseRoute{
     
     protected List<String> errors = new ArrayList<String>();
 
-    private IFramework framework;
+    private CPSFacade cps;
 
-    public ResourcesRoute(ResponseBuilder responseBuilder,  IFramework framework ) {
+    public ResourcesRoute(ResponseBuilder responseBuilder, IFramework framework) throws ConfigurationPropertyStoreException {
         super(responseBuilder, path);
-         this.framework = framework;
+        this.cps = new CPSFacade(framework);
     }
 
     @Override
@@ -76,7 +76,7 @@ public class ResourcesRoute  extends BaseRoute{
     }
 
     protected List<String> processRequest(String jsonBody) throws InternalServletException{
-        
+
         JsonObject body = gson.fromJson(jsonBody, JsonObject.class);
         String action = body.get("action").getAsString().toLowerCase().trim();
         if (validActions.contains(action)){
@@ -187,8 +187,8 @@ public class ResourcesRoute  extends BaseRoute{
                 String expectedApiVersion = GalasaProperty.DEFAULTAPIVERSION;
                 if (apiversion.equals(expectedApiVersion)) {
                     GalasaProperty galasaProperty = gson.fromJson(resource, GalasaProperty.class);           
-                    CPSFacade cps = new CPSFacade(framework);
                     CPSNamespace namespace = cps.getNamespace(galasaProperty.getNamespace());
+
                     //getPropertyFromStore() will only return null if the property is in a hidden namespace
                     CPSProperty property = namespace.getPropertyFromStore(galasaProperty.getName());
 

--- a/galasa-parent/dev.galasa.framework.api.resources/src/test/java/dev/galasa/framework/api/resources/routes/TestResourcesRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.resources/src/test/java/dev/galasa/framework/api/resources/routes/TestResourcesRoute.java
@@ -126,8 +126,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         MockResourcesServlet servlet = getServlet();
         IFramework framework = servlet.getFramework();
         ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
-        String jsonString = generatePropertyJSON(namespace, propertyname, value, "galasa-dev/v1alpha1");
-        JsonObject propertyJson = JsonParser.parseString(jsonString).getAsJsonObject();
+        JsonObject propertyJson = generatePropertyJson(namespace, propertyname, value, "galasa-dev/v1alpha1");
 
         //When...
         resourcesRoute.processGalasaProperty(propertyJson, "apply");
@@ -146,8 +145,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         MockResourcesServlet servlet = getServlet();
         IFramework framework = servlet.getFramework();
         ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
-        String jsonString = generatePropertyJSON(namespace, propertyname, value, "galasa-dev/v1alpha1");
-        JsonObject propertyJson = JsonParser.parseString(jsonString).getAsJsonObject();
+        JsonObject propertyJson = generatePropertyJson(namespace, propertyname, value, "galasa-dev/v1alpha1");
 
         //When...
         resourcesRoute.processGalasaProperty(propertyJson, "apply");
@@ -166,8 +164,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         MockResourcesServlet servlet = getServlet();
         IFramework framework = servlet.getFramework();
         ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
-        String jsonString = generatePropertyJSON(namespace, propertyname, value, "galasa-dev/v1alpha1");
-        JsonObject propertyJson = JsonParser.parseString(jsonString).getAsJsonObject();
+        JsonObject propertyJson = generatePropertyJson(namespace, propertyname, value, "galasa-dev/v1alpha1");
 
         //When...
         resourcesRoute.processGalasaProperty(propertyJson, "apply");
@@ -190,8 +187,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         MockResourcesServlet servlet = getServlet();
         IFramework framework = servlet.getFramework();
         ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
-        String jsonString = generatePropertyJSON(namespace, propertyname, value, "galasa-dev/v1alpha1");
-        JsonObject propertyJson = JsonParser.parseString(jsonString).getAsJsonObject();
+        JsonObject propertyJson = generatePropertyJson(namespace, propertyname, value, "galasa-dev/v1alpha1");
 
         //When...
         resourcesRoute.processGalasaProperty(propertyJson, "apply");
@@ -214,8 +210,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         MockResourcesServlet servlet = getServlet();
         IFramework framework = servlet.getFramework();
         ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
-        String jsonString = generatePropertyJSON(namespace, propertyname, value, "galasa-dev/v1alpha1");
-        JsonObject propertyJson = JsonParser.parseString(jsonString).getAsJsonObject();
+        JsonObject propertyJson = generatePropertyJson(namespace, propertyname, value, "galasa-dev/v1alpha1");
 
         //When...
         resourcesRoute.processGalasaProperty(propertyJson, "apply");
@@ -238,8 +233,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         MockResourcesServlet servlet = getServlet();
         IFramework framework = servlet.getFramework();
         ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
-        String jsonString = generatePropertyJSON(namespace, propertyname, value, "galasa-dev/v1alpha1");
-        JsonObject propertyJson = JsonParser.parseString(jsonString).getAsJsonObject();
+        JsonObject propertyJson = generatePropertyJson(namespace, propertyname, value, "galasa-dev/v1alpha1");
 
         //When...
         resourcesRoute.processGalasaProperty(propertyJson, "apply");
@@ -262,8 +256,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         MockResourcesServlet servlet = getServlet();
         IFramework framework = servlet.getFramework();
         ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
-        String jsonString = generatePropertyJSON(namespace, propertyname, value, "galasa-dev/v1alpha1");
-        JsonObject propertyJson = JsonParser.parseString(jsonString).getAsJsonObject();
+        JsonObject propertyJson = generatePropertyJson(namespace, propertyname, value, "galasa-dev/v1alpha1");
 
         //When...
         resourcesRoute.processGalasaProperty(propertyJson, "apply");
@@ -286,8 +279,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         MockResourcesServlet servlet = getServlet();
         IFramework framework = servlet.getFramework();
         ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
-        String jsonString = generatePropertyJSON(namespace, propertyname, value, "galasa-dev/v1alpha1");
-        JsonObject propertyJson = JsonParser.parseString(jsonString).getAsJsonObject();
+        JsonObject propertyJson = generatePropertyJson(namespace, propertyname, value, "galasa-dev/v1alpha1");
 
         //When...
         resourcesRoute.processGalasaProperty(propertyJson, "apply");
@@ -310,8 +302,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         MockResourcesServlet servlet = getServlet();
         IFramework framework = servlet.getFramework();
         ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
-        String jsonString = generatePropertyJSON(namespace, propertyname, value, "galasa-dev/v1alpha1");
-        JsonObject propertyJson = JsonParser.parseString(jsonString).getAsJsonObject();
+        JsonObject propertyJson = generatePropertyJson(namespace, propertyname, value, "galasa-dev/v1alpha1");
 
         //When...
         resourcesRoute.processGalasaProperty(propertyJson, "apply");
@@ -334,8 +325,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         MockResourcesServlet servlet = getServlet();
         IFramework framework = servlet.getFramework();
         ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
-        String jsonString = generatePropertyJSON(namespace, propertyname, value, "galasa-dev/v1alpha1");
-        JsonObject propertyJson = JsonParser.parseString(jsonString).getAsJsonObject();
+        JsonObject propertyJson = generatePropertyJson(namespace, propertyname, value, "galasa-dev/v1alpha1");
 
         //When...
         resourcesRoute.processGalasaProperty(propertyJson, "apply");
@@ -358,8 +348,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         MockResourcesServlet servlet = getServlet();
         IFramework framework = servlet.getFramework();
         ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
-        String jsonString = generatePropertyJSON(namespace, propertyname, value, "galasa-dev/v1alpha1");
-        JsonObject propertyJson = JsonParser.parseString(jsonString).getAsJsonObject();
+        JsonObject propertyJson = generatePropertyJson(namespace, propertyname, value, "galasa-dev/v1alpha1");
 
         //When...
         resourcesRoute.processGalasaProperty(propertyJson, "apply");
@@ -382,8 +371,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         MockResourcesServlet servlet = getServlet();
         IFramework framework = servlet.getFramework();
         ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
-        String jsonString = generatePropertyJSON(namespace, propertyname, value, "galasa-dev/v1alpha1");
-        JsonObject propertyJson = JsonParser.parseString(jsonString).getAsJsonObject();
+        JsonObject propertyJson = generatePropertyJson(namespace, propertyname, value, "galasa-dev/v1alpha1");
 
         //When...
         resourcesRoute.processGalasaProperty(propertyJson, "apply");
@@ -407,8 +395,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         MockResourcesServlet servlet = getServlet();
         IFramework framework = servlet.getFramework();
         ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
-        String jsonString = generatePropertyJSON(namespace, propertyname, value, "galasa-dev/v1alpha1");
-        JsonObject propertyJson = JsonParser.parseString(jsonString).getAsJsonObject();
+        JsonObject propertyJson = generatePropertyJson(namespace, propertyname, value, "galasa-dev/v1alpha1");
 
         //When...
         resourcesRoute.processGalasaProperty(propertyJson, "apply");
@@ -460,8 +447,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         MockResourcesServlet servlet = getServlet();
         IFramework framework = servlet.getFramework();
         ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
-        String jsonString = generatePropertyJSON(namespace, propertyname, value, "");
-        JsonObject propertyJson = JsonParser.parseString(jsonString).getAsJsonObject();
+        JsonObject propertyJson = generatePropertyJson(namespace, propertyname, value, "");
 
         //When...
         Throwable thrown = catchThrowable(() -> {
@@ -601,8 +587,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         MockResourcesServlet servlet = getServlet();
         IFramework framework = servlet.getFramework();
         ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
-        String jsonString = generateArrayJson(namespace,propertyname,value,"galasa-dev/v1alpha1");
-        JsonArray propertyJson = JsonParser.parseString(jsonString).getAsJsonArray();
+        JsonArray propertyJson = generatePropertyArrayJson(namespace,propertyname,value,"galasa-dev/v1alpha1");
 
         //When...
         resourcesRoute.processDataArray(propertyJson, "apply");
@@ -654,8 +639,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         MockResourcesServlet servlet = getServlet();
         IFramework framework = servlet.getFramework();
         ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
-        String jsonString ="["+ generatePropertyJSON(namespace,propertyname,value,"galasa-dev/v1alpha1");
-        jsonString = jsonString+","+ generatePropertyJSON(namespace,propertyNameTwo,valueTwo,"galasa-dev/v1alpha1") +"]";
+        String jsonString ="["+ generatePropertyJson(namespace,propertyname,value,"galasa-dev/v1alpha1");
+        jsonString = jsonString+","+ generatePropertyJson(namespace,propertyNameTwo,valueTwo,"galasa-dev/v1alpha1") +"]";
         JsonArray propertyJson = JsonParser.parseString(jsonString).getAsJsonArray();
 
         //When...
@@ -682,8 +667,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         MockResourcesServlet servlet = getServlet();
         IFramework framework = servlet.getFramework();
         ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
-        String jsonString ="["+ generatePropertyJSON(namespace,propertyname,value,"galasa-dev/v1alpha1");
-        jsonString = jsonString+","+ generatePropertyJSON(namespace,propertyNameTwo,valueTwo,"galasa-dev/v1alpha1") +"]";
+        String jsonString ="["+ generatePropertyJson(namespace,propertyname,value,"galasa-dev/v1alpha1");
+        jsonString = jsonString+","+ generatePropertyJson(namespace,propertyNameTwo,valueTwo,"galasa-dev/v1alpha1") +"]";
         JsonArray propertyJson = JsonParser.parseString(jsonString).getAsJsonArray();
 
         //When...
@@ -712,8 +697,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         MockResourcesServlet servlet = getServlet();
         IFramework framework = servlet.getFramework();
         ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
-        String jsonString ="["+ generatePropertyJSON(namespace,propertyname,value,"galasa-dev/v1alpha1");
-        jsonString = jsonString+","+ generatePropertyJSON(namespace,propertyNameTwo,valueTwo,"galasa-dev/v1alpha1") +"]";
+        String jsonString ="["+ generatePropertyJson(namespace,propertyname,value,"galasa-dev/v1alpha1");
+        jsonString = jsonString+","+ generatePropertyJson(namespace,propertyNameTwo,valueTwo,"galasa-dev/v1alpha1") +"]";
         JsonArray propertyJson = JsonParser.parseString(jsonString).getAsJsonArray();
 
         //When...
@@ -739,8 +724,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         MockResourcesServlet servlet = getServlet();
         IFramework framework = servlet.getFramework();
         ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
-        String jsonString ="["+ generatePropertyJSON(namespace,propertyname,value,"galasa-dev/v1alpha1");
-        jsonString = jsonString+","+ generatePropertyJSON(namespace,propertyNameTwo,valueTwo,"galasa-dev/v1alpha1") +"]";
+        String jsonString ="["+ generatePropertyJson(namespace,propertyname,value,"galasa-dev/v1alpha1");
+        jsonString = jsonString+","+ generatePropertyJson(namespace,propertyNameTwo,valueTwo,"galasa-dev/v1alpha1") +"]";
         JsonArray propertyJson = JsonParser.parseString(jsonString).getAsJsonArray();
 
         //When...
@@ -770,10 +755,10 @@ public class TestResourcesRoute extends ResourcesServletTest{
         MockResourcesServlet servlet = getServlet();
         IFramework framework = servlet.getFramework();
         ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
-        String jsonString = generateRequestJson(action, namespace,propertyname,value,"galasa-dev/v1alpha1");
+        JsonObject requestJson = generateRequestJson(action, namespace,propertyname,value,"galasa-dev/v1alpha1");
 
         //When...
-        resourcesRoute.processRequest(jsonString);
+        resourcesRoute.processRequest(requestJson);
         List<String> errors = resourcesRoute.errors;
 
         //Then...
@@ -792,7 +777,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         MockResourcesServlet servlet = getServlet();
         IFramework framework = servlet.getFramework();
         ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
-        String jsonString = generateRequestJson(action, namespace,propertyname,value,"galasa-dev/v1alpha1");
+        JsonObject jsonString = generateRequestJson(action, namespace,propertyname,value,"galasa-dev/v1alpha1");
 
         //When...
         resourcesRoute.processRequest(jsonString);
@@ -814,7 +799,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         MockResourcesServlet servlet = getServlet();
         IFramework framework = servlet.getFramework();
         ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
-        String jsonString = generateRequestJson(action, namespace,propertyname,value,"galasa-dev/v1alpha1");
+        JsonObject jsonString = generateRequestJson(action, namespace,propertyname,value,"galasa-dev/v1alpha1");
 
         //When...
         resourcesRoute.processRequest(jsonString);
@@ -836,7 +821,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         MockResourcesServlet servlet = getServlet();
         IFramework framework = servlet.getFramework();
         ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
-        String jsonString = generateRequestJson(action, namespace,propertyname,value,"galasa-dev/v1alpha1");
+        JsonObject jsonString = generateRequestJson(action, namespace,propertyname,value,"galasa-dev/v1alpha1");
 
         //When...
         Throwable thrown = catchThrowable(() -> {
@@ -861,8 +846,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String propertyname = "property.name";
         String value = "value";
         String action = "apply";
-		String propertyJSON = generateRequestJson(action, namespace, propertyname,value,"galasa-dev/v1alpha1");
-		setServlet("/", namespace, propertyJSON , "POST");
+		JsonObject propertyJson = generateRequestJson(action, namespace, propertyname,value,"galasa-dev/v1alpha1");
+		setServlet("/", namespace, propertyJson , "POST");
 		MockResourcesServlet servlet = getServlet();
 		HttpServletRequest req = getRequest();
 		HttpServletResponse resp = getResponse();
@@ -885,8 +870,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String propertyname = "property.name";
         String value = "value";
         String action = "create";
-		String propertyJSON = generateRequestJson(action, namespace, propertyname,value,"galasa-dev/v1alpha1");
-		setServlet("/", namespace, propertyJSON , "POST");
+		JsonObject propertyJson = generateRequestJson(action, namespace, propertyname,value,"galasa-dev/v1alpha1");
+		setServlet("/", namespace, propertyJson , "POST");
 		MockResourcesServlet servlet = getServlet();
 		HttpServletRequest req = getRequest();
 		HttpServletResponse resp = getResponse();
@@ -909,8 +894,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String propertyname = "property.name";
         String value = "value";
         String action = "update";
-		String propertyJSON = generateRequestJson(action, namespace, propertyname,value,"galasa-dev/v1alpha1");
-		setServlet("/", namespace, propertyJSON , "POST");
+		JsonObject propertyJson = generateRequestJson(action, namespace, propertyname,value,"galasa-dev/v1alpha1");
+		setServlet("/", namespace, propertyJson , "POST");
 		MockResourcesServlet servlet = getServlet();
 		HttpServletRequest req = getRequest();
 		HttpServletResponse resp = getResponse();
@@ -939,10 +924,10 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String valuetwo = "value";
         String apiVersion = "galasa-dev/v1alpha1";
         String action = "apply";
-        String propertyone = generatePropertyJSON(namespace, propertyname, value, apiVersion);
-        String propertytwo = generatePropertyJSON(namespace, propertynametwo, valuetwo, apiVersion);
-		String propertyJSON = "{\n \"action\":\""+action+"\", \"data\":["+propertyone+","+propertytwo+"]\n}";
-		setServlet("/", namespace, propertyJSON , "POST");
+        JsonObject propertyone = generatePropertyJson(namespace, propertyname, value, apiVersion);
+        JsonObject propertytwo = generatePropertyJson(namespace, propertynametwo, valuetwo, apiVersion);
+		JsonObject propertyJson = generateRequestJson(action, List.of(propertyone, propertytwo));
+		setServlet("/", namespace, propertyJson , "POST");
 		MockResourcesServlet servlet = getServlet();
 		HttpServletRequest req = getRequest();
 		HttpServletResponse resp = getResponse();
@@ -966,8 +951,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String propertyname = "property.1";
         String value = "newvalue";
         String action = "apply";
-		String propertyJSON = generateRequestJson(action, namespace, propertyname,value,"galasa-dev/v1alpha1");
-		setServlet("/", namespace, propertyJSON , "POST");
+		JsonObject propertyJson = generateRequestJson(action, namespace, propertyname,value,"galasa-dev/v1alpha1");
+		setServlet("/", namespace, propertyJson , "POST");
 		MockResourcesServlet servlet = getServlet();
 		HttpServletRequest req = getRequest();
 		HttpServletResponse resp = getResponse();
@@ -990,8 +975,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String propertyname = "property.1";
         String value = "newvalue";
         String action = "create";
-		String propertyJSON = generateRequestJson(action, namespace, propertyname,value,"galasa-dev/v1alpha1");
-		setServlet("/", namespace, propertyJSON , "POST");
+		JsonObject propertyJson = generateRequestJson(action, namespace, propertyname,value,"galasa-dev/v1alpha1");
+		setServlet("/", namespace, propertyJson , "POST");
 		MockResourcesServlet servlet = getServlet();
 		HttpServletRequest req = getRequest();
 		HttpServletResponse resp = getResponse();
@@ -1017,8 +1002,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String propertyname = "property.1";
         String value = "newvalue";
         String action = "update";
-		String propertyJSON = generateRequestJson(action, namespace, propertyname,value,"galasa-dev/v1alpha1");
-		setServlet("/", namespace, propertyJSON , "POST");
+		JsonObject propertyJson = generateRequestJson(action, namespace, propertyname,value,"galasa-dev/v1alpha1");
+		setServlet("/", namespace, propertyJson , "POST");
 		MockResourcesServlet servlet = getServlet();
 		HttpServletRequest req = getRequest();
 		HttpServletResponse resp = getResponse();	
@@ -1044,10 +1029,10 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String valuetwo = "newvalue";
         String apiVersion = "galasa-dev/v1alpha1";
         String action = "apply";
-        String propertyone = generatePropertyJSON(namespace, propertyname, value, apiVersion);
-        String propertytwo = generatePropertyJSON(namespace, propertynametwo, valuetwo, apiVersion);
-		String propertyJSON = "{\n \"action\":\""+action+"\", \"data\":["+propertyone+","+propertytwo+"]\n}";
-		setServlet("/", namespace, propertyJSON , "POST");
+        JsonObject propertyone = generatePropertyJson(namespace, propertyname, value, apiVersion);
+        JsonObject propertytwo = generatePropertyJson(namespace, propertynametwo, valuetwo, apiVersion);
+		JsonObject propertyJson = generateRequestJson(action, List.of(propertyone, propertytwo));
+		setServlet("/", namespace, propertyJson , "POST");
 		MockResourcesServlet servlet = getServlet();
 		HttpServletRequest req = getRequest();
 		HttpServletResponse resp = getResponse();
@@ -1074,10 +1059,10 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String valuetwo = "newvalue";
         String apiVersion = "galasa-dev/v1alpha1";
         String action = "apply";
-        String propertyone = generatePropertyJSON(namespace, propertyname, value, apiVersion);
-        String propertytwo = generatePropertyJSON(namespace, propertynametwo, valuetwo, apiVersion);
-		String propertyJSON = "{\n \"action\":\""+action+"\", \"data\":["+propertyone+","+propertytwo+"]\n}";
-		setServlet("/", namespace, propertyJSON , "POST");
+        JsonObject propertyone = generatePropertyJson(namespace, propertyname, value, apiVersion);
+        JsonObject propertytwo = generatePropertyJson(namespace, propertynametwo, valuetwo, apiVersion);
+		JsonObject propertyJson = generateRequestJson(action, List.of(propertyone, propertytwo));
+		setServlet("/", namespace, propertyJson , "POST");
 		MockResourcesServlet servlet = getServlet();
 		HttpServletRequest req = getRequest();
 		HttpServletResponse resp = getResponse();
@@ -1101,8 +1086,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String propertyname = "property.1";
         String value = "value1";
         String action = "delete";
-		String propertyJSON = generateRequestJson(action, namespace, propertyname,value,"galasa-dev/v1alpha1");
-		setServlet("/", namespace, propertyJSON , "POST");
+		JsonObject propertyJson = generateRequestJson(action, namespace, propertyname,value,"galasa-dev/v1alpha1");
+		setServlet("/", namespace, propertyJson , "POST");
 		MockResourcesServlet servlet = getServlet();
 		HttpServletRequest req = getRequest();
 		HttpServletResponse resp = getResponse();	
@@ -1128,10 +1113,10 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String valuetwo = "value1";
         String apiVersion = "galasa-dev/v1alpha1";
         String action = "delete";
-        String propertyone = generatePropertyJSON(namespace, propertyname, value, apiVersion);
-        String propertytwo = generatePropertyJSON(namespace, propertynametwo, valuetwo, apiVersion);
-		String propertyJSON = "{\n \"action\":\""+action+"\", \"data\":["+propertyone+","+propertytwo+"]\n}";
-		setServlet("/", namespace, propertyJSON , "POST");
+        JsonObject propertyone = generatePropertyJson(namespace, propertyname, value, apiVersion);
+        JsonObject propertytwo = generatePropertyJson(namespace, propertynametwo, valuetwo, apiVersion);
+		JsonObject propertyJson = generateRequestJson(action, List.of(propertyone, propertytwo));
+		setServlet("/", namespace, propertyJson , "POST");
 		MockResourcesServlet servlet = getServlet();
 		HttpServletRequest req = getRequest();
 		HttpServletResponse resp = getResponse();
@@ -1155,8 +1140,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String propertyname = "property.10";
         String value = "newvalue";
         String action = "delete";
-		String propertyJSON = generateRequestJson(action, namespace, propertyname,value,"galasa-dev/v1alpha1");
-		setServlet("/", namespace, propertyJSON , "POST");
+		JsonObject propertyJson = generateRequestJson(action, namespace, propertyname,value,"galasa-dev/v1alpha1");
+		setServlet("/", namespace, propertyJson , "POST");
 		MockResourcesServlet servlet = getServlet();
 		HttpServletRequest req = getRequest();
 		HttpServletResponse resp = getResponse();	
@@ -1182,10 +1167,10 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String valuetwo = "value1";
         String apiVersion = "galasa-dev/v1alpha1";
         String action = "delete";
-        String propertyone = generatePropertyJSON(namespace, propertyname, value, apiVersion);
-        String propertytwo = generatePropertyJSON(namespace, propertynametwo, valuetwo, apiVersion);
-		String propertyJSON = "{\n \"action\":\""+action+"\", \"data\":["+propertyone+","+propertytwo+"]\n}";
-		setServlet("/", namespace, propertyJSON , "POST");
+        JsonObject propertyone = generatePropertyJson(namespace, propertyname, value, apiVersion);
+        JsonObject propertytwo = generatePropertyJson(namespace, propertynametwo, valuetwo, apiVersion);
+		JsonObject propertyJson = generateRequestJson(action, List.of(propertyone, propertytwo));
+		setServlet("/", namespace, propertyJson , "POST");
 		MockResourcesServlet servlet = getServlet();
 		HttpServletRequest req = getRequest();
 		HttpServletResponse resp = getResponse();
@@ -1212,10 +1197,10 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String valuetwo = "value1";
         String apiVersion = "galasa-dev/v1alpha1";
         String action = "delete";
-        String propertyone = generatePropertyJSON(namespace, propertyname, value, apiVersion);
-        String propertytwo = generatePropertyJSON(namespace, propertynametwo, valuetwo, apiVersion);
-		String propertyJSON = "{\n \"action\":\""+action+"\", \"data\":["+propertyone+","+propertytwo+"]\n}";
-		setServlet("/", namespace, propertyJSON , "POST");
+        JsonObject propertyone = generatePropertyJson(namespace, propertyname, value, apiVersion);
+        JsonObject propertytwo = generatePropertyJson(namespace, propertynametwo, valuetwo, apiVersion);
+		JsonObject propertyJson = generateRequestJson(action, List.of(propertyone, propertytwo));
+		setServlet("/", namespace, propertyJson , "POST");
 		MockResourcesServlet servlet = getServlet();
 		HttpServletRequest req = getRequest();
 		HttpServletResponse resp = getResponse();
@@ -1239,8 +1224,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String propertyname = "property.1";
         String value = "value1";
         String action = "delete";
-		String propertyJSON = generateRequestJson(action, namespace, propertyname,value,"galasa-dev/v1alpha1");
-		setServlet("/", null, propertyJSON , "POST");
+		JsonObject propertyJson = generateRequestJson(action, namespace, propertyname,value,"galasa-dev/v1alpha1");
+		setServlet("/", null, propertyJson , "POST");
 		MockResourcesServlet servlet = getServlet();
 		HttpServletRequest req = getRequest();
 		HttpServletResponse resp = getResponse();	
@@ -1269,10 +1254,10 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String valuetwo = "value1";
         String apiVersion = "galasa-dev/v1alpha1";
         String action = "delete";
-        String propertyone = generatePropertyJSON(namespace, propertyname, value, apiVersion);
-        String propertytwo = generatePropertyJSON(namespace, propertynametwo, valuetwo, apiVersion);
-		String propertyJSON = "{\n \"action\":\""+action+"\", \"data\":["+propertyone+","+propertytwo+"]\n}";
-		setServlet("/", null, propertyJSON , "POST");
+        JsonObject propertyone = generatePropertyJson(namespace, propertyname, value, apiVersion);
+        JsonObject propertytwo = generatePropertyJson(namespace, propertynametwo, valuetwo, apiVersion);
+		JsonObject propertyJson = generateRequestJson(action, List.of(propertyone, propertytwo));
+		setServlet("/", null, propertyJson , "POST");
 		MockResourcesServlet servlet = getServlet();
 		HttpServletRequest req = getRequest();
 		HttpServletResponse resp = getResponse();
@@ -1303,10 +1288,16 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String valuetwo = "newvalue";
         String apiVersion = "galasa-dev/v1alpha1";
         String action = "apply";
-        String propertyone = generatePropertyJSON(namespace, propertyname, value, apiVersion);
-        String propertytwo = generatePropertyJSON(namespace, propertynametwo, valuetwo, apiVersion);
-		String propertyJSON = "{\n \"action\":\""+action+"\", \"data\":[null,"+propertyone+","+propertytwo+"]\n}";
-		setServlet("/", namespace, propertyJSON , "POST");
+        JsonObject propertyone = generatePropertyJson(namespace, propertyname, value, apiVersion);
+        JsonObject propertytwo = generatePropertyJson(namespace, propertynametwo, valuetwo, apiVersion);
+
+        List<JsonObject> propertyList = new ArrayList<>();
+        propertyList.add(null);
+        propertyList.add(propertyone);
+        propertyList.add(propertytwo);
+
+		JsonObject propertyJson = generateRequestJson(action, propertyList);
+		setServlet("/", namespace, propertyJson , "POST");
 		MockResourcesServlet servlet = getServlet();
 		HttpServletRequest req = getRequest();
 		HttpServletResponse resp = getResponse();
@@ -1329,8 +1320,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
     @Test
     public void TestHandlePOSTwithNoDataReturnsOK() throws Exception {
         // Given...
-		String propertyJSON = "{\n \"action\":\"apply\", \"data\":[]\n}";
-		setServlet("/", "framework", propertyJSON , "POST");
+		JsonObject propertyJson = generateRequestJson("apply", new ArrayList<>());
+		setServlet("/", "framework", propertyJson , "POST");
 		MockResourcesServlet servlet = getServlet();
 		HttpServletRequest req = getRequest();
 		HttpServletResponse resp = getResponse();
@@ -1389,13 +1380,13 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String valuetwo = "value1";
         String apiVersion = "galasa-dev/v1alpha1";
         String action = "delete";
-        String propertyone = generatePropertyJSON(namespace, propertyname, value, apiVersion);
-        String propertytwo = generatePropertyJSON(namespace, propertynametwo, valuetwo, apiVersion);
-		String propertyJSON = "{\n \"action\":\""+action+"\", \"data\":["+propertyone+","+propertytwo+"]\n}";
+        JsonObject propertyone = generatePropertyJson(namespace, propertyname, value, apiVersion);
+        JsonObject propertytwo = generatePropertyJson(namespace, propertynametwo, valuetwo, apiVersion);
+		JsonObject propertyJson = generateRequestJson(action, List.of(propertyone, propertytwo));
         Map<String, String> headers = new HashMap<String,String>();
         headers.put("Accept", "application/xml");
-		setServlet("/", "framework", propertyJSON , "POST", headers);
-		setServlet("/", null, propertyJSON , "POST");
+		setServlet("/", "framework", propertyJson , "POST", headers);
+		setServlet("/", null, propertyJson , "POST");
 		MockResourcesServlet servlet = getServlet();
 		HttpServletRequest req = getRequest();
 		HttpServletResponse resp = getResponse();

--- a/galasa-parent/dev.galasa.framework.api.resources/src/test/java/dev/galasa/framework/api/resources/routes/TestResourcesRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.resources/src/test/java/dev/galasa/framework/api/resources/routes/TestResourcesRoute.java
@@ -23,9 +23,9 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
+import dev.galasa.framework.api.common.resources.CPSFacade;
 import dev.galasa.framework.api.resources.ResourcesServletTest;
 import dev.galasa.framework.api.resources.mocks.MockResourcesServlet;
-import dev.galasa.framework.spi.IFramework;
 import dev.galasa.framework.spi.utils.GalasaGson;
 
 public class TestResourcesRoute extends ResourcesServletTest{
@@ -124,8 +124,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String value = "myvalue";
         setServlet(namespace);
         MockResourcesServlet servlet = getServlet();
-        IFramework framework = servlet.getFramework();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
+        CPSFacade cps = new CPSFacade(servlet.getFramework());
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps);
         JsonObject propertyJson = generatePropertyJson(namespace, propertyname, value, "galasa-dev/v1alpha1");
 
         //When...
@@ -143,8 +143,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String value = "myvalue";
         setServlet("framework");
         MockResourcesServlet servlet = getServlet();
-        IFramework framework = servlet.getFramework();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
+        CPSFacade cps = new CPSFacade(servlet.getFramework());
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps);
         JsonObject propertyJson = generatePropertyJson(namespace, propertyname, value, "galasa-dev/v1alpha1");
 
         //When...
@@ -162,8 +162,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String value = "myvalue";
         setServlet(namespace);
         MockResourcesServlet servlet = getServlet();
-        IFramework framework = servlet.getFramework();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
+        CPSFacade cps = new CPSFacade(servlet.getFramework());
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps);
         JsonObject propertyJson = generatePropertyJson(namespace, propertyname, value, "galasa-dev/v1alpha1");
 
         //When...
@@ -185,8 +185,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String value = "myvalue";
         setServlet(namespace);
         MockResourcesServlet servlet = getServlet();
-        IFramework framework = servlet.getFramework();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
+        CPSFacade cps = new CPSFacade(servlet.getFramework());
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps);
         JsonObject propertyJson = generatePropertyJson(namespace, propertyname, value, "galasa-dev/v1alpha1");
 
         //When...
@@ -208,8 +208,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String value = "myvalue";
         setServlet(namespace);
         MockResourcesServlet servlet = getServlet();
-        IFramework framework = servlet.getFramework();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
+        CPSFacade cps = new CPSFacade(servlet.getFramework());
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps);
         JsonObject propertyJson = generatePropertyJson(namespace, propertyname, value, "galasa-dev/v1alpha1");
 
         //When...
@@ -231,8 +231,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String value = "myvalue";
         setServlet(namespace);
         MockResourcesServlet servlet = getServlet();
-        IFramework framework = servlet.getFramework();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
+        CPSFacade cps = new CPSFacade(servlet.getFramework());
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps);
         JsonObject propertyJson = generatePropertyJson(namespace, propertyname, value, "galasa-dev/v1alpha1");
 
         //When...
@@ -254,8 +254,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String value = "myvalue";
         setServlet(namespace);
         MockResourcesServlet servlet = getServlet();
-        IFramework framework = servlet.getFramework();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
+        CPSFacade cps = new CPSFacade(servlet.getFramework());
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps);
         JsonObject propertyJson = generatePropertyJson(namespace, propertyname, value, "galasa-dev/v1alpha1");
 
         //When...
@@ -277,8 +277,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String value = "myvalue";
         setServlet(namespace);
         MockResourcesServlet servlet = getServlet();
-        IFramework framework = servlet.getFramework();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
+        CPSFacade cps = new CPSFacade(servlet.getFramework());
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps);
         JsonObject propertyJson = generatePropertyJson(namespace, propertyname, value, "galasa-dev/v1alpha1");
 
         //When...
@@ -300,8 +300,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String value = "myvalue";
         setServlet(namespace);
         MockResourcesServlet servlet = getServlet();
-        IFramework framework = servlet.getFramework();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
+        CPSFacade cps = new CPSFacade(servlet.getFramework());
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps);
         JsonObject propertyJson = generatePropertyJson(namespace, propertyname, value, "galasa-dev/v1alpha1");
 
         //When...
@@ -323,8 +323,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String value = "myvalue";
         setServlet(namespace);
         MockResourcesServlet servlet = getServlet();
-        IFramework framework = servlet.getFramework();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
+        CPSFacade cps = new CPSFacade(servlet.getFramework());
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps);
         JsonObject propertyJson = generatePropertyJson(namespace, propertyname, value, "galasa-dev/v1alpha1");
 
         //When...
@@ -346,8 +346,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String value = "myvalue";
         setServlet(namespace);
         MockResourcesServlet servlet = getServlet();
-        IFramework framework = servlet.getFramework();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
+        CPSFacade cps = new CPSFacade(servlet.getFramework());
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps);
         JsonObject propertyJson = generatePropertyJson(namespace, propertyname, value, "galasa-dev/v1alpha1");
 
         //When...
@@ -369,8 +369,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String value = "";
         setServlet(namespace);
         MockResourcesServlet servlet = getServlet();
-        IFramework framework = servlet.getFramework();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
+        CPSFacade cps = new CPSFacade(servlet.getFramework());
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps);
         JsonObject propertyJson = generatePropertyJson(namespace, propertyname, value, "galasa-dev/v1alpha1");
 
         //When...
@@ -393,8 +393,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String value = "";
         setServlet(namespace);
         MockResourcesServlet servlet = getServlet();
-        IFramework framework = servlet.getFramework();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
+        CPSFacade cps = new CPSFacade(servlet.getFramework());
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps);
         JsonObject propertyJson = generatePropertyJson(namespace, propertyname, value, "galasa-dev/v1alpha1");
 
         //When...
@@ -418,8 +418,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String value = "";
         setServlet(namespace);
         MockResourcesServlet servlet = getServlet();
-        IFramework framework = servlet.getFramework();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
+        CPSFacade cps = new CPSFacade(servlet.getFramework());
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps);
         String jsonString = "{\"apiVersion\": \"galasa-dev/v1alpha1\",\n\"kind\": \"GalasaProperty\",\"metadata\": {},\"data\": {}}";
         JsonObject propertyJson = JsonParser.parseString(jsonString).getAsJsonObject();
 
@@ -445,8 +445,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String value = "value";
         setServlet(namespace);
         MockResourcesServlet servlet = getServlet();
-        IFramework framework = servlet.getFramework();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
+        CPSFacade cps = new CPSFacade(servlet.getFramework());
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps);
         JsonObject propertyJson = generatePropertyJson(namespace, propertyname, value, "");
 
         //When...
@@ -470,8 +470,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String value = "value";
         setServlet(namespace);
         MockResourcesServlet servlet = getServlet();
-        IFramework framework = servlet.getFramework();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
+        CPSFacade cps = new CPSFacade(servlet.getFramework());
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps);
         String jsonString = "{\"apiVersion\":\"galasa-dev/v1alpha1\","+namespace+"."+propertyname+":"+value+"}";
         JsonObject propertyJson = JsonParser.parseString(jsonString).getAsJsonObject();
 
@@ -494,8 +494,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String value = "value";
         setServlet(namespace);
         MockResourcesServlet servlet = getServlet();
-        IFramework framework = servlet.getFramework();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
+        CPSFacade cps = new CPSFacade(servlet.getFramework());
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps);
         String jsonString = "[{},{},{}]";
         JsonArray propertyJson = JsonParser.parseString(jsonString).getAsJsonArray();
 
@@ -517,8 +517,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String value = "value";
         setServlet(namespace);
         MockResourcesServlet servlet = getServlet();
-        IFramework framework = servlet.getFramework();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
+        CPSFacade cps = new CPSFacade(servlet.getFramework());
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps);
         String jsonString = "[{\"kind\":\"GalasaProperty\",\"apiVersion\":\"galasa-dev/v1alpha1\","+namespace+"."+propertyname+":"+value+"}]";
         JsonArray propertyJson = JsonParser.parseString(jsonString).getAsJsonArray();
 
@@ -540,8 +540,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String value = "value";
         setServlet(namespace);
         MockResourcesServlet servlet = getServlet();
-        IFramework framework = servlet.getFramework();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
+        CPSFacade cps = new CPSFacade(servlet.getFramework());
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps);
         String jsonString = "[{\"kind\":\"GalasaProperly\",\"apiVersion\":\"v1alpha1\","+namespace+"."+propertyname+":"+value+"}]";
         JsonArray propertyJson = JsonParser.parseString(jsonString).getAsJsonArray();
 
@@ -563,8 +563,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String namespace = "framework";
         setServlet(namespace);
         MockResourcesServlet servlet = getServlet();
-        IFramework framework = servlet.getFramework();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
+        CPSFacade cps = new CPSFacade(servlet.getFramework());
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps);
         String jsonString = "[null]";
         JsonArray propertyJson = JsonParser.parseString(jsonString).getAsJsonArray();
 
@@ -585,8 +585,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String value = "value";
         setServlet(namespace);
         MockResourcesServlet servlet = getServlet();
-        IFramework framework = servlet.getFramework();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
+        CPSFacade cps = new CPSFacade(servlet.getFramework());
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps);
         JsonArray propertyJson = generatePropertyArrayJson(namespace,propertyname,value,"galasa-dev/v1alpha1");
 
         //When...
@@ -606,8 +606,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String value = "value";
         setServlet(namespace);
         MockResourcesServlet servlet = getServlet();
-        IFramework framework = servlet.getFramework();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
+        CPSFacade cps = new CPSFacade(servlet.getFramework());
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps);
         String jsonString = "[null, {\"kind\":\"GalasaProperty\",\"apiVersion\":\"galasa-dev/v1alpha1\","+namespace+"."+propertyname+":"+value+"},"+
             "{\"kind\":\"GalasaProperly\",\"apiVersion\":\"v1alpha1\","+namespace+"."+propertyname+":"+value+"},{}]";
         JsonArray propertyJson = JsonParser.parseString(jsonString).getAsJsonArray();
@@ -637,8 +637,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String valueTwo = "random";
         setServlet(namespace);
         MockResourcesServlet servlet = getServlet();
-        IFramework framework = servlet.getFramework();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
+        CPSFacade cps = new CPSFacade(servlet.getFramework());
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps);
         String jsonString ="["+ generatePropertyJson(namespace,propertyname,value,"galasa-dev/v1alpha1");
         jsonString = jsonString+","+ generatePropertyJson(namespace,propertyNameTwo,valueTwo,"galasa-dev/v1alpha1") +"]";
         JsonArray propertyJson = JsonParser.parseString(jsonString).getAsJsonArray();
@@ -665,8 +665,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String valueTwo = "random";
         setServlet(namespace);
         MockResourcesServlet servlet = getServlet();
-        IFramework framework = servlet.getFramework();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
+        CPSFacade cps = new CPSFacade(servlet.getFramework());
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps);
         String jsonString ="["+ generatePropertyJson(namespace,propertyname,value,"galasa-dev/v1alpha1");
         jsonString = jsonString+","+ generatePropertyJson(namespace,propertyNameTwo,valueTwo,"galasa-dev/v1alpha1") +"]";
         JsonArray propertyJson = JsonParser.parseString(jsonString).getAsJsonArray();
@@ -695,8 +695,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String valueTwo = "random";
         setServlet(namespace);
         MockResourcesServlet servlet = getServlet();
-        IFramework framework = servlet.getFramework();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
+        CPSFacade cps = new CPSFacade(servlet.getFramework());
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps);
         String jsonString ="["+ generatePropertyJson(namespace,propertyname,value,"galasa-dev/v1alpha1");
         jsonString = jsonString+","+ generatePropertyJson(namespace,propertyNameTwo,valueTwo,"galasa-dev/v1alpha1") +"]";
         JsonArray propertyJson = JsonParser.parseString(jsonString).getAsJsonArray();
@@ -722,8 +722,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String valueTwo = "random";
         setServlet(namespace);
         MockResourcesServlet servlet = getServlet();
-        IFramework framework = servlet.getFramework();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
+        CPSFacade cps = new CPSFacade(servlet.getFramework());
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps);
         String jsonString ="["+ generatePropertyJson(namespace,propertyname,value,"galasa-dev/v1alpha1");
         jsonString = jsonString+","+ generatePropertyJson(namespace,propertyNameTwo,valueTwo,"galasa-dev/v1alpha1") +"]";
         JsonArray propertyJson = JsonParser.parseString(jsonString).getAsJsonArray();
@@ -753,8 +753,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String action = "apply";
         setServlet(namespace);
         MockResourcesServlet servlet = getServlet();
-        IFramework framework = servlet.getFramework();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
+        CPSFacade cps = new CPSFacade(servlet.getFramework());
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps);
         JsonObject requestJson = generateRequestJson(action, namespace,propertyname,value,"galasa-dev/v1alpha1");
 
         //When...
@@ -775,8 +775,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String action = "create";
         setServlet(namespace);
         MockResourcesServlet servlet = getServlet();
-        IFramework framework = servlet.getFramework();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
+        CPSFacade cps = new CPSFacade(servlet.getFramework());
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps);
         JsonObject jsonString = generateRequestJson(action, namespace,propertyname,value,"galasa-dev/v1alpha1");
 
         //When...
@@ -797,8 +797,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String action = "apply";
         setServlet(namespace);
         MockResourcesServlet servlet = getServlet();
-        IFramework framework = servlet.getFramework();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
+        CPSFacade cps = new CPSFacade(servlet.getFramework());
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps);
         JsonObject jsonString = generateRequestJson(action, namespace,propertyname,value,"galasa-dev/v1alpha1");
 
         //When...
@@ -819,8 +819,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String action = "BadAction";
         setServlet(namespace);
         MockResourcesServlet servlet = getServlet();
-        IFramework framework = servlet.getFramework();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
+        CPSFacade cps = new CPSFacade(servlet.getFramework());
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps);
         JsonObject jsonString = generateRequestJson(action, namespace,propertyname,value,"galasa-dev/v1alpha1");
 
         //When...
@@ -1347,8 +1347,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         errors.add("{\"error_code\":5030,\"error_message\":\"GAL5030E: Error occured when trying to delete Property 'property.1'. Report the problem to your Galasa Ecosystem owner.\"}");
         setServlet("framework");
         MockResourcesServlet servlet = getServlet();
-        IFramework framework = servlet.getFramework();
-        ResourcesRoute resourcesRoute = new ResourcesRoute(null, framework);
+        CPSFacade cps = new CPSFacade(servlet.getFramework());
+        ResourcesRoute resourcesRoute = new ResourcesRoute(null, cps);
 
         // When...
         String json = resourcesRoute.getErrorsAsJson(errors);

--- a/galasa-parent/dev.galasa.framework.api.resources/src/test/java/dev/galasa/framework/api/resources/routes/TestResourcesRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.resources/src/test/java/dev/galasa/framework/api/resources/routes/TestResourcesRoute.java
@@ -393,7 +393,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         assertThat(errors).isNotNull();
         assertThat(errors.size()).isEqualTo(1);
         assertThat(errors.get(0)).contains("GAL5024E: Error occured because the Galasa Property is invalid.",
-            "The 'value' field can not be empty. The field 'value' is mandaotry for the type GalasaProperty.");
+            "The 'value' field cannot be empty. The field 'value' is mandatory for the type GalasaProperty.");
         checkPropertyNotInNamespace(namespace,propertyname,value);
     }
 
@@ -419,7 +419,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         assertThat(errors.size()).isEqualTo(3);
         assertThat(errors.get(0)).contains("GAL5040E: Invalid property name. Property name is missing or empty.");
         assertThat(errors.get(1)).contains("GAL5031E: Invalid namespace. Namespace is empty.");
-        assertThat(errors.get(2)).contains("GAL5024E: Error occured because the Galasa Property is invalid. 'The 'value' field can not be empty. The field 'value' is mandaotry for the type GalasaProperty.'");
+        assertThat(errors.get(2)).contains("GAL5024E: Error occured because the Galasa Property is invalid. 'The 'value' field cannot be empty. The field 'value' is mandatory for the type GalasaProperty.'");
         checkPropertyNotInNamespace(namespace,propertyname,value);
     }
 
@@ -444,9 +444,9 @@ public class TestResourcesRoute extends ResourcesServletTest{
         assertThat(errors).isNotNull();
         assertThat(errors.size()).isEqualTo(2);
         assertThat(errors.get(0)).contains("GAL5024E: Error occured because the Galasa Property is invalid.",
-            "The 'metadata' field can not be empty. The fields 'name' and 'namespace' are mandaotry for the type GalasaProperty.");
+            "The 'metadata' field cannot be empty. The fields 'name' and 'namespace' are mandatory for the type GalasaProperty.");
         assertThat(errors.get(1)).contains("GAL5024E: Error occured because the Galasa Property is invalid.",
-            "The 'data' field can not be empty. The field 'value' is mandaotry for the type GalasaProperty.");
+            "The 'data' field cannot be empty. The field 'value' is mandatory for the type GalasaProperty.");
         checkPropertyNotInNamespace(namespace,propertyname,value);
     }
 


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1959

## Changes
- Stopped the CPS facade class from making unnecessary calls to etcd to update a `bakedInNamespaceMap` for each GalasaProperty being processed
- Stopped updating the `bakedInNamespaceMap` when getting namespaces - it's initialised with the `framework`, `dss`, `dex`, and `secure` namespaces and these should be the only "baked-in" namespaces
- Replaced the usage of `readAllBytes` with an existing line-by-line approach to read request bodies to avoid any out-of-memory exceptions that may occur when the server receives large payloads
- Fixed typos in error messages