### PR TITLE
Throw error instead of handling PATCH/etc requests as GETs, fix typos in errors

### DIFF
--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/JwtAuthFilterTest.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/JwtAuthFilterTest.java
@@ -343,7 +343,7 @@ public class JwtAuthFilterTest extends BaseServletTest {
 
         // Then...
         assertThat(servletResponse.getStatus()).isEqualTo(500);
-        checkErrorStructure(outStream.toString(), 5000, "GAL5000E", "Error occured when trying to access the endpoint");
+        checkErrorStructure(outStream.toString(), 5000, "GAL5000E", "Error occurred when trying to access the endpoint");
     }
 
     @Test

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthCallbackRouteTest.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthCallbackRouteTest.java
@@ -40,12 +40,12 @@ public class AuthCallbackRouteTest extends BaseServletTest {
         // Expecting this json:
         // {
         // "error_code" : 5400,
-        // "error_message" : "GAL5400E: Error occured when trying to execute request
+        // "error_message" : "GAL5400E: Error occurred when trying to execute request
         // '/auth/callback'. Please check your request parameters or report the problem to your
         // Galasa Ecosystem owner."
         // }
         assertThat(servletResponse.getStatus()).isEqualTo(400);
-        checkErrorStructure(outStream.toString(), 5400, "GAL5400E", "Error occured when trying to execute request");
+        checkErrorStructure(outStream.toString(), 5400, "GAL5400E", "Error occurred when trying to execute request");
     }
 
     @Test
@@ -66,12 +66,12 @@ public class AuthCallbackRouteTest extends BaseServletTest {
         // Expecting this json:
         // {
         // "error_code" : 5400,
-        // "error_message" : "GAL5400E: Error occured when trying to execute request
+        // "error_message" : "GAL5400E: Error occurred when trying to execute request
         // '/auth/callback'. Please check your request parameters or report the problem to your
         // Galasa Ecosystem owner."
         // }
         assertThat(servletResponse.getStatus()).isEqualTo(400);
-        checkErrorStructure(outStream.toString(), 5400, "GAL5400E", "Error occured when trying to execute request");
+        checkErrorStructure(outStream.toString(), 5400, "GAL5400E", "Error occurred when trying to execute request");
     }
 
     @Test
@@ -92,12 +92,12 @@ public class AuthCallbackRouteTest extends BaseServletTest {
         // Expecting this json:
         // {
         // "error_code" : 5400,
-        // "error_message" : "GAL5400E: Error occured when trying to execute request
+        // "error_message" : "GAL5400E: Error occurred when trying to execute request
         // '/auth/callback'. Please check your request parameters or report the problem to your
         // Galasa Ecosystem owner."
         // }
         assertThat(servletResponse.getStatus()).isEqualTo(400);
-        checkErrorStructure(outStream.toString(), 5400, "GAL5400E", "Error occured when trying to execute request");
+        checkErrorStructure(outStream.toString(), 5400, "GAL5400E", "Error occurred when trying to execute request");
     }
 
     @Test
@@ -130,12 +130,12 @@ public class AuthCallbackRouteTest extends BaseServletTest {
         // Expecting this json:
         // {
         // "error_code" : 5400,
-        // "error_message" : "GAL5400E: Error occured when trying to execute request
+        // "error_message" : "GAL5400E: Error occurred when trying to execute request
         // '/auth/callback'. Please check your request parameters or report the problem to your
         // Galasa Ecosystem owner."
         // }
         assertThat(servletResponse.getStatus()).isEqualTo(400);
-        checkErrorStructure(outStream.toString(), 5400, "GAL5400E", "Error occured when trying to execute request");
+        checkErrorStructure(outStream.toString(), 5400, "GAL5400E", "Error occurred when trying to execute request");
     }
 
     @Test
@@ -228,12 +228,12 @@ public class AuthCallbackRouteTest extends BaseServletTest {
         // Expecting this json:
         // {
         // "error_code" : 5400,
-        // "error_message" : "GAL5400E: Error occured when trying to execute request
+        // "error_message" : "GAL5400E: Error occurred when trying to execute request
         // '/auth/callback'. Please check your request parameters or report the problem to your
         // Galasa Ecosystem owner."
         // }
         assertThat(servletResponse.getStatus()).isEqualTo(400);
-        checkErrorStructure(outStream.toString(), 5400, "GAL5400E", "Error occured when trying to execute request");
+        checkErrorStructure(outStream.toString(), 5400, "GAL5400E", "Error occurred when trying to execute request");
     }
 
     @Test
@@ -264,12 +264,12 @@ public class AuthCallbackRouteTest extends BaseServletTest {
         // Expecting this json:
         // {
         // "error_code" : 5400,
-        // "error_message" : "GAL5400E: Error occured when trying to execute request
+        // "error_message" : "GAL5400E: Error occurred when trying to execute request
         // '/auth/callback'. Please check your request parameters or report the problem to your
         // Galasa Ecosystem owner."
         // }
         assertThat(servletResponse.getStatus()).isEqualTo(400);
-        checkErrorStructure(outStream.toString(), 5400, "GAL5400E", "Error occured when trying to execute request");
+        checkErrorStructure(outStream.toString(), 5400, "GAL5400E", "Error occurred when trying to execute request");
     }
 
     @Test
@@ -296,11 +296,11 @@ public class AuthCallbackRouteTest extends BaseServletTest {
         // Expecting this json:
         // {
         // "error_code" : 5400,
-        // "error_message" : "GAL5400E: Error occured when trying to execute request
+        // "error_message" : "GAL5400E: Error occurred when trying to execute request
         // '/auth/callback'. Please check your request parameters or report the problem to your
         // Galasa Ecosystem owner."
         // }
         assertThat(servletResponse.getStatus()).isEqualTo(400);
-        checkErrorStructure(outStream.toString(), 5400, "GAL5400E", "Error occured when trying to execute request");
+        checkErrorStructure(outStream.toString(), 5400, "GAL5400E", "Error occurred when trying to execute request");
     }
 }

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthClientsRouteTest.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthClientsRouteTest.java
@@ -44,11 +44,11 @@ public class AuthClientsRouteTest extends BaseServletTest {
         // Expecting this json:
         // {
         // "error_code" : 5000,
-        // "error_message" : "GAL5000E: Error occured when trying to access the
+        // "error_message" : "GAL5000E: Error occurred when trying to access the
         // endpoint. Report the problem to your Galasa Ecosystem owner."
         // }
         assertThat(servletResponse.getStatus()).isEqualTo(500);
-        checkErrorStructure(outStream.toString(), 5000, "GAL5000E", "Error occured when trying to access the endpoint");
+        checkErrorStructure(outStream.toString(), 5000, "GAL5000E", "Error occurred when trying to access the endpoint");
     }
 
     @Test

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthRouteTest.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthRouteTest.java
@@ -370,11 +370,11 @@ public class AuthRouteTest extends BaseServletTest {
         // Expecting this json:
         // {
         // "error_code" : 5000,
-        // "error_message" : "GAL5000E: Error occured when trying to access the
+        // "error_message" : "GAL5000E: Error occurred when trying to access the
         // endpoint. Report the problem to your Galasa Ecosystem owner."
         // }
         assertThat(servletResponse.getStatus()).isEqualTo(500);
-        checkErrorStructure(outStream.toString(), 5000, "GAL5000E", "Error occured when trying to access the endpoint");
+        checkErrorStructure(outStream.toString(), 5000, "GAL5000E", "Error occurred when trying to access the endpoint");
     }
 
     @Test
@@ -494,11 +494,11 @@ public class AuthRouteTest extends BaseServletTest {
         // Expecting this json:
         // {
         // "error_code" : 5400,
-        // "error_message" : "GAL5400E: Error occured when trying to execute request
+        // "error_message" : "GAL5400E: Error occurred when trying to execute request
         // "/auth". Please check your request parameters or report the problem to your Galasa Ecosystem owner."
         // }
         assertThat(servletResponse.getStatus()).isEqualTo(400);
-        checkErrorStructure(outStream.toString(), 5400, "GAL5400E", "Error occured when trying to execute request");
+        checkErrorStructure(outStream.toString(), 5400, "GAL5400E", "Error occurred when trying to execute request");
     }
 
     @Test
@@ -519,11 +519,11 @@ public class AuthRouteTest extends BaseServletTest {
         // Expecting this json:
         // {
         // "error_code" : 5400,
-        // "error_message" : "GAL5400E: Error occured when trying to execute request
+        // "error_message" : "GAL5400E: Error occurred when trying to execute request
         // "/auth". Please check your request parameters or report the problem to your Galasa Ecosystem owner."
         // }
         assertThat(servletResponse.getStatus()).isEqualTo(400);
-        checkErrorStructure(outStream.toString(), 5400, "GAL5400E", "Error occured when trying to execute request");
+        checkErrorStructure(outStream.toString(), 5400, "GAL5400E", "Error occurred when trying to execute request");
     }
 
     @Test
@@ -544,11 +544,11 @@ public class AuthRouteTest extends BaseServletTest {
         // Expecting this json:
         // {
         // "error_code" : 5400,
-        // "error_message" : "GAL5400E: Error occured when trying to execute request
+        // "error_message" : "GAL5400E: Error occurred when trying to execute request
         // "/auth". Please check your request parameters or report the problem to your Galasa Ecosystem owner."
         // }
         assertThat(servletResponse.getStatus()).isEqualTo(400);
-        checkErrorStructure(outStream.toString(), 5400, "GAL5400E", "Error occured when trying to execute request");
+        checkErrorStructure(outStream.toString(), 5400, "GAL5400E", "Error occurred when trying to execute request");
     }
 
     @Test
@@ -572,11 +572,11 @@ public class AuthRouteTest extends BaseServletTest {
         // Expecting this json:
         // {
         // "error_code" : 5400,
-        // "error_message" : "GAL5400E: Error occured when trying to execute request
+        // "error_message" : "GAL5400E: Error occurred when trying to execute request
         // "/auth". Please check your request parameters or report the problem to your Galasa Ecosystem owner."
         // }
         assertThat(servletResponse.getStatus()).isEqualTo(400);
-        checkErrorStructure(outStream.toString(), 5400, "GAL5400E", "Error occured when trying to execute request");
+        checkErrorStructure(outStream.toString(), 5400, "GAL5400E", "Error occurred when trying to execute request");
     }
 
     @Test

--- a/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthTokensRouteTest.java
+++ b/galasa-parent/dev.galasa.framework.api.authentication/src/test/java/dev/galasa/framework/api/authentication/routes/AuthTokensRouteTest.java
@@ -666,11 +666,11 @@ public class AuthTokensRouteTest extends BaseServletTest {
         // Expecting this json:
         // {
         // "error_code" : 5000,
-        // "error_message" : "GAL5000E: Error occured when trying to access the
+        // "error_message" : "GAL5000E: Error occurred when trying to access the
         // endpoint. Report the problem to your Galasa Ecosystem owner."
         // }
         assertThat(servletResponse.getStatus()).isEqualTo(500);
-        checkErrorStructure(outStream.toString(), 5000, "GAL5000E", "Error occured when trying to access the endpoint");
+        checkErrorStructure(outStream.toString(), 5000, "GAL5000E", "Error occurred when trying to access the endpoint");
     }
 
     @Test

--- a/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/BaseServlet.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/BaseServlet.java
@@ -11,6 +11,7 @@ import org.apache.commons.logging.LogFactory;
 import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.utils.GalasaGson;
 
+import static dev.galasa.framework.api.common.HttpMethod.*;
 import static dev.galasa.framework.api.common.ServletErrorMessage.*;
 
 import java.io.IOException;
@@ -117,15 +118,7 @@ public class BaseServlet extends HttpServlet {
             if (matcher.matches()) {
                 pathMatched = true;
                 logger.info("BaseServlet: Found a route that matches.");
-                if (req.getMethod().contains("PUT")){
-                    route.handlePutRequest(url, queryParameters, req, res);
-                } else if (req.getMethod().contains("POST")){
-                    route.handlePostRequest(url, queryParameters, req, res);
-                } else if (req.getMethod().contains("DELETE")){
-                    route.handleDeleteRequest(url, queryParameters, req, res);
-                } else {
-                    route.handleGetRequest(url, queryParameters, req, res);
-                }
+                handleRoute(route, url, queryParameters, req, res);
                 break;
             }
         }
@@ -135,6 +128,30 @@ public class BaseServlet extends HttpServlet {
             logger.info("BaseServlet: No matching route found.");
             ServletError error = new ServletError(GAL5404_UNRESOLVED_ENDPOINT_ERROR, url);
             throw new InternalServletException(error, HttpServletResponse.SC_NOT_FOUND);
+        }
+    }
+
+    private void handleRoute(
+        IRoute route,
+        String pathInfo,
+        QueryParameters queryParameters,
+        HttpServletRequest req,
+        HttpServletResponse res
+    ) throws ServletException, IOException, FrameworkException {
+        String requestMethodStr = req.getMethod();
+        HttpMethod requestMethod = HttpMethod.getFromString(requestMethodStr);
+        if (requestMethod == GET) {
+            route.handleGetRequest(pathInfo, queryParameters, req, res);
+        } else if (requestMethod == POST) {
+            route.handlePostRequest(pathInfo, queryParameters, req, res);
+        } else if (requestMethod == PUT) {
+            route.handlePutRequest(pathInfo, queryParameters, req, res);
+        } else if (requestMethod == DELETE) {
+            route.handleDeleteRequest(pathInfo, queryParameters, req, res);
+        } else {
+            // The request was sent wih an unsupported method, so throw an error
+            ServletError error = new ServletError(GAL5405_METHOD_NOT_ALLOWED, pathInfo, requestMethodStr);
+            throw new InternalServletException(error, HttpServletResponse.SC_METHOD_NOT_ALLOWED);     
         }
     }
 }

--- a/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/BaseServlet.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/BaseServlet.java
@@ -149,7 +149,7 @@ public class BaseServlet extends HttpServlet {
         } else if (requestMethod == DELETE) {
             route.handleDeleteRequest(pathInfo, queryParameters, req, res);
         } else {
-            // The request was sent wih an unsupported method, so throw an error
+            // The request was sent with an unsupported method, so throw an error
             ServletError error = new ServletError(GAL5405_METHOD_NOT_ALLOWED, pathInfo, requestMethodStr);
             throw new InternalServletException(error, HttpServletResponse.SC_METHOD_NOT_ALLOWED);     
         }

--- a/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/HttpMethod.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/HttpMethod.java
@@ -17,5 +17,17 @@ public enum HttpMethod {
     PATCH,
     TRACE,
     OPTIONS,
-    CONNECT,
+    CONNECT
+    ;
+
+    public static HttpMethod getFromString(String httpMethodStr) {
+        HttpMethod match = null;
+        for (HttpMethod possibleMatch : values()) {
+            if (possibleMatch.toString().equalsIgnoreCase(httpMethodStr)) {
+                match = possibleMatch;
+                break;
+            }
+        }
+        return match;
+    }
 }

--- a/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/ServletErrorMessage.java
@@ -23,12 +23,12 @@ public enum ServletErrorMessage {
     GAL5014_STATUS_NAME_NOT_RECOGNIZED                (5014,"E: Error parsing the query parameters. 'status' value ''{0}'' not recognised. Expected status name to match one of the following ''{1}''."),
 
     // RunsReset/Cancel...
-    GAL5045_INVALID_STATUS_UPDATE_REQUEST             (5045, "E: Error occured. The field ''status'' in the request body is invalid. The ''status'' value ''{0}'' supplied is not supported. Supported values are: ''queued'' and ''finished''."),
-    GAL5046_UNABLE_TO_CANCEL_RUN_INVALID_RESULT       (5046, "E: Error occured when trying to cancel the run ''{0}''. The ''result'' ''{1}''' supplied is not supported. Supported values are: ''cancelled''."),
-    GAL5047_UNABLE_TO_RESET_RUN                       (5047, "E: Error occured when trying to reset the run ''{0}''. Report the problem to your Galasa Ecosystem owner."),
-    GAL5048_UNABLE_TO_CANCEL_RUN                      (5048, "E: Error occured when trying to cancel the run ''{0}''. Report the problem to your Galasa Ecosystem owner."),
-    GAL5049_UNABLE_TO_RESET_COMPLETED_RUN             (5049, "E: Error occured when trying to reset the run ''{0}''. The run has already completed."),
-    GAL5050_UNABLE_TO_CANCEL_COMPLETED_RUN            (5050, "E: Error occured when trying to cancel the run ''{0}''. The run has already completed."),
+    GAL5045_INVALID_STATUS_UPDATE_REQUEST             (5045, "E: Error occurred. The field ''status'' in the request body is invalid. The ''status'' value ''{0}'' supplied is not supported. Supported values are: ''queued'' and ''finished''."),
+    GAL5046_UNABLE_TO_CANCEL_RUN_INVALID_RESULT       (5046, "E: Error occurred when trying to cancel the run ''{0}''. The ''result'' ''{1}''' supplied is not supported. Supported values are: ''cancelled''."),
+    GAL5047_UNABLE_TO_RESET_RUN                       (5047, "E: Error occurred when trying to reset the run ''{0}''. Report the problem to your Galasa Ecosystem owner."),
+    GAL5048_UNABLE_TO_CANCEL_RUN                      (5048, "E: Error occurred when trying to cancel the run ''{0}''. Report the problem to your Galasa Ecosystem owner."),
+    GAL5049_UNABLE_TO_RESET_COMPLETED_RUN             (5049, "E: Error occurred when trying to reset the run ''{0}''. The run has already completed."),
+    GAL5050_UNABLE_TO_CANCEL_COMPLETED_RUN            (5050, "E: Error occurred when trying to cancel the run ''{0}''. The run has already completed."),
 
     // RunArtifactsList...
     GAL5007_ERROR_RETRIEVING_ARTIFACTS_LIST           (5007,"E: Error retrieving artifacts for run with identifier ''{0}''."),
@@ -38,35 +38,35 @@ public enum ServletErrorMessage {
     GAL5009_ERROR_RETRIEVING_ARTIFACT                 (5009,"E: Error retrieving artifact ''{0}'' for run with identifier ''{1}''."),
 
     // RunDelete...
-    GAL5091_ERROR_RUN_NOT_FOUND_BY_ID                 (5091,"E: Error occured when seaching for a run with identifier ''{0}''."),
+    GAL5091_ERROR_RUN_NOT_FOUND_BY_ID                 (5091,"E: Error occurred when seaching for a run with identifier ''{0}''."),
 
     // GenericErrors...
-    GAL5000_GENERIC_API_ERROR                         (5000,"E: Error occured when trying to access the endpoint. Report the problem to your Galasa Ecosystem owner."),
-    GAL5400_BAD_REQUEST                               (5400,"E: Error occured when trying to execute request ''{0}''. Please check your request parameters or report the problem to your Galasa Ecosystem owner."),
+    GAL5000_GENERIC_API_ERROR                         (5000,"E: Error occurred when trying to access the endpoint. Report the problem to your Galasa Ecosystem owner."),
+    GAL5400_BAD_REQUEST                               (5400,"E: Error occurred when trying to execute request ''{0}''. Please check your request parameters or report the problem to your Galasa Ecosystem owner."),
     GAL5401_UNAUTHORIZED                              (5401,"E: Unauthorized. Please ensure you have provided a valid 'Authorization' header with a valid bearer token and try again."),
-    GAL5404_UNRESOLVED_ENDPOINT_ERROR                 (5404,"E: Error occured when trying to identify the endpoint ''{0}''. Please check your endpoint URL or report the problem to your Galasa Ecosystem owner."),
-    GAL5405_METHOD_NOT_ALLOWED                        (5405,"E: Error occured when trying to access the endpoint ''{0}''. The method ''{1}'' is not allowed."),
+    GAL5404_UNRESOLVED_ENDPOINT_ERROR                 (5404,"E: Error occurred when trying to identify the endpoint ''{0}''. Please check your endpoint URL or report the problem to your Galasa Ecosystem owner."),
+    GAL5405_METHOD_NOT_ALLOWED                        (5405,"E: Error occurred when trying to access the endpoint ''{0}''. The method ''{1}'' is not allowed."),
     GAL5406_UNSUPPORTED_CONTENT_TYPE_REQUESTED        (5406, "E: Unsupported ''Accept'' header value set. Supported response types are: [{0}]. Ensure the ''Accept'' header in your request contains a valid value and try again"),
-    GAL5411_NO_REQUEST_BODY                           (5411,"E: Error occured when trying to access the endpoint ''{0}''. The request body is empty."),
+    GAL5411_NO_REQUEST_BODY                           (5411,"E: Error occurred when trying to access the endpoint ''{0}''. The request body is empty."),
 
     //CPS Namespaces...
-    GAL5015_INTERNAL_CPS_ERROR                        (5015,"E: Error occured when trying to access the Configuration Property Store. Report the problem to your Galasa Ecosystem owner."),
-    GAL5016_INVALID_NAMESPACE_ERROR                   (5016,"E: Error occured when trying to access namespace ''{0}''. The namespace provided is invalid."),
-    GAL5017_PROPERTY_DOES_NOT_EXIST_ERROR             (5017,"E: Error occured when trying to access property ''{0}''. The property does not exist."),
-    GAL5018_PROPERTY_ALREADY_EXISTS_ERROR             (5018,"E: Error occured when trying to access property ''{0}''. The property name provided already exists in the ''{1}'' namespace."),
+    GAL5015_INTERNAL_CPS_ERROR                        (5015,"E: Error occurred when trying to access the Configuration Property Store. Report the problem to your Galasa Ecosystem owner."),
+    GAL5016_INVALID_NAMESPACE_ERROR                   (5016,"E: Error occurred when trying to access namespace ''{0}''. The namespace provided is invalid."),
+    GAL5017_PROPERTY_DOES_NOT_EXIST_ERROR             (5017,"E: Error occurred when trying to access property ''{0}''. The property does not exist."),
+    GAL5018_PROPERTY_ALREADY_EXISTS_ERROR             (5018,"E: Error occurred when trying to access property ''{0}''. The property name provided already exists in the ''{1}'' namespace."),
     GAL5028_PROPERTY_NAMESPACE_DOES_NOT_MATCH_ERROR   (5028,"E: The GalasaProperty namespace ''{0}'' must match the url namespace ''{1}''."),
     GAL5029_PROPERTY_NAME_DOES_NOT_MATCH_ERROR        (5029,"E: The GalasaProperty name ''{0}'' must match the url namespace ''{1}''."),
-    GAL5030_UNABLE_TO_DELETE_PROPERTY_ERROR           (5030,"E: Error occured when trying to delete Property ''{0}''. Report the problem to your Galasa Ecosystem owner."),
+    GAL5030_UNABLE_TO_DELETE_PROPERTY_ERROR           (5030,"E: Error occurred when trying to delete Property ''{0}''. Report the problem to your Galasa Ecosystem owner."),
 
     //Schedule Runs...
     GAL5019_UNABLE_TO_RETRIEVE_RUNS                   (5019, "E: Unable to retrieve runs for Run Group: ''{0}''."),
-    GAL5020_UNABLE_TO_CONVERT_TO_SCHEDULE_REQUEST     (5020, "E: Error occured when trying to translate the payload into a run."),
-    GAL5021_UNABLE_TO_SUBMIT_RUNS                     (5021, "E: Error occured when trying to submit run ''{0}''."),
-    GAL5022_UNABLE_TO_PARSE_SHARED_ENVIRONMENT_PHASE  (5022, "E: Error occured trying parse the sharedEnvironmentPhase ''{0}''. Valid options are 'BUILD', 'DISCARD'."),
+    GAL5020_UNABLE_TO_CONVERT_TO_SCHEDULE_REQUEST     (5020, "E: Error occurred when trying to translate the payload into a run."),
+    GAL5021_UNABLE_TO_SUBMIT_RUNS                     (5021, "E: Error occurred when trying to submit run ''{0}''."),
+    GAL5022_UNABLE_TO_PARSE_SHARED_ENVIRONMENT_PHASE  (5022, "E: Error occurred trying parse the sharedEnvironmentPhase ''{0}''. Valid options are 'BUILD', 'DISCARD'."),
 
     //Galasa Property...
-    GAL5023_UNABLE_TO_CAST_TO_GALASAPROPERTY          (5023, "E: Error occured trying to interpret resource ''{0}''. P This could indicate a mis-match between client and server levels. Please check with your Ecosystem administrator the level. You may have to upgrade/downgrade your client program."),
-    GAL5024_INVALID_GALASAPROPERTY                    (5024, "E: Error occured because the Galasa Property is invalid. ''{0}''"),
+    GAL5023_UNABLE_TO_CAST_TO_GALASAPROPERTY          (5023, "E: Error occurred trying to interpret resource ''{0}''. P This could indicate a mis-match between client and server levels. Please check with your Ecosystem administrator the level. You may have to upgrade/downgrade your client program."),
+    GAL5024_INVALID_GALASAPROPERTY                    (5024, "E: Error occurred because the Galasa Property is invalid. ''{0}''"),
     GAL5031_EMPTY_NAMESPACE                           (5031, "E: Invalid namespace. Namespace is empty."),
     GAL5032_INVALID_FIRST_CHARACTER_NAMESPACE         (5032, "E: Invalid namespace name. ''{0}'' must not start with the ''{1}'' character. Allowable first characters are 'a'-'z' or 'A'-'Z'."),
     GAL5033_INVALID_NAMESPACE_INVALID_MIDDLE_CHAR     (5033, "E: Invalid namespace name. ''{0}'' must not contain the ''{1}'' character. Allowable characters after the first character are 'a'-'z', 'A'-'Z', '0'-'9'."),
@@ -75,19 +75,19 @@ public enum ServletErrorMessage {
     GAL5036_INVALID_PROPERTY_NAME_PREFIX_INVALID_CHAR (5036, "E: Invalid property name prefix. ''{0}'' must not contain the ''{1}'' character. Allowable characters after the first character are 'a'-'z', 'A'-'Z', '0'-'9', '-' (dash), '.' (dot) and '_' (underscore)."),
     GAL5037_INVALID_PROPERTY_NAME_SUFFIX_EMPTY        (5037, "E: Invalid property name. Property name is missing or empty."),
     GAL5038_INVALID_PROPERTY_NAME_SUFFIX_FIRST_CHAR   (5038, "E: Invalid property name suffix. ''{0}'' must not start with the ''{1}'' character. Allowable first characters are 'a'-'z' or 'A'-'Z'."),
-    GAL5039_INVALID_PROPERTY_NAME_SUUFIX_INVALID_CHAR (5039, "E: Invalid property name suffix. ''{0}'' must not contain the ''{1}'' character. Allowable characters after the first character are 'a'-'z', 'A'-'Z', '0'-'9', '-' (dash), '.' (dot) and '_' (underscore)."),
+    GAL5039_INVALID_PROPERTY_NAME_SUFFIX_INVALID_CHAR (5039, "E: Invalid property name suffix. ''{0}'' must not contain the ''{1}'' character. Allowable characters after the first character are 'a'-'z', 'A'-'Z', '0'-'9', '-' (dash), '.' (dot) and '_' (underscore)."),
     GAL5040_INVALID_PROPERTY_NAME_EMPTY               (5040, "E: Invalid property name. Property name is missing or empty."),
     GAL5041_INVALID_PROPERTY_NAME_FIRST_CHAR          (5041, "E: Invalid property name. ''{0}'' must not start with the ''{1}'' character. Allowable first characters are 'a'-'z' or 'A'-'Z'."),
     GAL5042_INVALID_PROPERTY_NAME_INVALID_CHAR        (5042, "E: Invalid property name. ''{0}'' must not contain the ''{1}'' character. Allowable characters after the first character are 'a'-'z', 'A'-'Z', '0'-'9', '-' (dash), '.' (dot) and '_' (underscore)"),
-    GAL5043_INVALID_PROPERTY_NAME_NO_DOT_SEPARATOR    (5043, "E: Invalid property name. Property name ''{0}'' much have at least two parts seperated by a '.' (dot)."),
-    GAL5044_INVALID_PROPERTY_NAME_TRAILING_DOT        (5044, "E: Invalid property name. Property name ''{0}'' must not end with a '.' (dot) seperator."),
+    GAL5043_INVALID_PROPERTY_NAME_NO_DOT_SEPARATOR    (5043, "E: Invalid property name. Property name ''{0}'' much have at least two parts separated by a '.' (dot)."),
+    GAL5044_INVALID_PROPERTY_NAME_TRAILING_DOT        (5044, "E: Invalid property name. Property name ''{0}'' must not end with a '.' (dot) separator."),
 
     //Resources APIs...
-    GAL5025_UNSUPPORTED_ACTION                        (5025, "E: Error occured. The field 'action' in the request body is invalid. The 'action' value''{0}'' supplied is not supported. Supported actions are: create, apply and update. This could indicate a mis-match between client and server levels. Please check with your Ecosystem administrator the level. You may have to upgrade/downgrade your client program."),
-    GAL5026_UNSUPPORTED_RESOURCE_TYPE                 (5026, "E: Error occured. The field 'kind' in the request body is invalid. The value ''{0}'' is not supported. This could indicate a mis-match between client and server levels. Please check with your Ecosystem administrator the level. You may have to upgrade/downgrade your client program."),
-    GAL5027_UNSUPPORTED_API_VERSION                   (5027, "E: Error occured. The field 'apiVersion' in the request body is invalid. The value ''{0}'' is not a supported version. Currently the ecosystem accepts the ''{1}'' api version. This could indicate a mis-match between client and server levels. Please check with your Ecosystem administrator the level. You may have to upgrade/downgrade your client program."),
-    GAL5067_NULL_RESOURCE_IN_BODY                     (5067, "E: Error occured. A ''NULL'' value is not a valid resource. Please check the request format, or check with your Ecosystem administrator."),
-    GAL5068_EMPTY_JSON_RESOURCE_IN_BODY               (5068, "E: Error occured. The JSON element for a resource can not be empty. Please check the request format, or check with your Ecosystem administrator."),
+    GAL5025_UNSUPPORTED_ACTION                        (5025, "E: Error occurred. The field 'action' in the request body is invalid. The 'action' value''{0}'' supplied is not supported. Supported actions are: create, apply and update. This could indicate a mis-match between client and server levels. Please check with your Ecosystem administrator the level. You may have to upgrade/downgrade your client program."),
+    GAL5026_UNSUPPORTED_RESOURCE_TYPE                 (5026, "E: Error occurred. The field 'kind' in the request body is invalid. The value ''{0}'' is not supported. This could indicate a mis-match between client and server levels. Please check with your Ecosystem administrator the level. You may have to upgrade/downgrade your client program."),
+    GAL5027_UNSUPPORTED_API_VERSION                   (5027, "E: Error occurred. The field 'apiVersion' in the request body is invalid. The value ''{0}'' is not a supported version. Currently the ecosystem accepts the ''{1}'' api version. This could indicate a mis-match between client and server levels. Please check with your Ecosystem administrator the level. You may have to upgrade/downgrade your client program."),
+    GAL5067_NULL_RESOURCE_IN_BODY                     (5067, "E: Error occurred. A ''NULL'' value is not a valid resource. Please check the request format, or check with your Ecosystem administrator."),
+    GAL5068_EMPTY_JSON_RESOURCE_IN_BODY               (5068, "E: Error occurred. The JSON element for a resource can not be empty. Please check the request format, or check with your Ecosystem administrator."),
 
     // Auth APIs...
     GAL5051_INVALID_GALASA_TOKEN_PROVIDED             (5051, "E: Invalid GALASA_TOKEN value provided. Please ensure you have set the correct GALASA_TOKEN property for the targeted ecosystem at ''{0}'' and try again."),

--- a/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/resources/ResourceNameValidator.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/main/java/dev/galasa/framework/api/common/resources/ResourceNameValidator.java
@@ -106,7 +106,7 @@ public class ResourceNameValidator {
             } else {
                 // Check a following character.
                 if(propertyValidFollowingCharacters.indexOf(c) < 0 ) {
-                    ServletError errorDetails = new ServletError(GAL5039_INVALID_PROPERTY_NAME_SUUFIX_INVALID_CHAR, suffix,  Character.toString(c));
+                    ServletError errorDetails = new ServletError(GAL5039_INVALID_PROPERTY_NAME_SUFFIX_INVALID_CHAR, suffix,  Character.toString(c));
                     throw new InternalServletException(errorDetails, HttpServletResponse.SC_BAD_REQUEST);
                 }
             }

--- a/galasa-parent/dev.galasa.framework.api.common/src/test/java/dev/galasa/framework/api/common/TestBaseRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/test/java/dev/galasa/framework/api/common/TestBaseRoute.java
@@ -42,7 +42,7 @@ public class TestBaseRoute {
 
         // Then...
         assertThat(thrown).isNotNull();
-        assertThat(thrown.getMessage()).contains("GAL5405","E: Error occured when trying to access the endpoint ''. The method 'GET' is not allowed");
+        assertThat(thrown.getMessage()).contains("GAL5405","E: Error occurred when trying to access the endpoint ''. The method 'GET' is not allowed");
     }
 
     @Test
@@ -59,7 +59,7 @@ public class TestBaseRoute {
 
         // Then...
         assertThat(thrown).isNotNull();
-        assertThat(thrown.getMessage()).contains("GAL5405","E: Error occured when trying to access the endpoint ''. The method 'PUT' is not allowed");
+        assertThat(thrown.getMessage()).contains("GAL5405","E: Error occurred when trying to access the endpoint ''. The method 'PUT' is not allowed");
     }
     
     @Test
@@ -76,7 +76,7 @@ public class TestBaseRoute {
 
         // Then...
         assertThat(thrown).isNotNull();
-        assertThat(thrown.getMessage()).contains("GAL5405","E: Error occured when trying to access the endpoint ''. The method 'POST' is not allowed");
+        assertThat(thrown.getMessage()).contains("GAL5405","E: Error occurred when trying to access the endpoint ''. The method 'POST' is not allowed");
     }
 
     @Test
@@ -93,7 +93,7 @@ public class TestBaseRoute {
 
         // Then...
         assertThat(thrown).isNotNull();
-        assertThat(thrown.getMessage()).contains("GAL5405","E: Error occured when trying to access the endpoint ''. The method 'DELETE' is not allowed");
+        assertThat(thrown.getMessage()).contains("GAL5405","E: Error occurred when trying to access the endpoint ''. The method 'DELETE' is not allowed");
     }
     
     @Test
@@ -109,7 +109,7 @@ public class TestBaseRoute {
 
         // Then...
         assertThat(thrown).isNotNull();
-        assertThat(thrown.getMessage()).contains("GAL5411","E: Error occured when trying to access the endpoint ''. The request body is empty.");
+        assertThat(thrown.getMessage()).contains("GAL5411","E: Error occurred when trying to access the endpoint ''. The request body is empty.");
     }
 
     @Test
@@ -125,7 +125,7 @@ public class TestBaseRoute {
 
         // Then...
         assertThat(thrown).isNotNull();
-        assertThat(thrown.getMessage()).contains("GAL5411","E: Error occured when trying to access the endpoint ''. The request body is empty.");
+        assertThat(thrown.getMessage()).contains("GAL5411","E: Error occurred when trying to access the endpoint ''. The request body is empty.");
     }
 
     @Test
@@ -170,7 +170,7 @@ public class TestBaseRoute {
 
         // Then...
         assertThat(thrown).isNotNull();
-        assertThat(thrown.getMessage()).contains("GAL5068","E: Error occured. The JSON element for a resource can not be empty. Please check the request format, or check with your Ecosystem administrator.");
+        assertThat(thrown.getMessage()).contains("GAL5068","E: Error occurred. The JSON element for a resource can not be empty. Please check the request format, or check with your Ecosystem administrator.");
     }
 
     @Test
@@ -185,7 +185,7 @@ public class TestBaseRoute {
 
         // Then...
         assertThat(thrown).isNotNull();
-        assertThat(thrown.getMessage()).contains("GAL5067","E: Error occured. A 'NULL' value is not a valid resource. Please check the request format, or check with your Ecosystem administrator.");
+        assertThat(thrown.getMessage()).contains("GAL5067","E: Error occurred. A 'NULL' value is not a valid resource. Please check the request format, or check with your Ecosystem administrator.");
     }
     
     @Test

--- a/galasa-parent/dev.galasa.framework.api.common/src/test/java/dev/galasa/framework/api/common/TestBaseServlet.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/test/java/dev/galasa/framework/api/common/TestBaseServlet.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.api.common;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.regex.Pattern;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Test;
+
+import dev.galasa.framework.api.common.mocks.MockEnvironment;
+import dev.galasa.framework.api.common.mocks.MockHttpServletRequest;
+import dev.galasa.framework.api.common.mocks.MockHttpServletResponse;
+import dev.galasa.framework.spi.FrameworkException;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class TestBaseServlet extends BaseServletTest {
+
+    private ResponseBuilder mockResponseBuilder = new ResponseBuilder(new MockEnvironment());
+
+    class MockRoute implements IRoute {
+
+        @Override
+        public Pattern getPath() {
+            return Pattern.compile("\\/");
+        }
+
+        @Override
+        public HttpServletResponse handleGetRequest(String pathInfo, QueryParameters queryParams,
+                HttpServletRequest request, HttpServletResponse response
+        ) throws ServletException, IOException, FrameworkException {
+            return writeMockResponse(request, response);
+        }
+
+        @Override
+        public HttpServletResponse handlePutRequest(String pathInfo, QueryParameters queryParameters,
+                HttpServletRequest request, HttpServletResponse response
+        ) throws ServletException, IOException, FrameworkException {
+            return writeMockResponse(request, response);
+        }
+
+        @Override
+        public HttpServletResponse handlePostRequest(String pathInfo, QueryParameters queryParameters,
+                HttpServletRequest request, HttpServletResponse response
+        ) throws ServletException, IOException, FrameworkException {
+            return writeMockResponse(request, response);
+        }
+
+        @Override
+        public HttpServletResponse handleDeleteRequest(String pathInfo, QueryParameters queryParameters,
+                HttpServletRequest request, HttpServletResponse response
+        ) throws ServletException, IOException, FrameworkException {
+            return writeMockResponse(request, response);
+        }
+
+        private HttpServletResponse writeMockResponse(HttpServletRequest request, HttpServletResponse response) throws IOException {
+            return mockResponseBuilder.buildResponse(request, response, HttpServletResponse.SC_OK);
+        }
+    }
+
+
+    @Test
+    public void testBaseServletMatchesRouteGetRequestOk() throws Exception {
+        // Given...
+        BaseServlet servlet = new BaseServlet();
+        MockRoute mockRoute = new MockRoute();
+        servlet.addRoute(mockRoute);
+
+        MockHttpServletRequest req = new MockHttpServletRequest("/");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        req.setMethod(HttpMethod.GET.toString());
+
+        // When...
+        servlet.doGet(req, resp);
+
+        // Then...
+        assertThat(resp.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+    }
+
+    @Test
+    public void testBaseServletMatchesRoutePostRequestOk() throws Exception {
+        // Given...
+        BaseServlet servlet = new BaseServlet();
+        MockRoute mockRoute = new MockRoute();
+        servlet.addRoute(mockRoute);
+
+        MockHttpServletRequest req = new MockHttpServletRequest("{}", "/");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        req.setMethod(HttpMethod.POST.toString());
+
+        // When...
+        servlet.doPost(req, resp);
+
+        // Then...
+        assertThat(resp.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+    }
+
+    @Test
+    public void testBaseServletMatchesRouteDeleteRequestOk() throws Exception {
+        // Given...
+        BaseServlet servlet = new BaseServlet();
+        MockRoute mockRoute = new MockRoute();
+        servlet.addRoute(mockRoute);
+
+        MockHttpServletRequest req = new MockHttpServletRequest("/");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        req.setMethod(HttpMethod.DELETE.toString());
+
+        // When...
+        servlet.doDelete(req, resp);
+
+        // Then...
+        assertThat(resp.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+    }
+
+    @Test
+    public void testBaseServletMatchesRoutePutRequestOk() throws Exception {
+        // Given...
+        BaseServlet servlet = new BaseServlet();
+        MockRoute mockRoute = new MockRoute();
+        servlet.addRoute(mockRoute);
+
+        MockHttpServletRequest req = new MockHttpServletRequest("/");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        req.setMethod(HttpMethod.PUT.toString());
+
+        // When...
+        servlet.doPut(req, resp);
+
+        // Then...
+        assertThat(resp.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+    }
+
+    @Test
+    public void testBaseServletThrowsErrorWhenGivenUnsupportedRequestMethod() throws Exception {
+        // Given...
+        BaseServlet servlet = new BaseServlet();
+        MockRoute mockRoute = new MockRoute();
+        servlet.addRoute(mockRoute);
+
+        MockHttpServletRequest req = new MockHttpServletRequest("/");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        String method = "badmethod";
+        req.setMethod(method);
+
+        // When...
+        servlet.doGet(req, resp);
+
+        // Then...
+        OutputStream outputStream = resp.getOutputStream();
+        assertThat(resp.getStatus()).isEqualTo(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+        checkErrorStructure(outputStream.toString(), 5405, "GAL5405E", method);
+    }
+
+    @Test
+    public void testBaseServletWithRouteThatThrowsInternalServletErrorReturnsError() throws Exception {
+        // Given...
+        BaseServlet servlet = new BaseServlet();
+        MockRoute mockRoute = new MockRoute() {
+            @Override
+            public HttpServletResponse handleGetRequest(String pathInfo, QueryParameters queryParams,
+                    HttpServletRequest request, HttpServletResponse response
+            ) throws ServletException, IOException, FrameworkException {
+                // Simulate an unauthorised error coming back from the route
+                ServletError error = new ServletError(ServletErrorMessage.GAL5401_UNAUTHORIZED);
+                throw new InternalServletException(error, HttpServletResponse.SC_UNAUTHORIZED);
+            }
+        };
+        servlet.addRoute(mockRoute);
+
+        MockHttpServletRequest req = new MockHttpServletRequest("/");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        req.setMethod(HttpMethod.GET.toString());
+
+        // When...
+        servlet.doGet(req, resp);
+
+        // Then...
+        assertThat(resp.getStatus()).isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+
+    @Test
+    public void testBaseServletWithRouteThatThrowsErrorReturnsInternalServerError() throws Exception {
+        // Given...
+        BaseServlet servlet = new BaseServlet();
+        MockRoute mockRoute = new MockRoute() {
+            @Override
+            public HttpServletResponse handleGetRequest(String pathInfo, QueryParameters queryParams,
+                    HttpServletRequest request, HttpServletResponse response
+            ) throws ServletException, IOException, FrameworkException {
+                throw new FrameworkException("simulating a failed framework operation");
+            }
+        };
+        servlet.addRoute(mockRoute);
+
+        MockHttpServletRequest req = new MockHttpServletRequest("/");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        req.setMethod(HttpMethod.GET.toString());
+
+        // When...
+        servlet.doGet(req, resp);
+
+        // Then...
+        OutputStream outputStream = resp.getOutputStream();
+        assertThat(resp.getStatus()).isEqualTo(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        checkErrorStructure(outputStream.toString(),
+            5000,
+            "GAL5000E",
+            "Error occurred when trying to access the endpoint"
+        );
+    }
+
+    @Test
+    public void testBaseServletWithNonMatchingRouteRequestReturnsNotFoundError() throws Exception {
+        // Given...
+        BaseServlet servlet = new BaseServlet();
+        MockRoute mockRoute = new MockRoute() {
+            @Override
+            public HttpServletResponse handleGetRequest(String pathInfo, QueryParameters queryParams,
+                    HttpServletRequest request, HttpServletResponse response
+            ) throws ServletException, IOException, FrameworkException {
+                throw new FrameworkException("simulating a failed framework operation");
+            }
+        };
+        servlet.addRoute(mockRoute);
+
+        MockHttpServletRequest req = new MockHttpServletRequest("not-a-matching-route");
+        MockHttpServletResponse resp = new MockHttpServletResponse();
+        req.setMethod(HttpMethod.GET.toString());
+
+        // When...
+        servlet.doGet(req, resp);
+
+        // Then...
+        OutputStream outputStream = resp.getOutputStream();
+        assertThat(resp.getStatus()).isEqualTo(HttpServletResponse.SC_NOT_FOUND);
+        checkErrorStructure(outputStream.toString(),
+            5404,
+            "GAL5404E",
+            "Error occurred when trying to identify the endpoint"
+        );
+    }
+}

--- a/galasa-parent/dev.galasa.framework.api.common/src/test/java/dev/galasa/framework/api/common/resources/TestCPSProperty.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/test/java/dev/galasa/framework/api/common/resources/TestCPSProperty.java
@@ -354,7 +354,7 @@ public class TestCPSProperty extends BaseServletTest {
         //Then...
         assertThat(thrown).isNotNull();
         checkErrorStructure(thrown.getMessage(),5030,
-            "GAL5030E: Error occured when trying to delete Property 'properly.name'.",
+            "GAL5030E: Error occurred when trying to delete Property 'properly.name'.",
             "Report the problem to your Galasa Ecosystem owner.");        
     }
 
@@ -403,7 +403,7 @@ public class TestCPSProperty extends BaseServletTest {
         //Then...
         assertThat(thrown).isNotNull();
         checkErrorStructure(thrown.getMessage(),5030,
-            "GAL5030E: Error occured when trying to delete Property 'property.name'.",
+            "GAL5030E: Error occurred when trying to delete Property 'property.name'.",
             "Report the problem to your Galasa Ecosystem owner.");        
     }
 

--- a/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockHttpServletRequest.java
+++ b/galasa-parent/dev.galasa.framework.api.common/src/testFixtures/java/dev/galasa/framework/api/common/mocks/MockHttpServletRequest.java
@@ -190,6 +190,10 @@ public class MockHttpServletRequest implements HttpServletRequest {
         this.headerMap.put(header, value);
     }
 
+    public void setMethod(String method) {
+        this.method = method;
+    }
+
     @Override
     public Object getAttribute(String name) {
         throw new UnsupportedOperationException("Unimplemented method 'getAttribute'");

--- a/galasa-parent/dev.galasa.framework.api.cps/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api.cps/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 description = 'Galasa API - CPS'
 
-version = '0.36.0'
+version = '0.37.0'
 
 dependencies {
     implementation project(':dev.galasa.framework')

--- a/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestAddPropertyInNamespaceRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestAddPropertyInNamespaceRoute.java
@@ -222,7 +222,7 @@ public class TestAddPropertyInNamespaceRoute extends CpsServletTest {
 		checkErrorStructure(
 			outStream.toString(),
 			5405,
-			"E: Error occured when trying to access the endpoint '/namespace/framework/property/property.456'. The method 'GET' is not allowed."
+			"E: Error occurred when trying to access the endpoint '/namespace/framework/property/property.456'. The method 'GET' is not allowed."
 		);
 	}
 
@@ -364,7 +364,7 @@ public class TestAddPropertyInNamespaceRoute extends CpsServletTest {
 		checkErrorStructure(
 			outStream.toString(),
 			5405,
-			"E: Error occured when trying to access the endpoint '/namespace/framework/property/property.456'. The method 'POST' is not allowed."
+			"E: Error occurred when trying to access the endpoint '/namespace/framework/property/property.456'. The method 'POST' is not allowed."
 		);
     }
 
@@ -392,7 +392,7 @@ public class TestAddPropertyInNamespaceRoute extends CpsServletTest {
 		checkErrorStructure(
 			outStream.toString(),
 			5405,
-			"E: Error occured when trying to access the endpoint '/namespace/framework/property/property.456'. The method 'DELETE' is not allowed."
+			"E: Error occurred when trying to access the endpoint '/namespace/framework/property/property.456'. The method 'DELETE' is not allowed."
 		);
     }
 

--- a/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestAllNamespaceRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestAllNamespaceRoute.java
@@ -183,7 +183,7 @@ public class TestAllNamespaceRoute extends CpsServletTest {
 			outStream.toString(),
 			5000,
 			"GAL5000E: ",
-			"Error occured when trying to access the endpoint"
+			"Error occurred when trying to access the endpoint"
 		);
     }
 
@@ -267,7 +267,7 @@ public class TestAllNamespaceRoute extends CpsServletTest {
 		checkErrorStructure(
 			outStream.toString(),
 			5015,
-			"E: Error occured when trying to access the Configuration Property Store.",
+			"E: Error occurred when trying to access the Configuration Property Store.",
 			" Report the problem to your Galasa Ecosystem owner."
 		);
     }
@@ -293,7 +293,7 @@ public class TestAllNamespaceRoute extends CpsServletTest {
 		checkErrorStructure(
 			outStream.toString(),
 			5404,
-			"E: Error occured when trying to identify the endpoint '.'. Please check your endpoint URL or report the problem to your Galasa Ecosystem owner."
+			"E: Error occurred when trying to identify the endpoint '.'. Please check your endpoint URL or report the problem to your Galasa Ecosystem owner."
 		);
     }
 
@@ -321,7 +321,7 @@ public class TestAllNamespaceRoute extends CpsServletTest {
 		checkErrorStructure(
 			outStream.toString(),
 			5405,
-			"E: Error occured when trying to access the endpoint '/namespace'. The method 'PUT' is not allowed."
+			"E: Error occurred when trying to access the endpoint '/namespace'. The method 'PUT' is not allowed."
 		);
     }
 
@@ -349,7 +349,7 @@ public class TestAllNamespaceRoute extends CpsServletTest {
 		checkErrorStructure(
 			outStream.toString(),
 			5405,
-			"E: Error occured when trying to access the endpoint '/namespace'. The method 'POST' is not allowed."
+			"E: Error occurred when trying to access the endpoint '/namespace'. The method 'POST' is not allowed."
 		);
     }
 
@@ -377,7 +377,7 @@ public class TestAllNamespaceRoute extends CpsServletTest {
 		checkErrorStructure(
 			outStream.toString(),
 			5405,
-			"E: Error occured when trying to access the endpoint '/namespace'. The method 'DELETE' is not allowed."
+			"E: Error occurred when trying to access the endpoint '/namespace'. The method 'DELETE' is not allowed."
 		);
     }
 

--- a/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestAllPropertiesInNamespaceFilteredRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestAllPropertiesInNamespaceFilteredRoute.java
@@ -222,7 +222,7 @@ public class TestAllPropertiesInNamespaceFilteredRoute extends CpsServletTest {
 			outStream.toString(),
 			5000,
 			"GAL5000E: ",
-			"Error occured when trying to access the endpoint"
+			"Error occurred when trying to access the endpoint"
 		);
     }
 
@@ -245,7 +245,7 @@ public class TestAllPropertiesInNamespaceFilteredRoute extends CpsServletTest {
 		checkErrorStructure(
 			outStream.toString(),
 			5016,
-			": Error occured when trying to access namespace 'framework'. The namespace provided is invalid."
+			": Error occurred when trying to access namespace 'framework'. The namespace provided is invalid."
 		);
     }
 
@@ -329,7 +329,7 @@ public class TestAllPropertiesInNamespaceFilteredRoute extends CpsServletTest {
 		checkErrorStructure(
 			outStream.toString(),
 			5404,
-			"E: Error occured when trying to identify the endpoint '.'. Please check your endpoint URL or report the problem to your Galasa Ecosystem owner."
+			"E: Error occurred when trying to identify the endpoint '.'. Please check your endpoint URL or report the problem to your Galasa Ecosystem owner."
 		);
     }
 
@@ -357,7 +357,7 @@ public class TestAllPropertiesInNamespaceFilteredRoute extends CpsServletTest {
 		checkErrorStructure(
 			outStream.toString(),
 			5405,
-			"E: Error occured when trying to access the endpoint '/namespace/framework/prefix/prop/suffix/erty'. The method 'PUT' is not allowed."
+			"E: Error occurred when trying to access the endpoint '/namespace/framework/prefix/prop/suffix/erty'. The method 'PUT' is not allowed."
 		);
     }
 
@@ -385,7 +385,7 @@ public class TestAllPropertiesInNamespaceFilteredRoute extends CpsServletTest {
 		checkErrorStructure(
 			outStream.toString(),
 			5405,
-			"E: Error occured when trying to access the endpoint '/namespace/framework/prefix/prop/suffix/erty'. The method 'POST' is not allowed."
+			"E: Error occurred when trying to access the endpoint '/namespace/framework/prefix/prop/suffix/erty'. The method 'POST' is not allowed."
 		);
     }
 
@@ -413,7 +413,7 @@ public class TestAllPropertiesInNamespaceFilteredRoute extends CpsServletTest {
 		checkErrorStructure(
 			outStream.toString(),
 			5405,
-			"E: Error occured when trying to access the endpoint '/namespace/framework/prefix/prop/suffix/erty'. The method 'DELETE' is not allowed."
+			"E: Error occurred when trying to access the endpoint '/namespace/framework/prefix/prop/suffix/erty'. The method 'DELETE' is not allowed."
 		);
     }
 

--- a/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestAllPropertiesInNamespaceRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestAllPropertiesInNamespaceRoute.java
@@ -196,7 +196,7 @@ public class TestAllPropertiesInNamespaceRoute extends CpsServletTest {
 			outStream.toString(),
 			5000,
 			"GAL5000E: ",
-			"Error occured when trying to access the endpoint"
+			"Error occurred when trying to access the endpoint"
 		);
     }
 
@@ -219,7 +219,7 @@ public class TestAllPropertiesInNamespaceRoute extends CpsServletTest {
 		checkErrorStructure(
 			outStream.toString(),
 			5016,
-			": Error occured when trying to access namespace 'framework'. The namespace provided is invalid."
+			": Error occurred when trying to access namespace 'framework'. The namespace provided is invalid."
 		);
     }
 
@@ -294,7 +294,7 @@ public class TestAllPropertiesInNamespaceRoute extends CpsServletTest {
 		checkErrorStructure(
 			outStream.toString(),
 			5404,
-			"E: Error occured when trying to identify the endpoint '.'. Please check your endpoint URL or report the problem to your Galasa Ecosystem owner."
+			"E: Error occurred when trying to identify the endpoint '.'. Please check your endpoint URL or report the problem to your Galasa Ecosystem owner."
 		);
     }
 
@@ -322,7 +322,7 @@ public class TestAllPropertiesInNamespaceRoute extends CpsServletTest {
 		checkErrorStructure(
 			outStream.toString(),
 			5405,
-			"E: Error occured when trying to access the endpoint '/namespace/framework'. The method 'PUT' is not allowed."
+			"E: Error occurred when trying to access the endpoint '/namespace/framework'. The method 'PUT' is not allowed."
 		);
     }
 
@@ -350,7 +350,7 @@ public class TestAllPropertiesInNamespaceRoute extends CpsServletTest {
 		checkErrorStructure(
 			outStream.toString(),
 			5405,
-			"E: Error occured when trying to access the endpoint '/namespace/framework'. The method 'POST' is not allowed."
+			"E: Error occurred when trying to access the endpoint '/namespace/framework'. The method 'POST' is not allowed."
 		);
     }
 
@@ -378,7 +378,7 @@ public class TestAllPropertiesInNamespaceRoute extends CpsServletTest {
 		checkErrorStructure(
 			outStream.toString(),
 			5405,
-			"E: Error occured when trying to access the endpoint '/namespace/framework'. The method 'DELETE' is not allowed."
+			"E: Error occurred when trying to access the endpoint '/namespace/framework'. The method 'DELETE' is not allowed."
 		);
     }
 

--- a/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestNamespacesRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestNamespacesRoute.java
@@ -170,7 +170,7 @@ public class TestNamespacesRoute extends CpsServletTest{
 			outStream.toString(),
 			5000,
 			"GAL5000E: ",
-			"Error occured when trying to access the endpoint"
+			"Error occurred when trying to access the endpoint"
 		);
     }
 
@@ -284,7 +284,7 @@ public class TestNamespacesRoute extends CpsServletTest{
 		checkErrorStructure(
 			outStream.toString(),
 			5015,
-			"E: Error occured when trying to access the Configuration Property Store.",
+			"E: Error occurred when trying to access the Configuration Property Store.",
 			" Report the problem to your Galasa Ecosystem owner."
 		);
     }
@@ -310,7 +310,7 @@ public class TestNamespacesRoute extends CpsServletTest{
 		checkErrorStructure(
 			outStream.toString(),
 			5404,
-			"E: Error occured when trying to identify the endpoint '.'. Please check your endpoint URL or report the problem to your Galasa Ecosystem owner."
+			"E: Error occurred when trying to identify the endpoint '.'. Please check your endpoint URL or report the problem to your Galasa Ecosystem owner."
 		);
     }
 
@@ -335,7 +335,7 @@ public class TestNamespacesRoute extends CpsServletTest{
 		checkErrorStructure(
 			outStream.toString(),
 			5404,
-			"E: Error occured when trying to identify the endpoint '/.'. Please check your endpoint URL or report the problem to your Galasa Ecosystem owner."
+			"E: Error occurred when trying to identify the endpoint '/.'. Please check your endpoint URL or report the problem to your Galasa Ecosystem owner."
 		);
     }
 
@@ -363,7 +363,7 @@ public class TestNamespacesRoute extends CpsServletTest{
 		checkErrorStructure(
 			outStream.toString(),
 			5405,
-			"E: Error occured when trying to access the endpoint '/'. The method 'PUT' is not allowed."
+			"E: Error occurred when trying to access the endpoint '/'. The method 'PUT' is not allowed."
 		);
     }
 
@@ -391,7 +391,7 @@ public class TestNamespacesRoute extends CpsServletTest{
 		checkErrorStructure(
 			outStream.toString(),
 			5405,
-			"E: Error occured when trying to access the endpoint '/'. The method 'POST' is not allowed."
+			"E: Error occurred when trying to access the endpoint '/'. The method 'POST' is not allowed."
 		);
     }
 
@@ -419,7 +419,7 @@ public class TestNamespacesRoute extends CpsServletTest{
 		checkErrorStructure(
 			outStream.toString(),
 			5405,
-			"E: Error occured when trying to access the endpoint '/'. The method 'DELETE' is not allowed."
+			"E: Error occurred when trying to access the endpoint '/'. The method 'DELETE' is not allowed."
 		);
     }
 }

--- a/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestPropertyRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestPropertyRoute.java
@@ -284,7 +284,7 @@ public class TestPropertyRoute extends CpsServletTest{
 			outStream.toString(),
 			5000,
 			"GAL5000E: ",
-			"Error occured when trying to access the endpoint"
+			"Error occurred when trying to access the endpoint"
 		);
     }
 
@@ -310,7 +310,7 @@ public class TestPropertyRoute extends CpsServletTest{
 		checkErrorStructure(
 			outStream.toString(),
 			5016,
-			"GAL5016E: Error occured when trying to access namespace 'badnamespace'. The namespace provided is invalid."
+			"GAL5016E: Error occurred when trying to access namespace 'badnamespace'. The namespace provided is invalid."
 		);
     }
 
@@ -394,7 +394,7 @@ public class TestPropertyRoute extends CpsServletTest{
 			outStream.toString(),
 			5016,
 			"GAL5016E: ",
-			"Error occured when trying to access namespace 'dss'. The namespace provided is invalid"
+			"Error occurred when trying to access namespace 'dss'. The namespace provided is invalid"
 		);
     }
 
@@ -420,7 +420,7 @@ public class TestPropertyRoute extends CpsServletTest{
 			outStream.toString(),
 			5404,
 			"GAL5404E:",
-			" Error occured when trying to identify the endpoint '/j!ndex/properties'. ",
+			" Error occurred when trying to identify the endpoint '/j!ndex/properties'. ",
 			"Please check your endpoint URL or report the problem to your Galasa Ecosystem owner."
 		);
 	}
@@ -973,7 +973,7 @@ public class TestPropertyRoute extends CpsServletTest{
 		checkErrorStructure(
 			outStream.toString(),
 			5405,
-			"E: Error occured when trying to access the endpoint '/multi/properties?prefix=.&suffix=1'. The method 'PUT' is not allowed."
+			"E: Error occurred when trying to access the endpoint '/multi/properties?prefix=.&suffix=1'. The method 'PUT' is not allowed."
 		);
     }
 
@@ -1001,7 +1001,7 @@ public class TestPropertyRoute extends CpsServletTest{
 		checkErrorStructure(
 			outStream.toString(),
 			5405,
-			"E: Error occured when trying to access the endpoint '/multi/properties?prefix=.&suffix=1'. The method 'DELETE' is not allowed."
+			"E: Error occurred when trying to access the endpoint '/multi/properties?prefix=.&suffix=1'. The method 'DELETE' is not allowed."
 		);
     }
 
@@ -1033,7 +1033,7 @@ public class TestPropertyRoute extends CpsServletTest{
 		checkErrorStructure(
 			outStream.toString(),
 			5000,
-			"GAL5000E: Error occured when trying to access the endpoint. Report the problem to your Galasa Ecosystem owner."
+			"GAL5000E: Error occurred when trying to access the endpoint. Report the problem to your Galasa Ecosystem owner."
 		);
     }
 
@@ -1062,7 +1062,7 @@ public class TestPropertyRoute extends CpsServletTest{
 		checkErrorStructure(
 			outStream.toString(),
 			5000,
-			"GAL5000E: Error occured when trying to access the endpoint. Report the problem to your Galasa Ecosystem owner."
+			"GAL5000E: Error occurred when trying to access the endpoint. Report the problem to your Galasa Ecosystem owner."
 		);
     }
 
@@ -1116,7 +1116,7 @@ public class TestPropertyRoute extends CpsServletTest{
 		checkErrorStructure(
 			outStream.toString(),
 			5404,
-			"Error occured when trying to identify the endpoint '/camelCase/properties'. "+
+			"Error occurred when trying to identify the endpoint '/camelCase/properties'. "+
 			"Please check your endpoint URL or report the problem to your Galasa Ecosystem owner."
 		);
     }
@@ -1145,7 +1145,7 @@ public class TestPropertyRoute extends CpsServletTest{
 		checkErrorStructure(
 			outStream.toString(),
 			5404,
-			"Error occured when trying to identify the endpoint '/NotCamelcase/properties'. "+
+			"Error occurred when trying to identify the endpoint '/NotCamelcase/properties'. "+
 			"Please check your endpoint URL or report the problem to your Galasa Ecosystem owner."
 		);     
     }
@@ -1174,7 +1174,7 @@ public class TestPropertyRoute extends CpsServletTest{
 		checkErrorStructure(
 			outStream.toString(),
 			5404,
-			"Error occured when trying to identify the endpoint '/notcamelcasE/properties'. "+
+			"Error occurred when trying to identify the endpoint '/notcamelcasE/properties'. "+
 			"Please check your endpoint URL or report the problem to your Galasa Ecosystem owner."
 		);   
     }
@@ -1203,7 +1203,7 @@ public class TestPropertyRoute extends CpsServletTest{
 		checkErrorStructure(
 			outStream.toString(),
 			5404,
-			"Error occured when trying to identify the endpoint '/camel3Case/properties'. "+
+			"Error occurred when trying to identify the endpoint '/camel3Case/properties'. "+
 			"Please check your endpoint URL or report the problem to your Galasa Ecosystem owner."
 		);      
     }
@@ -1232,7 +1232,7 @@ public class TestPropertyRoute extends CpsServletTest{
 		checkErrorStructure(
 			outStream.toString(),
 			5404,
-			"Error occured when trying to identify the endpoint '/camelCase3/properties'. "+
+			"Error occurred when trying to identify the endpoint '/camelCase3/properties'. "+
 			"Please check your endpoint URL or report the problem to your Galasa Ecosystem owner."
 		);         
     }
@@ -1344,7 +1344,7 @@ public class TestPropertyRoute extends CpsServletTest{
 		checkErrorStructure(
 			outStream.toString(),
 			5016,
-			"GAL5016E: Error occured when trying to access namespace 'dss'. The namespace provided is invalid."
+			"GAL5016E: Error occurred when trying to access namespace 'dss'. The namespace provided is invalid."
 		);    
     }
 
@@ -1371,7 +1371,7 @@ public class TestPropertyRoute extends CpsServletTest{
        checkErrorStructure(
 			outStream.toString(),
 			5018,
-			"E: Error occured when trying to access property 'property.5'.",
+			"E: Error occurred when trying to access property 'property.5'.",
             " The property name provided already exists in the 'framework' namespace."
 		);        
     }
@@ -1451,7 +1451,7 @@ public class TestPropertyRoute extends CpsServletTest{
 		checkErrorStructure(
 			outStream.toString(),
 			5411,
-            "E: Error occured when trying to access the endpoint '/framew0rk/properties'.",
+            "E: Error occurred when trying to access the endpoint '/framew0rk/properties'.",
             " The request body is empty."
 		); 
     }
@@ -1477,7 +1477,7 @@ public class TestPropertyRoute extends CpsServletTest{
 		checkErrorStructure(
 			outStream.toString(),
 			5411,
-            "E: Error occured when trying to access the endpoint '/framework/properties'.",
+            "E: Error occurred when trying to access the endpoint '/framework/properties'.",
             " The request body is empty."
 		); 
     }

--- a/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestPropertyUpdateRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.cps/src/test/java/dev/galasa/framework/api/cps/internal/routes/TestPropertyUpdateRoute.java
@@ -218,7 +218,7 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
 		checkErrorStructure(
 			outStream.toString(),
 			5016,
-			"GAL5016E: Error occured when trying to access namespace 'namespace1'. The namespace provided is invalid."
+			"GAL5016E: Error occurred when trying to access namespace 'namespace1'. The namespace provided is invalid."
 		);
     }
 
@@ -243,7 +243,7 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
 		checkErrorStructure(
 			outStream.toString(),
 			5016,
-			"E: Error occured when trying to access namespace 'error'. The namespace provided is invalid."
+			"E: Error occurred when trying to access namespace 'error'. The namespace provided is invalid."
 		);
     }
 
@@ -313,7 +313,7 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
 			outStream.toString(),
 			5016,
 			"GAL5016E: ",
-			"Error occured when trying to access namespace 'dss'. The namespace provided is invalid"
+			"Error occurred when trying to access namespace 'dss'. The namespace provided is invalid"
 		);
     }
 
@@ -401,7 +401,7 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
 			outStream.toString(),
 			5024,
 			"GAL5024E: ",
-			"Error occured because the Galasa Property is invalid. 'Invalid property name. Property name much have at least two parts seperated by a '.' (dot)"
+			"Error occurred because the Galasa Property is invalid. 'Invalid property name. Property name much have at least two parts seperated by a '.' (dot)"
 		);
     }
 
@@ -427,7 +427,7 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
 			outStream.toString(),
 			5404,
 			"GAL5404E: ",
-			"Error occured when trying to identify the endpoint '/framework/properties/.badproperty'. Please check your endpoint URL or report the problem to your Galasa Ecosystem owner."
+			"Error occurred when trying to identify the endpoint '/framework/properties/.badproperty'. Please check your endpoint URL or report the problem to your Galasa Ecosystem owner."
 		);
     }
 
@@ -453,7 +453,7 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
 			outStream.toString(),
 			5024,
 			"GAL5024E: ",
-			"Error occured because the Galasa Property is invalid. 'Invalid property name. Property name 'badproperty.' can not end with a '.' (dot) seperator."
+			"Error occurred because the Galasa Property is invalid. 'Invalid property name. Property name 'badproperty.' can not end with a '.' (dot) seperator."
 		);
     }
 
@@ -483,7 +483,7 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
 		checkErrorStructure(
 			outStream.toString(),
 			5016,
-			"GAL5016E: Error occured when trying to access namespace 'namespace1'. The namespace provided is invalid."
+			"GAL5016E: Error occurred when trying to access namespace 'namespace1'. The namespace provided is invalid."
 		);
     }
     
@@ -591,7 +591,7 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
 			outStream.toString(),
 			5016,
 			"GAL5016E: ",
-			"Error occured when trying to access namespace 'dss'. The namespace provided is invalid"
+			"Error occurred when trying to access namespace 'dss'. The namespace provided is invalid"
 		);
     }
 
@@ -619,7 +619,7 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
        checkErrorStructure(
 			outStream.toString(),
 			5017,
-			"E: Error occured when trying to access property 'property.6'. The property does not exist."
+			"E: Error occurred when trying to access property 'property.6'. The property does not exist."
 		);        
     }
 
@@ -673,7 +673,7 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
 		checkErrorStructure(
 			outStream.toString(),
 			5411,
-            "E: Error occured when trying to access the endpoint '/framew0rk/properties/property5'.",
+            "E: Error occurred when trying to access the endpoint '/framew0rk/properties/property5'.",
             " The request body is empty."
 		); 
     }
@@ -700,7 +700,7 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
 		checkErrorStructure(
 			outStream.toString(),
 			5411,
-            "E: Error occured when trying to access the endpoint '/framework/properties/property6'.",
+            "E: Error occurred when trying to access the endpoint '/framework/properties/property6'.",
             " The request body is empty."
 		); 
     }
@@ -730,7 +730,7 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
 		checkErrorStructure(
 			outStream.toString(),
 			5000,
-			"GAL5000E: Error occured when trying to access the endpoint. Report the problem to your Galasa Ecosystem owner."
+			"GAL5000E: Error occurred when trying to access the endpoint. Report the problem to your Galasa Ecosystem owner."
         );
     }
         
@@ -757,7 +757,7 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
 			outStream.toString(),
 			5016,
 			"GAL5016E: ",
-			"Error occured when trying to access namespace 'dss'. The namespace provided is invalid"
+			"Error occurred when trying to access namespace 'dss'. The namespace provided is invalid"
 		);
     }
     
@@ -782,7 +782,7 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
 		checkErrorStructure(
 			outStream.toString(),
 			5000,
-			"GAL5000E: Error occured when trying to access the endpoint. Report the problem to your Galasa Ecosystem owner."
+			"GAL5000E: Error occurred when trying to access the endpoint. Report the problem to your Galasa Ecosystem owner."
         );
         }
         
@@ -885,7 +885,7 @@ public class TestPropertyUpdateRoute extends CpsServletTest{
 		checkErrorStructure(
 			outStream.toString(),
 			5405,
-			"E: Error occured when trying to access the endpoint '/framework/properties/property1'. The method 'POST' is not allowed."
+			"E: Error occurred when trying to access the endpoint '/framework/properties/property1'. The method 'POST' is not allowed."
 		);
     }
 }

--- a/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
+++ b/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml
@@ -63,7 +63,7 @@ paths:
                 missingparametererror:
                   value:
                     error_code: 5400
-                    error_message: "E: Error occured when trying to execute request '/user'. Please check your request parameters or report the problem to your Galasa Ecosystem owner."
+                    error_message: "E: Error occurred when trying to execute request '/user'. Please check your request parameters or report the problem to your Galasa Ecosystem owner."
                   summary: One or more required query parameters are missing
         '500':
           $ref: '#/components/responses/InternalServerError'
@@ -99,7 +99,7 @@ paths:
                 missingparametererror:
                   value:
                     error_code: 5400
-                    error_message: "E: Error occured when trying to execute request '/auth'. Please check your request parameters or report the problem to your Galasa Ecosystem owner."
+                    error_message: "E: Error occurred when trying to execute request '/auth'. Please check your request parameters or report the problem to your Galasa Ecosystem owner."
                   summary: One or more required body properties are missing
         '500':
           $ref: '#/components/responses/InternalServerError'
@@ -143,7 +143,7 @@ paths:
                 missingparametererror:
                   value:
                     error_code: 5400
-                    error_message: "E: Error occured when trying to execute request '/auth/callback'. Please check your request parameters or report the problem to your Galasa Ecosystem owner."
+                    error_message: "E: Error occurred when trying to execute request '/auth/callback'. Please check your request parameters or report the problem to your Galasa Ecosystem owner."
                   summary: One or more required query parameters are missing
   /auth/clients:
     parameters:
@@ -223,7 +223,7 @@ paths:
                 missingparametererror:
                   value:
                     error_code: 5400
-                    error_message: "E: Error occured when trying to execute request '/auth/tokens'. Please check your request parameters or report the problem to your Galasa Ecosystem owner."
+                    error_message: "E: Error occurred when trying to execute request '/auth/tokens'. Please check your request parameters or report the problem to your Galasa Ecosystem owner."
                   summary: One or more required body properties are missing
         '500':
           $ref: '#/components/responses/InternalServerError'
@@ -282,8 +282,8 @@ paths:
                 genericerror:
                   value:
                     error_code: 5000
-                    error_message: "GAL5000E: Error occured when trying to access the endpoint. Report the problem to your Galasa Ecosystem owner."
-                  summary: An error occured when trying to access the endpoint
+                    error_message: "GAL5000E: Error occurred when trying to access the endpoint. Report the problem to your Galasa Ecosystem owner."
+                  summary: An Error occurred when trying to access the endpoint
                   
 ##################################################################################
 # Users API
@@ -322,7 +322,7 @@ paths:
                 missingparametererror:
                   value:
                     error_code: 5400
-                    error_message: "E: Error occured when trying to execute request '/users'. Please check your request parameters or report the problem to your Galasa Ecosystem owner."
+                    error_message: "E: Error occurred when trying to execute request '/users'. Please check your request parameters or report the problem to your Galasa Ecosystem owner."
                   summary: One or more required query parameters are missing
 ##################################################################################
 # CPS API
@@ -427,8 +427,8 @@ paths:
                 namespacerror:
                   value:
                     error_code: 5016
-                    error_message: "GAL5016E: Error occured when trying to access namespace 'xyz'. Namespace 'xyz' is not available."
-                  summary: An error occured when trying to retrieve the CPS namespaces
+                    error_message: "GAL5016E: Error occurred when trying to access namespace 'xyz'. Namespace 'xyz' is not available."
+                  summary: An Error occurred when trying to retrieve the CPS namespaces
         '500':
           $ref: '#/components/responses/InternalServerError'
     post:
@@ -477,13 +477,13 @@ paths:
                 namespaceerror:
                   value:
                     error_code: 5016
-                    error_message: "GAL5016E: Error occured when trying to access namespace 'xyz'. The Namespace provided is invalid."
-                  summary: An error occured when trying to retrieve the CPS namespaces
+                    error_message: "GAL5016E: Error occurred when trying to access namespace 'xyz'. The Namespace provided is invalid."
+                  summary: An Error occurred when trying to retrieve the CPS namespaces
                 existingpropertyerror:
                   value:
                     error_code: 5018
-                    error_message: "GAL5018E: Error occured when trying to access property 'propertyName'. The property name provided already exists in the 'framework' namespace."
-                  summary: An error occured because the property already exists
+                    error_message: "GAL5018E: Error occurred when trying to access property 'propertyName'. The property name provided already exists in the 'framework' namespace."
+                  summary: An Error occurred because the property already exists
         '411':
           description: Content Length Required
           content:
@@ -494,8 +494,8 @@ paths:
                 nocontenterror:
                   value:
                     error_code: 5411
-                    error_message: "GAL5411E: Error occured when trying to access the endpoint '/cps/namespace/properties/propertyName'. The request body is empty."
-                  summary: An error occured when no value was supplied in the request body
+                    error_message: "GAL5411E: Error occurred when trying to access the endpoint '/cps/namespace/properties/propertyName'. The request body is empty."
+                  summary: An Error occurred when no value was supplied in the request body
         '500':
           $ref: '#/components/responses/InternalServerError'
   #--------------------------------------
@@ -577,8 +577,8 @@ paths:
                 invalidnamespaceerror:
                   value:
                     error_code: 5016
-                    error_message: "GAL5016E: Error occured when trying to access namespace 'xyz'. The Namespace provided is invalid."
-                  summary: An error occured when trying to retrieve the CPS namespaces
+                    error_message: "GAL5016E: Error occurred when trying to access namespace 'xyz'. The Namespace provided is invalid."
+                  summary: An Error occurred when trying to retrieve the CPS namespaces
         '500':
           $ref: '#/components/responses/InternalServerError'
     put:
@@ -636,13 +636,13 @@ paths:
                 namespaceerror:
                   value:
                     error_code: 5016
-                    error_message: "GAL5016E: Error occured when trying to access namespace 'xyz'. The Namespace provided is invalid."
-                  summary: An error occured when trying to retrieve the CPS namespaces
+                    error_message: "GAL5016E: Error occurred when trying to access namespace 'xyz'. The Namespace provided is invalid."
+                  summary: An Error occurred when trying to retrieve the CPS namespaces
                 newpropertyerror:
                   value:
                     error_code: 5017
-                    error_message: "GAL5017E: Error occured when trying to access property 'propertyName'. The property name provided is invalid."
-                  summary: An error occured because the property does not exist
+                    error_message: "GAL5017E: Error occurred when trying to access property 'propertyName'. The property name provided is invalid."
+                  summary: An Error occurred because the property does not exist
         '411':
           description: Content Length Required
           content:
@@ -653,8 +653,8 @@ paths:
                 nocontenterror:
                   value:
                     error_code: 5411
-                    error_message: "GAL5411E: Error occured when trying to access the endpoint '/cps/namespace/properties/propertyName'. The request body is empty."
-                  summary: An error occured when no value was supplied in the request body
+                    error_message: "GAL5411E: Error occurred when trying to access the endpoint '/cps/namespace/properties/propertyName'. The request body is empty."
+                  summary: An Error occurred when no value was supplied in the request body
         '500':
           $ref: '#/components/responses/InternalServerError'
     delete:
@@ -705,13 +705,13 @@ paths:
                 namespaceerror:
                   value:
                     error_code: 5016
-                    error_message: "GAL5016E: Error occured when trying to access namespace 'xyz'. The Namespace provided is invalid."
-                  summary: An error occured when trying to retrieve the CPS namespaces
+                    error_message: "GAL5016E: Error occurred when trying to access namespace 'xyz'. The Namespace provided is invalid."
+                  summary: An Error occurred when trying to retrieve the CPS namespaces
                 newpropertyerror:
                   value:
                     error_code: 5017
-                    error_message: "GAL5017E: Error occured when trying to access property 'propertyName'. The property name provided is invalid."
-                  summary: An error occured because the property does not exist
+                    error_message: "GAL5017E: Error occurred when trying to access property 'propertyName'. The property name provided is invalid."
+                  summary: An Error occurred because the property does not exist
         '500':
           $ref: '#/components/responses/InternalServerError'
 ##################################################################################
@@ -778,8 +778,8 @@ paths:
                 namespaceerror:
                   value:
                     error_code: 5016
-                    error_message: "GAL5016E: Error occured when trying to access namespace 'xyz'. The Namespace provided is invalid."
-                  summary: An error occured when trying to retrieve the CPS namespaces
+                    error_message: "GAL5016E: Error occurred when trying to access namespace 'xyz'. The Namespace provided is invalid."
+                  summary: An Error occurred when trying to retrieve the CPS namespaces
         '500':
           $ref: '#/components/responses/InternalServerError'
   /cps/namespace/{namespace}/prefix/{prefix}/suffix/{suffix}:
@@ -969,13 +969,13 @@ paths:
                 singleError:
                   value:
                   - error_code: 5017
-                    error_message: "GAL5017E: Error occured when trying to access property 'propertyName'. The property name provided is invalid."
+                    error_message: "GAL5017E: Error occurred when trying to access property 'propertyName'. The property name provided is invalid."
                 multipleErrors:
                   value:
                   - error_code: 5017
-                    error_message: "GAL5017E: Error occured when trying to access property 'propertyName'. The property name provided is invalid."
+                    error_message: "GAL5017E: Error occurred when trying to access property 'propertyName'. The property name provided is invalid."
                   - error_code: 5016
-                    error_message: "GAL5016E: Error occured when trying to access namespace 'xyz'. The Namespace provided is invalid."
+                    error_message: "GAL5016E: Error occurred when trying to access namespace 'xyz'. The Namespace provided is invalid."
         '401':
           $ref: "#/components/responses/Unauthorized"
         '500':
@@ -1238,22 +1238,22 @@ paths:
                   value:
                     error_code: 5001
                     error_message: "GAL5001E: Error parsing the date-time field 'from' in the request URL. Invalid value '202E-04-12T13:08:10.295971Z'. Expecting a java LocalDateTime format. For example: '2023-04-11T09:42:06.589180Z'"
-                  summary: An error occured parsing the from date-time field
+                  summary: An Error occurred parsing the from date-time field
                 toerror:
                   value:
                     error_code: 5001
                     error_message: "GAL5001E: Error parsing the date-time field 'to' in the request URL. Invalid value '2023-0F-12T13:08:10.295971Z'. Expecting a java LocalDateTime format. For example: '2023-04-11T09:52:56.586180Z'"
-                  summary: An error occured parsing the to date-time field
+                  summary: An Error occurred parsing the to date-time field
                 interror:
                   value:
                     error_code: 5005
                     error_message: "GAL5005E: Error parsing the query parameter 'page'' in the request URL. Invalid value 'five'. Expecting an integer."
-                  summary: An error occured parsing integer parameter
+                  summary: An Error occurred parsing integer parameter
                 duplicateerror:
                   value:
                     error_code: 5006
                     error_message: "GAL5006E: Error parsing the query parameters. Duplicate instances of query parameter 'size' found in the request URL. Expecting only one."
-                  summary: An error occured parsing duplicate parameter
+                  summary: An Error occurred parsing duplicate parameter
         '401':
           $ref: "#/components/responses/Unauthorized"
         '404':
@@ -1267,7 +1267,7 @@ paths:
                   value:
                     error_code: 5002
                     error_message: "GAL5002E: Error retrieving ras run from RunID 'cdb-xxx'."
-                  summary: An error occured when trying to retrieve a specific run using a runId
+                  summary: An Error occurred when trying to retrieve a specific run using a runId
         '500':
           $ref: '#/components/responses/InternalServerError'
           examples:
@@ -1275,12 +1275,12 @@ paths:
               value:
                 error_code: 5003
                 error_message: "GAL5003E: Error retrieving runs. Report the problem to your Galasa Ecosystem owner."
-              summary: An error occured when trying to retireve the runs
+              summary: An Error occurred when trying to retireve the runs
             pageerror:
               value:
                 error_code: 5004
                 error_message: "GAL5004E: Error retrieving page. Report the problem to your Galasa Ecosystem owner."
-              summary: An error occured when trying to return a results page
+              summary: An Error occurred when trying to return a results page
 
 
   #--------------------------------------
@@ -1320,7 +1320,7 @@ paths:
                   value:
                     error_code: 5091
                     error_message: "GAL5091E: Error deleting ras run from RunID 'cdb-xxx'."
-                  summary: An error occured when trying to delete a run using the given runId
+                  summary: An Error occurred when trying to delete a run using the given runId
         '401':
           $ref: "#/components/responses/Unauthorized"
         '500':
@@ -1405,22 +1405,22 @@ paths:
                 invalidStatusUpdateRequest:
                   value:
                     error_code: 5045
-                    error_message: "GAL5045E: Error occured. The field 'status' in the request body is invalid. The 'status' value 'create' supplied is not supported. Supported values are: 'cancel' and 'reset'"
-                  summary: An error occured because the status field does not contain an expected action
+                    error_message: "GAL5045E: Error occurred. The field 'status' in the request body is invalid. The 'status' value 'create' supplied is not supported. Supported values are: 'cancel' and 'reset'"
+                  summary: An Error occurred because the status field does not contain an expected action
                 runNameDoesNotMatch:
                   value:
                     error_code: 5046
                     error_message: "GAL5046E: The 'runName' 'badRun' from the request body does not match the  'runName' 'U123'  associated with the runID in the url 'xx12345xx'."
-                  summary: An error occured because the runName in the request body does not match the runName derived from runID in the URL
+                  summary: An Error occurred because the runName in the request body does not match the runName derived from runID in the URL
                 resetRunHasAlreadyCompleted:
                   value:
                     error_code: 5049
-                    error_message: "GAL5049E: Error occured when trying to reset the run ''{0}''. The run has already completed."
+                    error_message: "GAL5049E: Error occurred when trying to reset the run ''{0}''. The run has already completed."
                   summary: The run in the request has already completed and can not be reset
                 cancelRunHasAlreadyCompleted:
                   value:
                     error_code: 5050
-                    error_message: "GAL5050E: Error occured when trying to cancel the run 'U123'. The run has already completed."
+                    error_message: "GAL5050E: Error occurred when trying to cancel the run 'U123'. The run has already completed."
                   summary: The run in the request has already completed and can not be cancelled
         '401':
           $ref: "#/components/responses/Unauthorized"
@@ -1434,18 +1434,18 @@ paths:
                 genericerror:
                   value:
                     error_code: 5000
-                    error_message: "GAL5000E: Error occured when trying to access the endpoint. Report the problem to your Galasa Ecosystem owner."
-                  summary: An error occured when trying to access the endpoint
+                    error_message: "GAL5000E: Error occurred when trying to access the endpoint. Report the problem to your Galasa Ecosystem owner."
+                  summary: An Error occurred when trying to access the endpoint
                 unableToReset:
                   value:
                    error_code: 5047
-                   error_message: "GAL5047E: Error occured when trying to reset the run 'U123'. Report the problem to your Galasa Ecosystem owner."
-                  summary: An error occured when trying to action the run reset
+                   error_message: "GAL5047E: Error occurred when trying to reset the run 'U123'. Report the problem to your Galasa Ecosystem owner."
+                  summary: An Error occurred when trying to action the run reset
                 unableToCancel:
                   value:
                     error_code: 5048
-                    error_message: "GAL5048E: Error occured when trying to cancel the run 'U123'. Report the problem to your Galasa Ecosystem owner."
-                  summary: An error occured when trying to action the run cancel
+                    error_message: "GAL5048E: Error occurred when trying to cancel the run 'U123'. Report the problem to your Galasa Ecosystem owner."
+                  summary: An Error occurred when trying to action the run cancel
   #--------------------------------------
   # Retrieve Run Log.
   #--------------------------------------
@@ -1525,7 +1525,7 @@ paths:
                   value:
                     error_code: 5002
                     error_message: "GAL5002E: Error retrieving ras run from RunID 'cdb-xxx'."
-                  summary: An error occured when trying to retrieve a specific run using a runId
+                  summary: An Error occurred when trying to retrieve a specific run using a runId
         '500':
           $ref: '#/components/responses/InternalServerError'
 
@@ -1581,7 +1581,7 @@ paths:
                   value:
                     error_code: 5002
                     error_message: "GAL5002E: Error retrieving ras run from RunID 'cdb-xxx'."
-                  summary: An error occured when trying to retrieve a specific run  using a runId
+                  summary: An Error occurred when trying to retrieve a specific run  using a runId
         '500':
           description: Internal Server Error
           content:
@@ -1592,18 +1592,18 @@ paths:
                 genericerror:
                   value:
                     error_code: 5000
-                    error_message: "GAL5000E: Error occured when trying to access the endpoint. Report the problem to your Galasa Ecosystem owner."
-                  summary: An error occured when trying to access the endpoint
+                    error_message: "GAL5000E: Error occurred when trying to access the endpoint. Report the problem to your Galasa Ecosystem owner."
+                  summary: An Error occurred when trying to access the endpoint
                 locatingerror:
                   value:
                     error_code: 5008
                     error_message: "GAL5008E: Error locating artifact '/unlocated.file' for run with identifier 'U116'."
-                  summary: An error occured when trying to locate the artifact
+                  summary: An Error occurred when trying to locate the artifact
                 retrievingerror:
                   value:
                     error_code: 5009
                     error_message: "GAL5009E: Error retrieving artifact  '/framework/cps_record.properties' for run with identifier 'U116'."
-                  summary: An error occured when trying to retrieve the artifact
+                  summary: An Error occurred when trying to retrieve the artifact
 
   #--------------------------------------
   # List all testclasses.
@@ -1741,8 +1741,8 @@ components:
             genericerror:
               value:
                 error_code: 5000
-                error_message: "GAL5000E: Error occured when trying to access the endpoint. Report the problem to your Galasa Ecosystem owner."
-              summary: An error occured when trying to access the endpoint
+                error_message: "GAL5000E: Error occurred when trying to access the endpoint. Report the problem to your Galasa Ecosystem owner."
+              summary: An Error occurred when trying to access the endpoint
     Unauthorized:
       description: Unauthorized as a valid bearer token has not been provided in the "Authorization" header
       content:

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunDetailsRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunDetailsRoute.java
@@ -553,7 +553,7 @@ public class TestRunDetailsRoute extends RasServletTest {
 		assertThat(resp.getStatus()).isEqualTo(400);
 		checkErrorStructure(outStream.toString(), 
 			5045, 
-			"E: Error occured. The field 'status' in the request body is invalid. The 'status' value 'submitted' supplied is not supported. Supported values are: 'queued' and 'finished'.");
+			"E: Error occurred. The field 'status' in the request body is invalid. The 'status' value 'submitted' supplied is not supported. Supported values are: 'queued' and 'finished'.");
 	}
 	
 	@Test
@@ -594,7 +594,7 @@ public class TestRunDetailsRoute extends RasServletTest {
 		assertThat(resp.getStatus()).isEqualTo(500);
 		checkErrorStructure(outStream.toString(), 
 			5047, 
-			"E: Error occured when trying to reset the run 'U123'. Report the problem to your Galasa Ecosystem owner.");
+			"E: Error occurred when trying to reset the run 'U123'. Report the problem to your Galasa Ecosystem owner.");
 	}
 
 	@Test
@@ -635,7 +635,7 @@ public class TestRunDetailsRoute extends RasServletTest {
 		assertThat(resp.getStatus()).isEqualTo(500);
 		checkErrorStructure(outStream.toString(), 
 			5048, 
-			"E: Error occured when trying to cancel the run 'U123'. Report the problem to your Galasa Ecosystem owner.");
+			"E: Error occurred when trying to cancel the run 'U123'. Report the problem to your Galasa Ecosystem owner.");
 	}
 	
 	@Test
@@ -676,7 +676,7 @@ public class TestRunDetailsRoute extends RasServletTest {
 		assertThat(resp.getStatus()).isEqualTo(400);
 		checkErrorStructure(outStream.toString(), 
 			5049, 
-			"E: Error occured when trying to reset the run 'U123'. The run has already completed.");
+			"E: Error occurred when trying to reset the run 'U123'. The run has already completed.");
 	}
 
 	@Test
@@ -717,7 +717,7 @@ public class TestRunDetailsRoute extends RasServletTest {
 		assertThat(resp.getStatus()).isEqualTo(400);
 		checkErrorStructure(outStream.toString(), 
 			5050, 
-			"E: Error occured when trying to cancel the run 'U123'. The run has already completed.");
+			"E: Error occurred when trying to cancel the run 'U123'. The run has already completed.");
 	}
 
 	@Test
@@ -753,7 +753,7 @@ public class TestRunDetailsRoute extends RasServletTest {
 		assertThat(resp.getStatus()).isEqualTo(400);
 		checkErrorStructure(outStream.toString(), 
 			5046, 
-			"E: Error occured when trying to cancel the run 'U123'. The 'result' 'deleted' supplied is not supported. Supported values are: 'cancelled'.");
+			"E: Error occurred when trying to cancel the run 'U123'. The 'result' 'deleted' supplied is not supported. Supported values are: 'cancelled'.");
 	}
 
 

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunQuery.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunQuery.java
@@ -431,7 +431,7 @@ public class TestRunQuery extends RasServletTest {
 			outStream.toString(),
 			5000,
 			"GAL5000E: ",
-			"Error occured when trying to access the endpoint"
+			"Error occurred when trying to access the endpoint"
 		);
 	}
 

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestTestClassesRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestTestClassesRoute.java
@@ -451,7 +451,7 @@ public class TestTestClassesRoute extends RasServletTest{
 			outStream.toString(),
 			5000,
 			"GAL5000E: ",
-			"Error occured when trying to access the endpoint. Report the problem to your Galasa Ecosystem owner."
+			"Error occurred when trying to access the endpoint. Report the problem to your Galasa Ecosystem owner."
 		);
 	}
 

--- a/galasa-parent/dev.galasa.framework.api.resources/src/test/java/dev/galasa/framework/api/resources/routes/TestResourcesRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.resources/src/test/java/dev/galasa/framework/api/resources/routes/TestResourcesRoute.java
@@ -173,7 +173,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         //Then...
         assertThat(errors).isNotNull();
         assertThat(errors.size()).isEqualTo(1);
-        assertThat(errors.get(0)).contains("GAL5043E: Invalid property name. Property name 'property1!' much have at least two parts seperated by a . (dot).");
+        assertThat(errors.get(0)).contains("GAL5043E: Invalid property name. Property name 'property1!' much have at least two parts separated by a . (dot).");
         checkPropertyNotInNamespace(namespace,propertyname,value);
     }
 
@@ -196,7 +196,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         //Then...
         assertThat(errors).isNotNull();
         assertThat(errors.size()).isEqualTo(1);
-        assertThat(errors.get(0)).contains("GAL5044E: Invalid property name. Property name 'property.name.' must not end with a . (dot) seperator.");
+        assertThat(errors.get(0)).contains("GAL5044E: Invalid property name. Property name 'property.name.' must not end with a . (dot) separator.");
         checkPropertyNotInNamespace(namespace,propertyname,value);
     }
 
@@ -242,7 +242,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         //Then...
         assertThat(errors).isNotNull();
         assertThat(errors.size()).isEqualTo(1);
-        assertThat(errors.get(0)).contains("GAL5043E: Invalid property name. Property name 'property' much have at least two parts seperated by a . (dot).");
+        assertThat(errors.get(0)).contains("GAL5043E: Invalid property name. Property name 'property' much have at least two parts separated by a . (dot).");
         checkPropertyNotInNamespace(namespace,propertyname,value);
     }
 
@@ -380,7 +380,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         //Then...
         assertThat(errors).isNotNull();
         assertThat(errors.size()).isEqualTo(1);
-        assertThat(errors.get(0)).contains("GAL5024E: Error occured because the Galasa Property is invalid.",
+        assertThat(errors.get(0)).contains("GAL5024E: Error occurred because the Galasa Property is invalid.",
             "The 'value' field cannot be empty. The field 'value' is mandatory for the type GalasaProperty.");
         checkPropertyNotInNamespace(namespace,propertyname,value);
     }
@@ -406,7 +406,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         assertThat(errors.size()).isEqualTo(3);
         assertThat(errors.get(0)).contains("GAL5040E: Invalid property name. Property name is missing or empty.");
         assertThat(errors.get(1)).contains("GAL5031E: Invalid namespace. Namespace is empty.");
-        assertThat(errors.get(2)).contains("GAL5024E: Error occured because the Galasa Property is invalid. 'The 'value' field cannot be empty. The field 'value' is mandatory for the type GalasaProperty.'");
+        assertThat(errors.get(2)).contains("GAL5024E: Error occurred because the Galasa Property is invalid. 'The 'value' field cannot be empty. The field 'value' is mandatory for the type GalasaProperty.'");
         checkPropertyNotInNamespace(namespace,propertyname,value);
     }
 
@@ -430,9 +430,9 @@ public class TestResourcesRoute extends ResourcesServletTest{
         //Then...
         assertThat(errors).isNotNull();
         assertThat(errors.size()).isEqualTo(2);
-        assertThat(errors.get(0)).contains("GAL5024E: Error occured because the Galasa Property is invalid.",
+        assertThat(errors.get(0)).contains("GAL5024E: Error occurred because the Galasa Property is invalid.",
             "The 'metadata' field cannot be empty. The fields 'name' and 'namespace' are mandatory for the type GalasaProperty.");
-        assertThat(errors.get(1)).contains("GAL5024E: Error occured because the Galasa Property is invalid.",
+        assertThat(errors.get(1)).contains("GAL5024E: Error occurred because the Galasa Property is invalid.",
             "The 'data' field cannot be empty. The field 'value' is mandatory for the type GalasaProperty.");
         checkPropertyNotInNamespace(namespace,propertyname,value);
     }
@@ -456,7 +456,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
 
         //Then...
         assertThat(thrown).isNotNull();
-        assertThat(thrown.getMessage()).contains("GAL5027E: Error occured. The field apiVersion in the request body is invalid. The value '' is not a supported version." +
+        assertThat(thrown.getMessage()).contains("GAL5027E: Error occurred. The field apiVersion in the request body is invalid. The value '' is not a supported version." +
             " Currently the ecosystem accepts the 'galasa-dev/v1alpha1' api version. This could indicate a mis-match between client and server levels." +
             " Please check with your Ecosystem administrator the level. You may have to upgrade/downgrade your client program.");
         checkPropertyNotInNamespace(namespace,propertyname,value);
@@ -482,7 +482,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         //Then...
         assertThat(errors).isNotNull();
         assertThat(errors.size()).isEqualTo(1);
-        assertThat(errors.get(0)).contains("GAL5400E: Error occured when trying to execute request ",". Please check your request parameters or report the problem to your Galasa Ecosystem owner.");
+        assertThat(errors.get(0)).contains("GAL5400E: Error occurred when trying to execute request ",". Please check your request parameters or report the problem to your Galasa Ecosystem owner.");
         checkPropertyNotInNamespace(namespace,propertyname,value);
     }
 
@@ -505,7 +505,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
 
         //Then...
         assertThat(errors.size()).isEqualTo(3);
-        checkErrorListContainsError(errors,"GAL5068E: Error occured. The JSON element for a resource can not be empty. Please check the request format, or check with your Ecosystem administrator.");
+        checkErrorListContainsError(errors,"GAL5068E: Error occurred. The JSON element for a resource can not be empty. Please check the request format, or check with your Ecosystem administrator.");
         checkPropertyNotInNamespace(namespace,propertyname,value);
     }
     
@@ -528,7 +528,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
 
         //Then...
         assertThat(errors.size()).isEqualTo(1);
-        checkErrorListContainsError(errors,"GAL5400E: Error occured when trying to execute request ");
+        checkErrorListContainsError(errors,"GAL5400E: Error occurred when trying to execute request ");
         checkPropertyNotInNamespace(namespace,propertyname,value);
     }
 
@@ -551,7 +551,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
 
         //Then...
         assertThat(errors.size()).isEqualTo(1);
-        checkErrorListContainsError(errors,"GAL5026E: Error occured. The field kind in the request body is invalid. The value 'GalasaProperly' is not supported." +
+        checkErrorListContainsError(errors,"GAL5026E: Error occurred. The field kind in the request body is invalid. The value 'GalasaProperly' is not supported." +
             " This could indicate a mis-match between client and server levels. Please check with your Ecosystem administrator the level." +
             " You may have to upgrade/downgrade your client program.");
         checkPropertyNotInNamespace(namespace,propertyname,value);
@@ -574,7 +574,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
 
         //Then...
         assertThat(errors.size()).isEqualTo(1);
-        checkErrorListContainsError(errors,"GAL5067E: Error occured. A 'NULL' value is not a valid resource. Please check the request format, or check with your Ecosystem administrator.");
+        checkErrorListContainsError(errors,"GAL5067E: Error occurred. A 'NULL' value is not a valid resource. Please check the request format, or check with your Ecosystem administrator.");
     }
 
     @Test
@@ -618,12 +618,12 @@ public class TestResourcesRoute extends ResourcesServletTest{
 
         //Then...
         assertThat(errors.size()).isEqualTo(4);
-        checkErrorListContainsError(errors,"GAL5067E: Error occured. A 'NULL' value is not a valid resource. Please check the request format, or check with your Ecosystem administrator.");
-        checkErrorListContainsError(errors,"GAL5400E: Error occured when trying to execute request ");
-        checkErrorListContainsError(errors,"GAL5026E: Error occured. The field kind in the request body is invalid. The value 'GalasaProperly' is not supported." +
+        checkErrorListContainsError(errors,"GAL5067E: Error occurred. A 'NULL' value is not a valid resource. Please check the request format, or check with your Ecosystem administrator.");
+        checkErrorListContainsError(errors,"GAL5400E: Error occurred when trying to execute request ");
+        checkErrorListContainsError(errors,"GAL5026E: Error occurred. The field kind in the request body is invalid. The value 'GalasaProperly' is not supported." +
             " This could indicate a mis-match between client and server levels. Please check with your Ecosystem administrator the level." +
             " You may have to upgrade/downgrade your client program.");
-        checkErrorListContainsError(errors,"GAL5068E: Error occured. The JSON element for a resource can not be empty. Please check the request format, or check with your Ecosystem administrator.");
+        checkErrorListContainsError(errors,"GAL5068E: Error occurred. The JSON element for a resource can not be empty. Please check the request format, or check with your Ecosystem administrator.");
         checkPropertyNotInNamespace(namespace,propertyname,value);
     }
 
@@ -651,7 +651,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         assertThat(errors.size()).isEqualTo(1);
         checkPropertyInNamespace(namespace,propertyname,value);
         checkPropertyNotInNamespace(namespace,propertyNameTwo,valueTwo);
-        assertThat(errors.get(0)).contains("GAL5018E: Error occured when trying to access property 'property.1'. "+
+        assertThat(errors.get(0)).contains("GAL5018E: Error occurred when trying to access property 'property.1'. "+
                 "The property name provided already exists in the 'framework' namespace.");
     }
 
@@ -679,9 +679,9 @@ public class TestResourcesRoute extends ResourcesServletTest{
         assertThat(errors.size()).isEqualTo(2);
         checkPropertyNotInNamespace(namespace,propertyname,value);
         checkPropertyNotInNamespace(namespace,propertyname,value);
-        assertThat(errors.get(0)).contains("GAL5018E: Error occured when trying to access property 'property.1'. "+
+        assertThat(errors.get(0)).contains("GAL5018E: Error occurred when trying to access property 'property.1'. "+
                 "The property name provided already exists in the 'framework' namespace.");
-        assertThat(errors.get(1)).contains("GAL5018E: Error occured when trying to access property 'property.2'. "+
+        assertThat(errors.get(1)).contains("GAL5018E: Error occurred when trying to access property 'property.2'. "+
                 "The property name provided already exists in the 'framework' namespace.");
     }
 
@@ -709,7 +709,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         assertThat(errors.size()).isEqualTo(1);
         checkPropertyNotInNamespace(namespace,propertyname,value);
         checkPropertyInNamespace(namespace,propertyNameTwo,valueTwo);
-        assertThat(errors.get(0)).contains("GAL5017E: Error occured when trying to access property 'property.name'. The property does not exist.");
+        assertThat(errors.get(0)).contains("GAL5017E: Error occurred when trying to access property 'property.name'. The property does not exist.");
     }
 
     @Test
@@ -736,8 +736,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         assertThat(errors.size()).isEqualTo(2);
         checkPropertyNotInNamespace(namespace,propertyname,value);
         checkPropertyNotInNamespace(namespace,propertyname,value);
-        assertThat(errors.get(0)).contains("GAL5017E: Error occured when trying to access property 'property.name'. The property does not exist.");
-        assertThat(errors.get(1)).contains("GAL5017E: Error occured when trying to access property 'property.name.2'. The property does not exist");
+        assertThat(errors.get(0)).contains("GAL5017E: Error occurred when trying to access property 'property.name'. The property does not exist.");
+        assertThat(errors.get(1)).contains("GAL5017E: Error occurred when trying to access property 'property.name.2'. The property does not exist");
     }
 
     /*
@@ -833,7 +833,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String message = thrown.getMessage();
         checkErrorStructure(message, 
             5025,
-            "GAL5025E: Error occured. The field action in the request body is invalid. The action value'badaction' supplied is not supported." +
+            "GAL5025E: Error occurred. The field action in the request body is invalid. The action value'badaction' supplied is not supported." +
                 " Supported actions are: create, apply and update. This could indicate a mis-match between client and server levels." +
                 " Please check with your Ecosystem administrator the level. You may have to upgrade/downgrade your client program.");
         checkPropertyNotInNamespace(namespace,propertyname,value);
@@ -910,7 +910,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String output = outStream.toString();
         assertThat(status).isEqualTo(400);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-        assertThat(output).contains("GAL5017E: Error occured when trying to access property 'property.name'. The property does not exist.");
+        assertThat(output).contains("GAL5017E: Error occurred when trying to access property 'property.name'. The property does not exist.");
         checkPropertyNotInNamespace(namespace, propertyname, value);
     }
 
@@ -1240,7 +1240,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String output = outStream.toString();
         assertThat(status).isEqualTo(400);
 		assertThat(resp.getContentType()).isEqualTo("application/json");
-        assertThat(output).contains("GAL5030E: Error occured when trying to delete Property 'property.1'. Report the problem to your Galasa Ecosystem owner.");
+        assertThat(output).contains("GAL5030E: Error occurred when trying to delete Property 'property.1'. Report the problem to your Galasa Ecosystem owner.");
         checkPropertyNotInNamespace(namespace, propertyname, value);
     }
 
@@ -1272,8 +1272,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String output = outStream.toString();
         assertThat(status).isEqualTo(400);
 		assertThat(resp.getContentType()).isEqualTo("application/json"); 
-        assertThat(output).contains("GAL5030E: Error occured when trying to delete Property 'property.1'. Report the problem to your Galasa Ecosystem owner.");
-        assertThat(output).contains("GAL5030E: Error occured when trying to delete Property 'property.5'. Report the problem to your Galasa Ecosystem owner.");
+        assertThat(output).contains("GAL5030E: Error occurred when trying to delete Property 'property.1'. Report the problem to your Galasa Ecosystem owner.");
+        assertThat(output).contains("GAL5030E: Error occurred when trying to delete Property 'property.5'. Report the problem to your Galasa Ecosystem owner.");
         checkPropertyNotInNamespace(namespace, propertyname, value);
         checkPropertyNotInNamespace(namespace, propertynametwo, valuetwo);
     }
@@ -1312,7 +1312,7 @@ public class TestResourcesRoute extends ResourcesServletTest{
         String output = outStream.toString();
         assertThat(status).isEqualTo(400);
 		assertThat(resp.getContentType()).isEqualTo("application/json"); 
-        assertThat(output).contains("GAL5067E: Error occured. A 'NULL' value is not a valid resource. Please check the request format, or check with your Ecosystem administrator.");
+        assertThat(output).contains("GAL5067E: Error occurred. A 'NULL' value is not a valid resource. Please check the request format, or check with your Ecosystem administrator.");
         checkPropertyInNamespace(namespace, propertyname, value);
         checkPropertyInNamespace(namespace, propertynametwo, valuetwo);
     }
@@ -1343,8 +1343,8 @@ public class TestResourcesRoute extends ResourcesServletTest{
     public void TestGetErrorsAsJsonReturnsJsonString() throws Exception{
         // Given...
         List<String> errors = new ArrayList<String>();
-        errors.add("{\"error_code\":5030,\"error_message\":\"GAL5030E: Error occured when trying to delete Property 'property.5'. Report the problem to your Galasa Ecosystem owner.\"}");
-        errors.add("{\"error_code\":5030,\"error_message\":\"GAL5030E: Error occured when trying to delete Property 'property.1'. Report the problem to your Galasa Ecosystem owner.\"}");
+        errors.add("{\"error_code\":5030,\"error_message\":\"GAL5030E: Error occurred when trying to delete Property 'property.5'. Report the problem to your Galasa Ecosystem owner.\"}");
+        errors.add("{\"error_code\":5030,\"error_message\":\"GAL5030E: Error occurred when trying to delete Property 'property.1'. Report the problem to your Galasa Ecosystem owner.\"}");
         setServlet("framework");
         MockResourcesServlet servlet = getServlet();
         CPSFacade cps = new CPSFacade(servlet.getFramework());
@@ -1358,10 +1358,10 @@ public class TestResourcesRoute extends ResourcesServletTest{
         JsonArray expectedJsonArray = new JsonArray();
         JsonObject errorProp5 = new JsonObject();
         errorProp5.addProperty("error_code" , 5030);
-        errorProp5.addProperty("error_message" , "GAL5030E: Error occured when trying to delete Property 'property.5'. Report the problem to your Galasa Ecosystem owner.");
+        errorProp5.addProperty("error_message" , "GAL5030E: Error occurred when trying to delete Property 'property.5'. Report the problem to your Galasa Ecosystem owner.");
         JsonObject errorProp1 = new JsonObject();
         errorProp1.addProperty("error_code" , 5030);
-        errorProp1.addProperty("error_message" , "GAL5030E: Error occured when trying to delete Property 'property.1'. Report the problem to your Galasa Ecosystem owner.");
+        errorProp1.addProperty("error_message" , "GAL5030E: Error occurred when trying to delete Property 'property.1'. Report the problem to your Galasa Ecosystem owner.");
         expectedJsonArray.add(errorProp5);
         expectedJsonArray.add(errorProp1);
         GalasaGson gson = new GalasaGson();
@@ -1401,10 +1401,10 @@ public class TestResourcesRoute extends ResourcesServletTest{
         JsonArray expectedJsonArray = new JsonArray();
         JsonObject errorProp5 = new JsonObject();
         errorProp5.addProperty("error_code" , 5030);
-        errorProp5.addProperty("error_message" , "GAL5030E: Error occured when trying to delete Property 'property.5'. Report the problem to your Galasa Ecosystem owner.");
+        errorProp5.addProperty("error_message" , "GAL5030E: Error occurred when trying to delete Property 'property.5'. Report the problem to your Galasa Ecosystem owner.");
         JsonObject errorProp1 = new JsonObject();
         errorProp1.addProperty("error_code" , 5030);
-        errorProp1.addProperty("error_message" , "GAL5030E: Error occured when trying to delete Property 'property.1'. Report the problem to your Galasa Ecosystem owner.");
+        errorProp1.addProperty("error_message" , "GAL5030E: Error occurred when trying to delete Property 'property.1'. Report the problem to your Galasa Ecosystem owner.");
         expectedJsonArray.add(errorProp5);
         expectedJsonArray.add(errorProp1);
         GalasaGson gson = new GalasaGson();

--- a/galasa-parent/dev.galasa.framework.api.runs/build.gradle
+++ b/galasa-parent/dev.galasa.framework.api.runs/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 description = 'Galasa Runs API'
 
-version = '0.36.0'
+version = '0.37.0'
 
 dependencies {
     implementation project(':dev.galasa.framework')

--- a/galasa-parent/dev.galasa.framework.api.runs/src/test/java/dev/galasa/framework/api/runs/routes/TestGroupRunsRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.runs/src/test/java/dev/galasa/framework/api/runs/routes/TestGroupRunsRoute.java
@@ -171,7 +171,7 @@ public class TestGroupRunsRoute extends RunsServletTest{
 			outStream.toString(),
 			5000,
 			"GAL5000E: ",
-			"Error occured when trying to access the endpoint"
+			"Error occurred when trying to access the endpoint"
 		);
     }
 
@@ -383,7 +383,7 @@ public class TestGroupRunsRoute extends RunsServletTest{
 			outStream.toString(),
 			5000,
 			"GAL5000E: ",
-			"Error occured when trying to access the endpoint"
+			"Error occurred when trying to access the endpoint"
 		);
     }
 
@@ -407,7 +407,7 @@ public class TestGroupRunsRoute extends RunsServletTest{
 
 		checkErrorStructure(
 			outStream.toString(),
-			5411, "GAL5411E: Error occured when trying to access the endpoint '/valid'. The request body is empty."
+			5411, "GAL5411E: Error occurred when trying to access the endpoint '/valid'. The request body is empty."
 		);
     }
 
@@ -431,7 +431,7 @@ public class TestGroupRunsRoute extends RunsServletTest{
 
 		checkErrorStructure(
 			outStream.toString(),
-			5020, "GAL5020E: Error occured when trying to translate the payload into a run."
+			5020, "GAL5020E: Error occurred when trying to translate the payload into a run."
 		);
     }
 
@@ -464,7 +464,7 @@ public class TestGroupRunsRoute extends RunsServletTest{
         assertThat(resp.getStatus()).isEqualTo(400);
         checkErrorStructure(
 			outStream.toString(),
-			5020, "E: Error occured when trying to translate the payload into a run."
+			5020, "E: Error occurred when trying to translate the payload into a run."
 		);
     }
     
@@ -497,7 +497,7 @@ public class TestGroupRunsRoute extends RunsServletTest{
         assertThat(resp.getStatus()).isEqualTo(500);
         checkErrorStructure(
 			outStream.toString(),
-			5022, "GAL5022E: Error occured trying parse the sharedEnvironmentPhase 'envPhase'. Valid options are BUILD, DISCARD."
+			5022, "GAL5022E: Error occurred trying parse the sharedEnvironmentPhase 'envPhase'. Valid options are BUILD, DISCARD."
 		);
     }
 
@@ -579,7 +579,7 @@ public class TestGroupRunsRoute extends RunsServletTest{
         assertThat(resp.getStatus()).isEqualTo(500);
         checkErrorStructure(
 			outStream.toString(),
-			5021, "E: Error occured when trying to submit run 'Class/name'."
+			5021, "E: Error occurred when trying to submit run 'Class/name'."
 		);
     }
 

--- a/release.yaml
+++ b/release.yaml
@@ -172,7 +172,7 @@ api:
     codecoverage: true
 
   - artifact: dev.galasa.framework.api.cps
-    version: 0.36.0
+    version: 0.37.0
     obr:          true
     mvp:          false
     bom:          false
@@ -235,7 +235,7 @@ api:
     codecoverage: true
 
   - artifact: dev.galasa.framework.api.runs
-    version: 0.36.0
+    version: 0.37.0
     obr:          true
     mvp:          false
     bom:          false


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1973

## Changes
- Fixed route handling logic to avoid processing PATCH and other unused methods as GET requests and instead throw a 405 Method Not Allowed error
- Fixed spelling errors in error messages: `occured -> occurred`, `seperator -> separator`, `seperated -> separated`