### PR TITLE
Fix server-side regex preventing runs download from downloading files with underscores

### DIFF
--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunArtifactsDownloadRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunArtifactsDownloadRoute.java
@@ -50,18 +50,27 @@ public class RunArtifactsDownloadRoute extends RunArtifactsRoute {
 
     static final GalasaGson gson = new GalasaGson();
 
-    protected static final String path = "\\/runs\\/([A-Za-z0-9.\\-=]+)\\/files\\/([A-Za-z0-9.\\-=\\/]+)";
+    // A pattern for artifact file paths that allows file paths containing at least one character of:
+    // Alphanumeric characters (A-Za-z0-9)
+    // periods (.)
+    // dashes (-)
+    // Equals signs (=)
+    // Underscores (_)
+    // Slashes (/)
+    // Parentheses ( '('' and ')' )
+    private static final String ARTIFACT_PATH_PATTERN = "([A-Za-z0-9.\\-=_\\/\\(\\)]+)";
+
+    // The regex pattern for the "/ras/runs/{run-id}/files/{artifact-path}" endpoint
+    private static final String path = "\\/runs\\/" + RUN_ID_PATTERN + "\\/files\\/" + ARTIFACT_PATH_PATTERN;
 
     private Map<String, IRunRootArtifact> rootArtifacts = new HashMap<>();
 
     public RunArtifactsDownloadRoute(ResponseBuilder responseBuilder, IFileSystem fileSystem, IFramework framework) {
-        //  Regex to match endpoint: /ras/runs/{runId}/files/{artifactPath}
         super(responseBuilder,
               path,
               fileSystem,
               framework
         );
-
 
         rootArtifacts.put("run.log", new RunLogArtifact());
         rootArtifacts.put("structure.json", new StructureJsonArtifact());

--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunArtifactsListRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunArtifactsListRoute.java
@@ -42,7 +42,8 @@ public class RunArtifactsListRoute extends RunArtifactsRoute {
 
     static final GalasaGson gson = new GalasaGson();
 
-    protected static final String path = "\\/runs\\/([A-Za-z0-9.\\-=]+)\\/artifacts\\/?";
+    //  Regex to match endpoint: /ras/runs/{runId}/artifacts
+    protected static final String path = "\\/runs\\/" + RUN_ID_PATTERN + "\\/artifacts\\/?";
 
     private List<IRunRootArtifact> rootArtifacts = new ArrayList<>();
 
@@ -51,7 +52,6 @@ public class RunArtifactsListRoute extends RunArtifactsRoute {
         IFileSystem fileSystem,
         IFramework framework
     ) {
-        //  Regex to match endpoint: /ras/runs/{runId}/artifacts
         super(responseBuilder, path, fileSystem, framework);
         rootArtifacts = Arrays.asList(
             new RunLogArtifact(),

--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunsRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunsRoute.java
@@ -38,6 +38,14 @@ public abstract class RunsRoute extends BaseRoute {
 
     static final GalasaGson gson = new GalasaGson();
 
+    // A pattern for run IDs allowing IDs containing at least one character of:
+    // Alphanumeric characters (A-Za-z0-9)
+    // Periods (.)
+    // Dashes (-)
+    // Equals signs (=)
+    // Underscores (_)
+    protected static final String RUN_ID_PATTERN = "([A-Za-z0-9.\\-=_]+)";
+
     // Define a default filter to accept everything
     static DirectoryStream.Filter<Path> defaultFilter = path -> { return true; };
 

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunArtifactsDownloadServlet.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunArtifactsDownloadServlet.java
@@ -37,13 +37,36 @@ public class TestRunArtifactsDownloadServlet extends RasServletTest {
      */
 
 	@Test
+	public void TestPathRegexWithAcceptedSpecialCharactersReturnsTrue() {
+		//Given...
+		Pattern expectedPath = new RunArtifactsDownloadRoute(null, null, null).getPath();
+
+		//Then...
+		assertThat(expectedPath.matcher("/runs/cdb_1234/files/my.properties").matches())
+            .as("Underscores in the run ID should be allowed")
+            .isTrue();
+
+        assertThat(expectedPath.matcher("/runs/4331cdb-1234/files/my/cps_record.properties").matches())
+            .as("Underscores in the file path should be allowed")
+            .isTrue();
+
+        assertThat(expectedPath.matcher("/runs/4331cdb_1234/files/my/cps-record.properties").matches())
+            .as("Dashes in the file path should be allowed")
+            .isTrue();
+
+        assertThat(expectedPath.matcher("/runs/4331cdb_1234/files/my/cps-record(1).properties").matches())
+            .as("Parentheses in the file path should be allowed")
+            .isTrue();
+	}
+
+	@Test
 	public void TestPathRegexExpectedLocalPathReturnsTrue(){
 		//Given...
-		String expectedPath = RunArtifactsDownloadRoute.path;
+		Pattern expectedPath = new RunArtifactsDownloadRoute(null, null, null).getPath();
 		String inputPath = "/runs/lcl-abcd-1234.run/files/run.log";
 
 		//When...
-		boolean matches = Pattern.compile(expectedPath).matcher(inputPath).matches();
+		boolean matches = expectedPath.matcher(inputPath).matches();
 
 		//Then...
 		assertThat(matches).isTrue();
@@ -52,11 +75,11 @@ public class TestRunArtifactsDownloadServlet extends RasServletTest {
 	@Test
 	public void TestPathRegexExpectedPathReturnsTrue(){
 		//Given...
-		String expectedPath = RunArtifactsDownloadRoute.path;
+		Pattern expectedPath = new RunArtifactsDownloadRoute(null, null, null).getPath();
 		String inputPath = "/runs/lcl-abcd-1234.run/files/artifacts/image123.png";
 
 		//When...
-		boolean matches = Pattern.compile(expectedPath).matcher(inputPath).matches();
+		boolean matches = expectedPath.matcher(inputPath).matches();
 
 		//Then...
 		assertThat(matches).isTrue();
@@ -65,11 +88,11 @@ public class TestRunArtifactsDownloadServlet extends RasServletTest {
 	@Test
 	public void TestPathRegexExpectedCouchDBPathReturnsTrue(){
 		//Given...
-		String expectedPath = RunArtifactsDownloadRoute.path;
+		Pattern expectedPath = new RunArtifactsDownloadRoute(null, null, null).getPath();
 		String inputPath = "/runs/cdb-efgh-5678.run/files/run.log";
 
 		//When...
-		boolean matches = Pattern.compile(expectedPath).matcher(inputPath).matches();
+		boolean matches = expectedPath.matcher(inputPath).matches();
 
 		//Then...
 		assertThat(matches).isTrue();
@@ -78,11 +101,11 @@ public class TestRunArtifactsDownloadServlet extends RasServletTest {
 	@Test
 	public void TestPathRegexLowerCasePathReturnsTrue(){
 		//Given...
-		String expectedPath = RunArtifactsDownloadRoute.path;
+		Pattern expectedPath = new RunArtifactsDownloadRoute(null, null, null).getPath();
 		String inputPath = "/runs/cdbstoredrun/files/run.log";
 
 		//When...
-		boolean matches = Pattern.compile(expectedPath).matcher(inputPath).matches();
+		boolean matches = expectedPath.matcher(inputPath).matches();
 
 		//Then...
 		assertThat(matches).isTrue();
@@ -91,11 +114,11 @@ public class TestRunArtifactsDownloadServlet extends RasServletTest {
 	@Test
 	public void TestPathRegexExpectedPathWithCapitalLeadingLetterReturnsTrue(){
 		//Given...
-		String expectedPath = RunArtifactsDownloadRoute.path;
+		Pattern expectedPath = new RunArtifactsDownloadRoute(null, null, null).getPath();
 		String inputPath = "/runs/ABC-DEFG-5678.run/files/run.log";
 
 		//When...
-		boolean matches = Pattern.compile(expectedPath).matcher(inputPath).matches();
+		boolean matches = expectedPath.matcher(inputPath).matches();
 
 		//Then...
 		assertThat(matches).isTrue();
@@ -104,11 +127,11 @@ public class TestRunArtifactsDownloadServlet extends RasServletTest {
 	@Test
 	public void TestPathRegexUpperCasePathReturnsFalse(){
 		//Given...
-		String expectedPath = RunArtifactsDownloadRoute.path;
+		Pattern expectedPath = new RunArtifactsDownloadRoute(null, null, null).getPath();
 		String inputPath = "/runs/cdb-EFGH-5678.run/FILES/run.log";
 
 		//When...
-		boolean matches = Pattern.compile(expectedPath).matcher(inputPath).matches();
+		boolean matches = expectedPath.matcher(inputPath).matches();
 
 		//Then...
 		assertThat(matches).isFalse();
@@ -117,11 +140,11 @@ public class TestRunArtifactsDownloadServlet extends RasServletTest {
 	@Test
 	public void TestPathRegexExpectedPathWithLeadingNumberReturnsTrue(){
 		//Given...
-		String expectedPath = RunArtifactsDownloadRoute.path;
+		Pattern expectedPath = new RunArtifactsDownloadRoute(null, null, null).getPath();
 		String inputPath = "/runs/cdb-EFGH-5678.run/files/1run.log";
 
 		//When...
-		boolean matches = Pattern.compile(expectedPath).matcher(inputPath).matches();
+		boolean matches = expectedPath.matcher(inputPath).matches();
 
 		//Then...
 		assertThat(matches).isTrue();
@@ -130,11 +153,11 @@ public class TestRunArtifactsDownloadServlet extends RasServletTest {
 	@Test
 	public void TestPathRegexExpectedPathWithTrailingForwardSlashReturnsTrue(){
 		//Given...
-		String expectedPath = RunArtifactsDownloadRoute.path;
+		Pattern expectedPath = new RunArtifactsDownloadRoute(null, null, null).getPath();
 		String inputPath = "/runs/cdb-EFGH-5678.run/files/run.log/";
 
 		//When...
-		boolean matches = Pattern.compile(expectedPath).matcher(inputPath).matches();
+		boolean matches = expectedPath.matcher(inputPath).matches();
 
 		//Then...
 		assertThat(matches).isTrue();
@@ -143,11 +166,11 @@ public class TestRunArtifactsDownloadServlet extends RasServletTest {
 	@Test
 	public void TestPathRegexNumberPathReturnsTrue(){
 		//Given...
-		String expectedPath = RunArtifactsDownloadRoute.path;
+		Pattern expectedPath = new RunArtifactsDownloadRoute(null, null, null).getPath();
 		String inputPath = "/runs/cdb-EFGH-5678.run/files/run1.log";
 
 		//When...
-		boolean matches = Pattern.compile(expectedPath).matcher(inputPath).matches();
+		boolean matches = expectedPath.matcher(inputPath).matches();
 
 		//Then...
 		assertThat(matches).isTrue();
@@ -156,11 +179,11 @@ public class TestRunArtifactsDownloadServlet extends RasServletTest {
 	@Test
 	public void TestPathRegexUnexpectedPathReturnsFalse(){
 		//Given...
-		String expectedPath = RunArtifactsDownloadRoute.path;
+		Pattern expectedPath = new RunArtifactsDownloadRoute(null, null, null).getPath();
 		String inputPath = "/runs/cdb-EFGH-5678.run/file/run.log";
 
 		//When...
-		boolean matches = Pattern.compile(expectedPath).matcher(inputPath).matches();
+		boolean matches = expectedPath.matcher(inputPath).matches();
 
 		//Then...
 		assertThat(matches).isFalse();
@@ -169,37 +192,39 @@ public class TestRunArtifactsDownloadServlet extends RasServletTest {
 	@Test
 	public void TestPathRegexEmptyPathReturnsFalse(){
 		//Given...
-		String expectedPath = RunArtifactsDownloadRoute.path;
+		Pattern expectedPath = new RunArtifactsDownloadRoute(null, null, null).getPath();
 		String inputPath = "";
 
 		//When...
-		boolean matches = Pattern.compile(expectedPath).matcher(inputPath).matches();
+		boolean matches = expectedPath.matcher(inputPath).matches();
 
 		//Then...
 		assertThat(matches).isFalse();
 	}
 
 	@Test
-	public void TestPathRegexSpecialCharacterPathReturnsFalse(){
+	public void TestPathRegexSpecialCharactersInFilePathReturnsFalse() {
 		//Given...
-		String expectedPath = RunArtifactsDownloadRoute.path;
-		String inputPath = "/runs/cdb-EFGH-5678.run/files/run.log?";
-
-		//When...
-		boolean matches = Pattern.compile(expectedPath).matcher(inputPath).matches();
+		Pattern expectedPath = new RunArtifactsDownloadRoute(null, null, null).getPath();
 
 		//Then...
-		assertThat(matches).isFalse();
+		assertThat(expectedPath.matcher("/runs/cdb-EFGH-5678.run/files/run.log?").matches())
+            .as("Question marks in the file name should be rejected")
+            .isFalse();
+
+        assertThat(expectedPath.matcher("/runs/cdb-EFGH-5678/files/<a href='blah'>run.log</a>").matches())
+            .as("HTML in the file name should be rejected")
+            .isFalse();
 	}
 
 	@Test
 	public void TestPathRegexMultipleForwardSlashPathReturnsTrue(){
 		//Given...
-		String expectedPath = RunArtifactsDownloadRoute.path;
+		Pattern expectedPath = new RunArtifactsDownloadRoute(null, null, null).getPath();
 		String inputPath = "/runs/cdb-EFGH-5678.run/files/run.log//////";
 
 		//When...
-		boolean matches = Pattern.compile(expectedPath).matcher(inputPath).matches();
+		boolean matches = expectedPath.matcher(inputPath).matches();
 
 		//Then...
 		assertThat(matches).isTrue();


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1983

## Changes
- Updated path regexes for the `/ras/runs/{runId}/artifacts` and `/ras/runs/{runId}/files/{artifactPath}` endpoints to allow underscores in run IDs and artifact paths.
  - Also allowed parentheses to artifact paths