### PR TITLE
Separate out loading run artifacts and only load artifacts where needed to improve delete runs performance

### DIFF
--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunArtifactsDownloadRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunArtifactsDownloadRoute.java
@@ -95,6 +95,7 @@ public class RunArtifactsDownloadRoute extends RunArtifactsRoute {
         // Get run details in order to find artifacts
         try {
             run = getRunByRunId(runId);
+            run.loadArtifacts();
             runName = run.getTestStructure().getRunName();
         } catch (ResultArchiveStoreException e) {
             ServletError error = new ServletError(GAL5002_INVALID_RUN_ID,runId);

--- a/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunArtifactsListRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/main/java/dev/galasa/framework/api/ras/internal/routes/RunArtifactsListRoute.java
@@ -74,6 +74,7 @@ public class RunArtifactsListRoute extends RunArtifactsRoute {
         JsonArray artifacts = new JsonArray();
         try {
             run = getRunByRunId(runId);
+            run.loadArtifacts();
         } catch (ResultArchiveStoreException e) {
             ServletError error = new ServletError(GAL5002_INVALID_RUN_ID, runId);
             throw new InternalServletException(error, HttpServletResponse.SC_NOT_FOUND, e);

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/mocks/MockRunResult.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/mocks/MockRunResult.java
@@ -18,7 +18,7 @@ public class MockRunResult implements IRunResult {
     private Path artifactRoot;
     private String log;
     private boolean isDiscarded = false;
-    private boolean areArtifactsLoaded = false;
+    private boolean isLoadingArtifactsEnabled = false;
 
     public MockRunResult( 
         String runId,
@@ -59,14 +59,14 @@ public class MockRunResult implements IRunResult {
 
     @Override
     public void loadArtifacts() throws ResultArchiveStoreException {
-        areArtifactsLoaded = true;
+        isLoadingArtifactsEnabled = true;
     }
 
     public boolean isDiscarded() {
         return this.isDiscarded;
     }
 
-    public boolean areArtifactsLoaded() {
-        return areArtifactsLoaded;
+    public boolean isLoadingArtifactsEnabled() {
+        return isLoadingArtifactsEnabled;
     }
 }

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/mocks/MockRunResult.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/mocks/MockRunResult.java
@@ -18,6 +18,7 @@ public class MockRunResult implements IRunResult {
     private Path artifactRoot;
     private String log;
     private boolean isDiscarded = false;
+    private boolean areArtifactsLoaded = false;
 
     public MockRunResult( 
         String runId,
@@ -55,9 +56,17 @@ public class MockRunResult implements IRunResult {
     public void discard() throws ResultArchiveStoreException {
         isDiscarded = true;
     }
-    
+
+    @Override
+    public void loadArtifacts() throws ResultArchiveStoreException {
+        areArtifactsLoaded = true;
+    }
 
     public boolean isDiscarded() {
         return this.isDiscarded;
+    }
+
+    public boolean areArtifactsLoaded() {
+        return areArtifactsLoaded;
     }
 }

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunDetailsRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunDetailsRoute.java
@@ -781,7 +781,7 @@ public class TestRunDetailsRoute extends RasServletTest {
 		// Then...
         MockRunResult deletedRun = (MockRunResult) mockInputRunResults.get(0);
 		assertThat(resp.getStatus()).isEqualTo(204);
-		assertThat(deletedRun.areArtifactsLoaded()).as("The fake run result's artifacts should not have been loaded.").isFalse();
+		assertThat(deletedRun.isLoadingArtifactsEnabled()).as("The fake run result's artifacts should not have been loaded.").isFalse();
 		assertThat(deletedRun.isDiscarded()).as("The fake run result has not been discarded.").isTrue();
 	}
 

--- a/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunDetailsRoute.java
+++ b/galasa-parent/dev.galasa.framework.api.ras/src/test/java/dev/galasa/framework/api/ras/internal/routes/TestRunDetailsRoute.java
@@ -779,8 +779,10 @@ public class TestRunDetailsRoute extends RasServletTest {
 		servlet.doDelete(req,resp);
 
 		// Then...
+        MockRunResult deletedRun = (MockRunResult) mockInputRunResults.get(0);
 		assertThat(resp.getStatus()).isEqualTo(204);
-		assertThat(((MockRunResult) mockInputRunResults.get(0)).isDiscarded()).as("The fake run result has not been discarded.").isTrue();
+		assertThat(deletedRun.areArtifactsLoaded()).as("The fake run result's artifacts should not have been loaded.").isFalse();
+		assertThat(deletedRun.isDiscarded()).as("The fake run result has not been discarded.").isTrue();
 	}
 
 

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/ras/directory/DirectoryRASRunResult.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/internal/ras/directory/DirectoryRASRunResult.java
@@ -81,4 +81,9 @@ public class DirectoryRASRunResult implements IRunResult {
     public String getRunId() {
         return this.id;
     }
+
+    @Override
+    public void loadArtifacts() throws ResultArchiveStoreException {
+        // Artifacts for local runs are already available on the filesystem so there is no need to load anything
+    }
 }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IRunResult.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/IRunResult.java
@@ -21,4 +21,6 @@ public interface IRunResult {
 
     void discard() throws ResultArchiveStoreException;
 
+    void loadArtifacts() throws ResultArchiveStoreException;
+
 }


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1210

When getting a run by its ID, all of the artifacts for the given run were being loaded which is unnecessary for API routes that don't care about artifacts. This PR separates the loading of artifacts into a separate `loadArtifacts` method on the IRunResult interface to provide more flexibility around when to load artifacts for a run.

## Changes
- Added `loadArtifacts` method to IRunResult interface and added calls to it in the routes that require artifacts to be loaded (i.e. the `/ras/runs/{run-id}/artifacts` and `/ras/runs/{run-id}/files/{artifact-path}` routes)