### PR TITLE
Set overrides in DSS as a single property, refactor code for submitting runs

### DIFF
--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BaseTestRunner.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BaseTestRunner.java
@@ -169,11 +169,13 @@ public class BaseTestRunner {
             String runOverridesProp = "run." + run.getName() + ".overrides";
             String runOverrides = dss.get(runOverridesProp);
             if (runOverrides != null && !runOverrides.isBlank()) {
-                for (String override : runOverrides.split(",")) {
+                for (String override : runOverrides.split("\n")) {
                     String[] overrideParts = override.split("=");
-                    String key = overrideParts[0];
-                    String value = overrideParts[1];
-                    overrideProperties.put(key, value);
+                    if (overrideParts.length == 2) {
+                        String key = overrideParts[0];
+                        String value = overrideParts[1];
+                        overrideProperties.put(key, value);
+                    }
                 }
             }
         } catch(Exception e) {

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BaseTestRunner.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BaseTestRunner.java
@@ -164,11 +164,12 @@ public class BaseTestRunner {
                                         IDynamicStatusStoreService dss) throws TestRunException {
         //*** Load the overrides if present
         try {
+            // The overrides DSS property contains a map of overrides, separated by newline characters in the form:
+            // dss.framework.run.<run-name>.overrides=override1=value1\noverride2=value2
             String runOverridesProp = "run." + run.getName() + ".overrides";
             String runOverrides = dss.get(runOverridesProp);
             if (runOverrides != null && !runOverrides.isBlank()) {
-                for(String override : runOverrides.split(",")) {
-                    // Each override is of the form "key=value"
+                for (String override : runOverrides.split(",")) {
                     String[] overrideParts = override.split("=");
                     String key = overrideParts[0];
                     String value = overrideParts[1];

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BaseTestRunner.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/BaseTestRunner.java
@@ -14,14 +14,12 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
-import java.util.Map.Entry;
 
 import javax.validation.constraints.NotNull;
 
 import dev.galasa.ResultArchiveStoreContentType;
 import dev.galasa.framework.internal.runner.ITestRunnerEventsProducer;
 import dev.galasa.framework.spi.AbstractManager;
-import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
 import dev.galasa.framework.spi.DynamicStatusStoreException;
 import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
@@ -166,12 +164,16 @@ public class BaseTestRunner {
                                         IDynamicStatusStoreService dss) throws TestRunException {
         //*** Load the overrides if present
         try {
-            String prefix = "run." + run.getName() + ".override.";
-            Map<String, String> runOverrides = dss.getPrefix(prefix);
-            for(Entry<String, String> entry : runOverrides.entrySet()) {
-                String key = entry.getKey().substring(prefix.length());
-                String value = entry.getValue();
-                overrideProperties.put(key, value);
+            String runOverridesProp = "run." + run.getName() + ".overrides";
+            String runOverrides = dss.get(runOverridesProp);
+            if (runOverrides != null && !runOverrides.isBlank()) {
+                for(String override : runOverrides.split(",")) {
+                    // Each override is of the form "key=value"
+                    String[] overrideParts = override.split("=");
+                    String key = overrideParts[0];
+                    String value = overrideParts[1];
+                    overrideProperties.put(key, value);
+                }
             }
         } catch(Exception e) {
             throw new TestRunException("Problem loading overrides from the run properties", e);

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkInitialisation.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkInitialisation.java
@@ -143,22 +143,26 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
         // *** If this is a test run, add the overrides from the run dss properties to
         // these overrides
         if (testrun) {
-            // The overrides DSS property contains a map of overrides, separated by newline characters in the form:
-            // dss.framework.run.<run-name>.overrides=override1=value1\noverride2=value2
-            String runOverridesProp = "run." + framework.getTestRunName() + ".overrides";
-            String runOverrides = this.dssFramework.get(runOverridesProp);
-            if (runOverrides != null && !runOverrides.isBlank()) {
-                for (String override : runOverrides.split("\n")) {
-                    String[] overrideParts = override.split("=");
-                    if (overrideParts.length == 2) {
-                        String key = overrideParts[0];
-                        String value = overrideParts[1];
-        
-                        if (logger.isTraceEnabled()) {
-                            logger.trace("Setting run override " + key + "=" + value);
-                        }
-                        overrideProperties.put(key, value);
+            loadOverridePropertiesFromDss(overrideProperties);
+        }
+    }
+
+    private void loadOverridePropertiesFromDss(Properties overrideProperties) throws DynamicStatusStoreException {
+        // The overrides DSS property contains a map of overrides, separated by newline characters in the form:
+        // dss.framework.run.<run-name>.overrides=override1=value1\noverride2=value2
+        String runOverridesProp = "run." + framework.getTestRunName() + ".overrides";
+        String runOverrides = this.dssFramework.get(runOverridesProp);
+        if (runOverrides != null && !runOverrides.isBlank()) {
+            for (String override : runOverrides.split("\n")) {
+                String[] overrideParts = override.split("=");
+                if (overrideParts.length == 2) {
+                    String key = overrideParts[0];
+                    String value = overrideParts[1];
+    
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("Setting run override " + key + "=" + value);
                     }
+                    overrideProperties.put(key, value);
                 }
             }
         }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkInitialisation.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkInitialisation.java
@@ -143,19 +143,22 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
         // *** If this is a test run, add the overrides from the run dss properties to
         // these overrides
         if (testrun) {
+            // The overrides DSS property contains a map of overrides, separated by newline characters in the form:
+            // dss.framework.run.<run-name>.overrides=override1=value1\noverride2=value2
             String runOverridesProp = "run." + framework.getTestRunName() + ".overrides";
             String runOverrides = this.dssFramework.get(runOverridesProp);
             if (runOverrides != null && !runOverrides.isBlank()) {
                 for (String override : runOverrides.split("\n")) {
-                    // Each override is of the form "key=value"
                     String[] overrideParts = override.split("=");
-                    String key = overrideParts[0];
-                    String value = overrideParts[1];
-    
-                    if (logger.isTraceEnabled()) {
-                        logger.trace("Setting run override " + key + "=" + value);
+                    if (overrideParts.length == 2) {
+                        String key = overrideParts[0];
+                        String value = overrideParts[1];
+        
+                        if (logger.isTraceEnabled()) {
+                            logger.trace("Setting run override " + key + "=" + value);
+                        }
+                        overrideProperties.put(key, value);
                     }
-                    overrideProperties.put(key, value);
                 }
             }
         }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkInitialisation.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkInitialisation.java
@@ -8,7 +8,6 @@ package dev.galasa.framework;
 import java.io.IOException;
 import java.net.*;
 import java.util.*;
-import java.util.Map.Entry;
 import java.nio.file.*;
 import javax.validation.constraints.NotNull;
 import org.apache.commons.logging.*;
@@ -144,18 +143,20 @@ public class FrameworkInitialisation implements IFrameworkInitialisation {
         // *** If this is a test run, add the overrides from the run dss properties to
         // these overrides
         if (testrun) {
-            String prefix = "run." + framework.getTestRunName() + ".override.";
-            int len = prefix.length();
-
-            Map<String, String> runOverrides = this.dssFramework.getPrefix(prefix);
-            for (Entry<String, String> override : runOverrides.entrySet()) {
-                String key = override.getKey().substring(len);
-                String value = override.getValue();
-
-                if (logger.isTraceEnabled()) {
-                    logger.trace("Setting run override " + key + "=" + value);
+            String runOverridesProp = "run." + framework.getTestRunName() + ".overrides";
+            String runOverrides = this.dssFramework.get(runOverridesProp);
+            if (runOverrides != null && !runOverrides.isBlank()) {
+                for (String override : runOverrides.split("\n")) {
+                    // Each override is of the form "key=value"
+                    String[] overrideParts = override.split("=");
+                    String key = overrideParts[0];
+                    String value = overrideParts[1];
+    
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("Setting run override " + key + "=" + value);
+                    }
+                    overrideProperties.put(key, value);
                 }
-                overrideProperties.put(override.getKey(), override.getValue());
             }
         }
     }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkRuns.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkRuns.java
@@ -207,39 +207,41 @@ public class FrameworkRuns implements IFrameworkRuns {
         boolean local = runRequest.isLocalRun();
         boolean trace = runRequest.isTraceEnabled();
 
+        String runPropertyPrefix = RUN_PREFIX + runName;
+
         // *** Set up the otherRunProperties that will go with the Run number
         HashMap<String, String> otherRunProperties = new HashMap<>();
-        otherRunProperties.put(RUN_PREFIX + runName + ".status", "queued");
-        otherRunProperties.put(RUN_PREFIX + runName + ".queued", Instant.now().toString());
-        otherRunProperties.put(RUN_PREFIX + runName + ".testbundle", bundleName);
-        otherRunProperties.put(RUN_PREFIX + runName + ".testclass", testName);
-        otherRunProperties.put(RUN_PREFIX + runName + ".request.type", runType);
-        otherRunProperties.put(RUN_PREFIX + runName + ".local", Boolean.toString(local));
+        otherRunProperties.put(runPropertyPrefix + ".status", "queued");
+        otherRunProperties.put(runPropertyPrefix + ".queued", Instant.now().toString());
+        otherRunProperties.put(runPropertyPrefix + ".testbundle", bundleName);
+        otherRunProperties.put(runPropertyPrefix + ".testclass", testName);
+        otherRunProperties.put(runPropertyPrefix + ".request.type", runType);
+        otherRunProperties.put(runPropertyPrefix + ".local", Boolean.toString(local));
         if (trace) {
-            otherRunProperties.put(RUN_PREFIX + runName + ".trace", "true");
+            otherRunProperties.put(runPropertyPrefix + ".trace", "true");
         }
         if (mavenRepository != null) {
-            otherRunProperties.put(RUN_PREFIX + runName + ".repository", mavenRepository);
+            otherRunProperties.put(runPropertyPrefix + ".repository", mavenRepository);
         }
         if (obr != null) {
-            otherRunProperties.put(RUN_PREFIX + runName + ".obr", obr);
+            otherRunProperties.put(runPropertyPrefix + ".obr", obr);
         }
         if (stream != null) {
-            otherRunProperties.put(RUN_PREFIX + runName + ".stream", stream);
+            otherRunProperties.put(runPropertyPrefix + ".stream", stream);
         }
         if (groupName != null) {
-            otherRunProperties.put(RUN_PREFIX + runName + ".group", groupName);
+            otherRunProperties.put(runPropertyPrefix + ".group", groupName);
         } else {
-            otherRunProperties.put(RUN_PREFIX + runName + ".group", UUID.randomUUID().toString());
+            otherRunProperties.put(runPropertyPrefix + ".group", UUID.randomUUID().toString());
         }
-        otherRunProperties.put(RUN_PREFIX + runName + ".requestor", requestor.toLowerCase());
+        otherRunProperties.put(runPropertyPrefix + ".requestor", requestor.toLowerCase());
 
         if (sharedEnvironmentPhase != null) {
-            otherRunProperties.put(RUN_PREFIX + runName + ".shared.environment", "true");
+            otherRunProperties.put(runPropertyPrefix + ".shared.environment", "true");
             overrides.put("framework.run.shared.environment.phase", sharedEnvironmentPhase.toString());
         }
-        if(gherkinTest != null) {
-            otherRunProperties.put(RUN_PREFIX + runName + ".gherkin", gherkinTest);
+        if (gherkinTest != null) {
+            otherRunProperties.put(runPropertyPrefix + ".gherkin", gherkinTest);
         }
 
         // *** Add in the overrides as a single property
@@ -249,12 +251,12 @@ public class FrameworkRuns implements IFrameworkRuns {
                 .map((entry) -> entry.getKey() + "=" + entry.getValue())
                 .collect(Collectors.joining("\n"));
 
-            otherRunProperties.put(RUN_PREFIX + runName + ".overrides", overridesStr);
+            otherRunProperties.put(runPropertyPrefix + ".overrides", overridesStr);
         }
 
         // *** See if we can setup the runnumber properties (clashes possible if low max
         // number or sharing prefix
-        return this.dss.putSwap(RUN_PREFIX + runName + ".test", null, bundleTest, otherRunProperties);
+        return this.dss.putSwap(runPropertyPrefix + ".test", null, bundleTest, otherRunProperties);
     }
 
     @Override
@@ -340,11 +342,12 @@ public class FrameworkRuns implements IFrameworkRuns {
         }
 
         HashMap<String, String> otherProperties = new HashMap<>();
-        otherProperties.put(RUN_PREFIX + sharedEnvironmentRunName + ".overrides", "framework.run.shared.environment.phase=" + SharedEnvironmentPhase.DISCARD.toString());
+        String runPropertyPrefix = RUN_PREFIX + sharedEnvironmentRunName;
+        otherProperties.put(runPropertyPrefix + ".overrides", "framework.run.shared.environment.phase=" + SharedEnvironmentPhase.DISCARD.toString());
         if (groupName != null) {
-            otherProperties.put(RUN_PREFIX + sharedEnvironmentRunName + ".group", groupName);
+            otherProperties.put(runPropertyPrefix + ".group", groupName);
         }
-        if (!this.dss.putSwap(RUN_PREFIX + sharedEnvironmentRunName + ".status", "up", "queued", otherProperties)) {
+        if (!this.dss.putSwap(runPropertyPrefix + ".status", "up", "queued", otherProperties)) {
             throw new FrameworkException("Failed to switch Shared Environment " + sharedEnvironmentRunName + " to discard");
         }
     }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkRuns.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkRuns.java
@@ -251,7 +251,7 @@ public class FrameworkRuns implements IFrameworkRuns {
 
             otherRunProperties.put(RUN_PREFIX + runName + ".overrides", overridesStr);
         }
-        
+
         // *** See if we can setup the runnumber properties (clashes possible if low max
         // number or sharing prefix
         return this.dss.putSwap(RUN_PREFIX + runName + ".test", null, bundleTest, otherRunProperties);
@@ -302,7 +302,7 @@ public class FrameworkRuns implements IFrameworkRuns {
 
     /**
      * Get the prefix of a given run type
-     */ 
+     */
     private String getRunTypePrefix(String runType) throws ConfigurationPropertyStoreException {
         String typePrefix = AbstractManager.nulled(this.cps.getProperty("request.type." + runType, "prefix"));
         if (typePrefix == null) {
@@ -416,7 +416,7 @@ public class FrameworkRuns implements IFrameworkRuns {
         if (AbstractManager.nulled(runRequest.getGroupName()) == null) {
             runRequest.setGroupName(NO_GROUP);
         }
-    
+
         String runType = AbstractManager.nulled(runRequest.getRunType());
         if (runType == null) {
             runType = NO_RUNTYPE;
@@ -468,11 +468,11 @@ public class FrameworkRuns implements IFrameworkRuns {
         SharedEnvironmentPhase sharedEnvironmentPhase = runRequest.getSharedEnvironmentPhase();
         if (sharedEnvironmentPhase != null) {
             String sharedEnvironmentRunName = runRequest.getSharedEnvironmentRunName();
-    
+
             if (sharedEnvironmentRunName == null || sharedEnvironmentRunName.trim().isEmpty()) {
                 throw new FrameworkException("Missing run name for shared environment");
             }
-    
+
             runRequest.setSharedEnvironmentRunName(sharedEnvironmentRunName.trim().toUpperCase());
         }
     }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/SubmitRunRequest.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/SubmitRunRequest.java
@@ -10,6 +10,9 @@ import java.util.Properties;
 import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.IFrameworkRuns.SharedEnvironmentPhase;
 
+/**
+ * An internal bean class containing the details required to submit a test run to the Galasa framework.
+ */
 public class SubmitRunRequest {
 
     private String runType;
@@ -45,10 +48,11 @@ public class SubmitRunRequest {
         String sharedEnvironmentRunName,
         String language
     ) throws FrameworkException {
+        setTestName(testName);
+
         this.runType = runType;
         this.requestor = requestor;
         this.bundleName = bundleName;
-        setTestName(testName);
         this.groupName = groupName;
         this.mavenRepository = mavenRepository;
         this.obr = obr;

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/SubmitRunRequest.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/SubmitRunRequest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework;
+
+import java.util.Properties;
+
+import dev.galasa.framework.spi.FrameworkException;
+import dev.galasa.framework.spi.IFrameworkRuns.SharedEnvironmentPhase;
+
+public class SubmitRunRequest {
+
+    private String runType;
+    private String requestor;
+    private String bundleName;
+    private String testName;
+    private String groupName;
+    private String mavenRepository;
+    private String obr;
+    private String stream;
+    private boolean isLocalRun;
+    private boolean isTraceEnabled = false;
+    private Properties overrides = new Properties();
+    private SharedEnvironmentPhase sharedEnvironmentPhase;
+    private String sharedEnvironmentRunName;
+    private String language = "java";
+    private String bundleTest;
+    private String gherkinTest;
+
+    public SubmitRunRequest(
+        String runType,
+        String requestor,
+        String bundleName,
+        String testName,
+        String groupName,
+        String mavenRepository,
+        String obr,
+        String stream,
+        boolean isLocalRun,
+        boolean isTraceEnabled,
+        Properties overrides,
+        SharedEnvironmentPhase sharedEnvironmentPhase,
+        String sharedEnvironmentRunName,
+        String language
+    ) throws FrameworkException {
+        this.runType = runType;
+        this.requestor = requestor;
+        this.bundleName = bundleName;
+        setTestName(testName);
+        this.groupName = groupName;
+        this.mavenRepository = mavenRepository;
+        this.obr = obr;
+        this.stream = stream;
+        this.isLocalRun = isLocalRun;
+        this.isTraceEnabled = isTraceEnabled;
+        this.overrides = overrides;
+        this.sharedEnvironmentPhase = sharedEnvironmentPhase;
+        this.sharedEnvironmentRunName = sharedEnvironmentRunName;
+        this.language = language;
+    }
+
+    public String getRunType() {
+        return runType;
+    }
+
+    public void setRunType(String runType) {
+        this.runType = runType;
+    }
+
+    public String getRequestor() {
+        return requestor;
+    }
+
+    public void setRequestor(String requestor) {
+        this.requestor = requestor;
+    }
+
+    public String getBundleName() {
+        return bundleName;
+    }
+
+    public void setBundleName(String bundleName) {
+        this.bundleName = bundleName;
+    }
+
+    public String getTestName() {
+        return testName;
+    }
+
+    public void setTestName(String testName) throws FrameworkException {
+        if (testName == null) {
+            throw new FrameworkException("Missing test name");
+        }
+        this.testName = testName;
+    }
+
+    public String getGroupName() {
+        return groupName;
+    }
+
+    public void setGroupName(String groupName) {
+        this.groupName = groupName;
+    }
+
+    public String getMavenRepository() {
+        return mavenRepository;
+    }
+
+    public void setMavenRepository(String mavenRepository) {
+        this.mavenRepository = mavenRepository;
+    }
+
+    public String getObr() {
+        return obr;
+    }
+
+    public void setObr(String obr) {
+        this.obr = obr;
+    }
+
+    public String getStream() {
+        return stream;
+    }
+
+    public void setStream(String stream) {
+        this.stream = stream;
+    }
+
+    public boolean isLocalRun() {
+        return isLocalRun;
+    }
+
+    public void setLocalRun(boolean isLocalRun) {
+        this.isLocalRun = isLocalRun;
+    }
+
+    public boolean isTraceEnabled() {
+        return isTraceEnabled;
+    }
+
+    public void setTraceEnabled(boolean isTraceEnabled) {
+        this.isTraceEnabled = isTraceEnabled;
+    }
+
+    public Properties getOverrides() {
+        return overrides;
+    }
+
+    public void setOverrides(Properties overrides) {
+        this.overrides = overrides;
+    }
+
+    public SharedEnvironmentPhase getSharedEnvironmentPhase() {
+        return sharedEnvironmentPhase;
+    }
+
+    public void setSharedEnvironmentPhase(SharedEnvironmentPhase sharedEnvironmentPhase) {
+        this.sharedEnvironmentPhase = sharedEnvironmentPhase;
+    }
+
+    public String getSharedEnvironmentRunName() {
+        return sharedEnvironmentRunName;
+    }
+
+    public void setSharedEnvironmentRunName(String sharedEnvironmentRunName) {
+        this.sharedEnvironmentRunName = sharedEnvironmentRunName;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public void setLanguage(String language) {
+        this.language = language;
+    }
+
+    public String getBundleTest() {
+        return bundleTest;
+    }
+
+    public void setBundleTest(String bundleTest) {
+        this.bundleTest = bundleTest;
+    }
+
+    public String getGherkinTest() {
+        return gherkinTest;
+    }
+
+    public void setGherkinTest(String gherkinTest) {
+        this.gherkinTest = gherkinTest;
+    }
+}

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/beans/Property.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/beans/Property.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.beans;
+
+import com.google.gson.annotations.SerializedName;
+
+public class Property {
+    @SerializedName("key")
+    private String key;
+
+    @SerializedName("value")
+    private String value;
+
+    public Property(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/beans/SubmitRunRequest.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/beans/SubmitRunRequest.java
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package dev.galasa.framework;
+package dev.galasa.framework.beans;
 
 import java.util.Properties;
 

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/FrameworkRunsTest.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/FrameworkRunsTest.java
@@ -1,0 +1,740 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.Properties;
+
+import org.junit.Test;
+
+import dev.galasa.framework.mocks.MockCPSStore;
+import dev.galasa.framework.mocks.MockDSSStore;
+import dev.galasa.framework.mocks.MockFramework;
+import dev.galasa.framework.spi.FrameworkException;
+import dev.galasa.framework.spi.IRun;
+import dev.galasa.framework.spi.IFrameworkRuns.SharedEnvironmentPhase;
+
+public class FrameworkRunsTest {
+   
+    @Test
+    public void testSubmitRunReturnsSubmittedRun() throws Exception {
+        // Given...
+        MockDSSStore mockDss = new MockDSSStore(new HashMap<>());
+        MockCPSStore mockCps = new MockCPSStore(new HashMap<>());
+        MockFramework mockFramework = new MockFramework(mockCps, mockDss);
+
+        FrameworkRuns frameworkRuns = new FrameworkRuns(mockFramework);
+
+        String runType = "unknown";
+        String requestor = "me";
+        String bundleName = "mybundle";
+        String testName = "mytest";
+        String groupName = "my.group";
+        String mavenRepo = "https://my.maven.repo";
+        String obr = "mvn:my.group/my.group.obr/0.38.0/obr";
+        String stream = "a-test-stream";
+        boolean local = true;
+        boolean trace = true;
+
+        Properties overrides = new Properties();
+        String override1Key = "override1";
+        String override1Value = "this-is-an-override";
+        String override2Key = "override2";
+        String override2Value = "this-is-another-override";
+        overrides.setProperty(override1Key, override1Value);
+        overrides.setProperty(override2Key, override2Value);
+
+        SharedEnvironmentPhase sharedEnvironmentPhase = null;
+        String sharedEnvironmentRunName = null;
+        String language = "java";
+
+        // When...
+        IRun run = frameworkRuns.submitRun(
+            runType,
+            requestor,
+            bundleName,
+            testName,
+            groupName,
+            mavenRepo,
+            obr,
+            stream,
+            local,
+            trace,
+            overrides,
+            sharedEnvironmentPhase,
+            sharedEnvironmentRunName,
+            language
+        );
+
+        // Then...
+        assertThat(run).isNotNull();
+        assertThat(run.getName()).isEqualTo("U1");
+        assertThat(run.getTest()).isEqualTo(bundleName + "/" + testName);
+
+        // Check that the DSS has been populated with the correct run-related properties
+        assertThat(mockDss.get("request.prefix.U.lastused")).isEqualTo("1");
+        assertThat(mockDss.get("run.U1.obr")).isEqualTo(obr);
+        assertThat(mockDss.get("run.U1.group")).isEqualTo(groupName);
+        assertThat(mockDss.get("run.U1.requestor")).isEqualTo(requestor);
+        assertThat(mockDss.get("run.U1.testbundle")).isEqualTo(bundleName);
+        assertThat(mockDss.get("run.U1.repository")).isEqualTo(mavenRepo);
+        assertThat(mockDss.get("run.U1.stream")).isEqualTo(stream);
+        assertThat(mockDss.get("run.U1.local")).isEqualTo(Boolean.toString(local));
+        assertThat(mockDss.get("run.U1.testclass")).isEqualTo(testName);
+        assertThat(mockDss.get("run.U1.trace")).isEqualTo(Boolean.toString(trace));
+        assertThat(mockDss.get("run.U1.request.type")).isEqualTo(runType.toUpperCase());
+        assertThat(mockDss.get("run.U1.status")).isEqualTo("queued");
+        assertThat(mockDss.get("run.U1.overrides")).isEqualTo(
+            override1Key + "=" + override1Value + "\n" +
+            override2Key + "=" + override2Value
+        );
+    }
+   
+    @Test
+    public void testSubmitRunWithMaxRunNumberReachedReturnsSubmittedRunOk() throws Exception {
+        // Given...
+        MockDSSStore mockDss = new MockDSSStore(new HashMap<>());
+        mockDss.put("request.prefix.U.lastused", "10");
+        
+        MockCPSStore mockCps = new MockCPSStore(new HashMap<>());
+        mockCps.setProperty("request.prefix.U.maximum", "10");
+        
+        MockFramework mockFramework = new MockFramework(mockCps, mockDss);
+
+        FrameworkRuns frameworkRuns = new FrameworkRuns(mockFramework);
+
+        String runType = "unknown";
+        String requestor = "me";
+        String bundleName = "mybundle";
+        String testName = "mytest";
+        String groupName = "my.group";
+        String mavenRepo = "https://my.maven.repo";
+        String obr = "mvn:my.group/my.group.obr/0.38.0/obr";
+        String stream = "a-test-stream";
+        boolean local = true;
+        boolean trace = true;
+
+        Properties overrides = new Properties();
+        String override1Key = "override1";
+        String override1Value = "this-is-an-override";
+        String override2Key = "override2";
+        String override2Value = "this-is-another-override";
+        overrides.setProperty(override1Key, override1Value);
+        overrides.setProperty(override2Key, override2Value);
+
+        SharedEnvironmentPhase sharedEnvironmentPhase = null;
+        String sharedEnvironmentRunName = null;
+        String language = "java";
+
+        // When...
+        IRun run = frameworkRuns.submitRun(
+            runType,
+            requestor,
+            bundleName,
+            testName,
+            groupName,
+            mavenRepo,
+            obr,
+            stream,
+            local,
+            trace,
+            overrides,
+            sharedEnvironmentPhase,
+            sharedEnvironmentRunName,
+            language
+        );
+
+        // Then...
+        assertThat(run).isNotNull();
+        assertThat(run.getName()).isEqualTo("U1");
+        assertThat(run.getTest()).isEqualTo(bundleName + "/" + testName);
+
+        // Check that the DSS has been populated with the correct run-related properties
+        assertThat(mockDss.get("request.prefix.U.lastused")).isEqualTo("1");
+        assertThat(mockDss.get("run.U1.obr")).isEqualTo(obr);
+        assertThat(mockDss.get("run.U1.group")).isEqualTo(groupName);
+        assertThat(mockDss.get("run.U1.requestor")).isEqualTo(requestor);
+        assertThat(mockDss.get("run.U1.testbundle")).isEqualTo(bundleName);
+        assertThat(mockDss.get("run.U1.repository")).isEqualTo(mavenRepo);
+        assertThat(mockDss.get("run.U1.stream")).isEqualTo(stream);
+        assertThat(mockDss.get("run.U1.local")).isEqualTo(Boolean.toString(local));
+        assertThat(mockDss.get("run.U1.testclass")).isEqualTo(testName);
+        assertThat(mockDss.get("run.U1.trace")).isEqualTo(Boolean.toString(trace));
+        assertThat(mockDss.get("run.U1.request.type")).isEqualTo(runType.toUpperCase());
+        assertThat(mockDss.get("run.U1.status")).isEqualTo("queued");
+        assertThat(mockDss.get("run.U1.overrides")).isEqualTo(
+            override1Key + "=" + override1Value + "\n" +
+            override2Key + "=" + override2Value
+        );
+    }
+   
+    @Test
+    public void testSubmitRunWithMaxRunNumberReachedTwiceThrowsError() throws Exception {
+        // Given...
+        MockDSSStore mockDss = new MockDSSStore(new HashMap<>());
+        mockDss.put("request.prefix.U.lastused", "10");
+
+        mockDss.setSwapSetToFail(true);
+        
+        MockCPSStore mockCps = new MockCPSStore(new HashMap<>());
+        mockCps.setProperty("request.prefix.U.maximum", "0");
+        
+        MockFramework mockFramework = new MockFramework(mockCps, mockDss);
+
+        FrameworkRuns frameworkRuns = new FrameworkRuns(mockFramework);
+
+        String runType = "unknown";
+        String requestor = "me";
+        String bundleName = "mybundle";
+        String testName = "mytest";
+        String groupName = "my.group";
+        String mavenRepo = "https://my.maven.repo";
+        String obr = "mvn:my.group/my.group.obr/0.38.0/obr";
+        String stream = "a-test-stream";
+        boolean local = true;
+        boolean trace = true;
+
+        Properties overrides = new Properties();
+        String override1Key = "override1";
+        String override1Value = "this-is-an-override";
+        String override2Key = "override2";
+        String override2Value = "this-is-another-override";
+        overrides.setProperty(override1Key, override1Value);
+        overrides.setProperty(override2Key, override2Value);
+
+        SharedEnvironmentPhase sharedEnvironmentPhase = null;
+        String sharedEnvironmentRunName = null;
+        String language = "java";
+
+        // When...
+        FrameworkException thrown = catchThrowableOfType(() -> {
+            frameworkRuns.submitRun(
+                runType,
+                requestor,
+                bundleName,
+                testName,
+                groupName,
+                mavenRepo,
+                obr,
+                stream,
+                local,
+                trace,
+                overrides,
+                sharedEnvironmentPhase,
+                sharedEnvironmentRunName,
+                language
+            );
+        }, FrameworkException.class);
+
+        // Then...
+        assertThat(thrown).isNotNull();
+        assertThat(thrown.getMessage()).isEqualTo("Not enough request type numbers available, looped twice");
+    }
+
+    @Test
+    public void testSubmitRunWithNoTestNameThrowsCorrectError() throws Exception {
+        // Given...
+        MockDSSStore mockDss = new MockDSSStore(new HashMap<>());
+        MockCPSStore mockCps = new MockCPSStore(new HashMap<>());
+        MockFramework mockFramework = new MockFramework(mockCps, mockDss);
+
+        FrameworkRuns frameworkRuns = new FrameworkRuns(mockFramework);
+
+        String testName = null;
+
+        String runType = "unknown";
+        String requestor = "me";
+        String bundleName = "mybundle";
+        String groupName = "my.group";
+        String mavenRepo = "https://my.maven.repo";
+        String obr = "mvn:my.group/my.group.obr/0.38.0/obr";
+        String stream = "a-test-stream";
+        boolean local = true;
+        boolean trace = true;
+
+        Properties overrides = new Properties();
+
+        SharedEnvironmentPhase sharedEnvironmentPhase = null;
+        String sharedEnvironmentRunName = null;
+        String language = "java";
+
+        // When...
+        FrameworkException thrown = catchThrowableOfType(() -> {
+            frameworkRuns.submitRun(
+                runType,
+                requestor,
+                bundleName,
+                testName,
+                groupName,
+                mavenRepo,
+                obr,
+                stream,
+                local,
+                trace,
+                overrides,
+                sharedEnvironmentPhase,
+                sharedEnvironmentRunName,
+                language
+            );
+        }, FrameworkException.class);
+
+        // Then...
+        assertThat(thrown).isNotNull();
+        assertThat(thrown.getMessage()).contains("Missing test name");
+    }
+
+    @Test
+    public void testSubmitRunWithNoBundleNameThrowsCorrectError() throws Exception {
+        // Given...
+        MockDSSStore mockDss = new MockDSSStore(new HashMap<>());
+        MockCPSStore mockCps = new MockCPSStore(new HashMap<>());
+        MockFramework mockFramework = new MockFramework(mockCps, mockDss);
+
+        FrameworkRuns frameworkRuns = new FrameworkRuns(mockFramework);
+
+        String bundleName = null;
+        
+        String testName = "mytest";
+        String runType = "unknown";
+        String requestor = "me";
+        String groupName = "my.group";
+        String mavenRepo = "https://my.maven.repo";
+        String obr = "mvn:my.group/my.group.obr/0.38.0/obr";
+        String stream = "a-test-stream";
+        boolean local = true;
+        boolean trace = true;
+
+        Properties overrides = new Properties();
+
+        SharedEnvironmentPhase sharedEnvironmentPhase = null;
+        String sharedEnvironmentRunName = null;
+        String language = "java";
+
+        // When...
+        FrameworkException thrown = catchThrowableOfType(() -> {
+            frameworkRuns.submitRun(
+                runType,
+                requestor,
+                bundleName,
+                testName,
+                groupName,
+                mavenRepo,
+                obr,
+                stream,
+                local,
+                trace,
+                overrides,
+                sharedEnvironmentPhase,
+                sharedEnvironmentRunName,
+                language
+            );
+        }, FrameworkException.class);
+
+        // Then...
+        assertThat(thrown).isNotNull();
+        assertThat(thrown.getMessage()).contains("Missing bundle name");
+    }
+
+    @Test
+    public void testSubmitRunWithNoLanguageDefaultsToJavaBundleFormat() throws Exception {
+        // Given...
+        MockDSSStore mockDss = new MockDSSStore(new HashMap<>());
+        MockCPSStore mockCps = new MockCPSStore(new HashMap<>());
+        MockFramework mockFramework = new MockFramework(mockCps, mockDss);
+
+        FrameworkRuns frameworkRuns = new FrameworkRuns(mockFramework);
+
+        String language = null;
+
+        String bundleName = "mybundle";
+        String testName = "mytest";
+        String runType = "unknown";
+        String requestor = "me";
+        String groupName = "my.group";
+        String mavenRepo = "https://my.maven.repo";
+        String obr = "mvn:my.group/my.group.obr/0.38.0/obr";
+        String stream = "a-test-stream";
+        boolean local = true;
+        boolean trace = true;
+
+        Properties overrides = new Properties();
+
+        SharedEnvironmentPhase sharedEnvironmentPhase = null;
+        String sharedEnvironmentRunName = null;
+
+        // When...
+        IRun run = frameworkRuns.submitRun(
+            runType,
+            requestor,
+            bundleName,
+            testName,
+            groupName,
+            mavenRepo,
+            obr,
+            stream,
+            local,
+            trace,
+            overrides,
+            sharedEnvironmentPhase,
+            sharedEnvironmentRunName,
+            language
+        );
+
+        // Then...
+        assertThat(run).isNotNull();
+        assertThat(run.getName()).isEqualTo("U1");
+        assertThat(run.getTest()).isEqualTo(bundleName + "/" + testName);
+    }
+
+    @Test
+    public void testSubmitRunWithLocalRunTypeSetsRunPrefixCorrectly() throws Exception {
+        // Given...
+        MockDSSStore mockDss = new MockDSSStore(new HashMap<>());
+        MockCPSStore mockCps = new MockCPSStore(new HashMap<>());
+        MockFramework mockFramework = new MockFramework(mockCps, mockDss);
+
+        FrameworkRuns frameworkRuns = new FrameworkRuns(mockFramework);
+
+        String runType = "local";
+        
+        String language = "java";
+        String bundleName = "mybundle";
+        String testName = "mytest";
+        String requestor = "me";
+        String groupName = "my.group";
+        String mavenRepo = "https://my.maven.repo";
+        String obr = "mvn:my.group/my.group.obr/0.38.0/obr";
+        String stream = "a-test-stream";
+        boolean local = true;
+        boolean trace = true;
+
+        Properties overrides = new Properties();
+
+        SharedEnvironmentPhase sharedEnvironmentPhase = null;
+        String sharedEnvironmentRunName = null;
+
+        // When...
+        IRun run = frameworkRuns.submitRun(
+            runType,
+            requestor,
+            bundleName,
+            testName,
+            groupName,
+            mavenRepo,
+            obr,
+            stream,
+            local,
+            trace,
+            overrides,
+            sharedEnvironmentPhase,
+            sharedEnvironmentRunName,
+            language
+        );
+
+        // Then...
+        assertThat(run).isNotNull();
+        assertThat(run.getType()).isEqualTo(runType.toUpperCase());
+        assertThat(run.getName()).isEqualTo("L1");
+    }
+
+    @Test
+    public void testSubmitRunWithGherkinReturnsRunCorrectly() throws Exception {
+        // Given...
+        MockDSSStore mockDss = new MockDSSStore(new HashMap<>());
+        MockCPSStore mockCps = new MockCPSStore(new HashMap<>());
+        MockFramework mockFramework = new MockFramework(mockCps, mockDss);
+
+        FrameworkRuns frameworkRuns = new FrameworkRuns(mockFramework);
+
+        String language = "gherkin";
+        
+        String runType = "local";
+        String bundleName = "mybundle";
+        String testName = "mygherkintest";
+        String requestor = "me";
+        String groupName = "my.group";
+        String mavenRepo = "https://my.maven.repo";
+        String obr = "mvn:my.group/my.group.obr/0.38.0/obr";
+        String stream = "a-test-stream";
+        boolean local = true;
+        boolean trace = true;
+
+        Properties overrides = new Properties();
+
+        SharedEnvironmentPhase sharedEnvironmentPhase = null;
+        String sharedEnvironmentRunName = null;
+
+        // When...
+        IRun run = frameworkRuns.submitRun(
+            runType,
+            requestor,
+            bundleName,
+            testName,
+            groupName,
+            mavenRepo,
+            obr,
+            stream,
+            local,
+            trace,
+            overrides,
+            sharedEnvironmentPhase,
+            sharedEnvironmentRunName,
+            language
+        );
+
+        // Then...
+        assertThat(run).isNotNull();
+        assertThat(run.getName()).isEqualTo("L1");
+        assertThat(run.getGherkin()).isEqualTo(testName);
+        assertThat(run.getTestBundleName()).isEqualTo(null);
+
+        // Check that the DSS has been populated with the correct run-related properties
+        assertThat(mockDss.get("run.L1.gherkin")).isEqualTo(testName);
+        assertThat(mockDss.get("run.L1.testclass")).isEqualTo(testName);
+        assertThat(mockDss.get("run.L1.testbundle")).isEqualTo("none");
+        assertThat(mockDss.get("request.prefix.L.lastused")).isEqualTo("1");
+        assertThat(mockDss.get("run.L1.obr")).isEqualTo(obr);
+        assertThat(mockDss.get("run.L1.group")).isEqualTo(groupName);
+        assertThat(mockDss.get("run.L1.requestor")).isEqualTo(requestor);
+        assertThat(mockDss.get("run.L1.repository")).isEqualTo(mavenRepo);
+        assertThat(mockDss.get("run.L1.stream")).isEqualTo(stream);
+        assertThat(mockDss.get("run.L1.local")).isEqualTo(Boolean.toString(local));
+        assertThat(mockDss.get("run.L1.trace")).isEqualTo(Boolean.toString(trace));
+        assertThat(mockDss.get("run.L1.request.type")).isEqualTo(runType.toUpperCase());
+        assertThat(mockDss.get("run.L1.status")).isEqualTo("queued");
+    }
+
+    @Test
+    public void testSubmitRunWithSharedEnvironmentBuildPhaseReturnsRunCorrectly() throws Exception {
+        // Given...
+        MockDSSStore mockDss = new MockDSSStore(new HashMap<>());
+        MockCPSStore mockCps = new MockCPSStore(new HashMap<>());
+        MockFramework mockFramework = new MockFramework(mockCps, mockDss);
+
+        FrameworkRuns frameworkRuns = new FrameworkRuns(mockFramework);
+
+        SharedEnvironmentPhase sharedEnvironmentPhase = SharedEnvironmentPhase.BUILD;
+        String sharedEnvironmentRunName = "SHARED-RUN1";
+
+        String language = "java";
+        String runType = "local";
+        String bundleName = "mybundle";
+        String testName = "mysharedenvtest";
+        String requestor = "me";
+        String groupName = "my.group";
+        String mavenRepo = "https://my.maven.repo";
+        String obr = "mvn:my.group/my.group.obr/0.38.0/obr";
+        String stream = "a-test-stream";
+        boolean local = true;
+        boolean trace = true;
+
+        Properties overrides = new Properties();
+
+        // When...
+        IRun run = frameworkRuns.submitRun(
+            runType,
+            requestor,
+            bundleName,
+            testName,
+            groupName,
+            mavenRepo,
+            obr,
+            stream,
+            local,
+            trace,
+            overrides,
+            sharedEnvironmentPhase,
+            sharedEnvironmentRunName,
+            language
+        );
+
+        // Then...
+        assertThat(run).isNotNull();
+        assertThat(run.getName()).isEqualTo(sharedEnvironmentRunName);
+
+        // Check that the DSS has been populated with the correct run-related properties
+        assertThat(mockDss.get("run.SHARED-RUN1.overrides")).isEqualTo("framework.run.shared.environment.phase=BUILD");
+        assertThat(mockDss.get("run.SHARED-RUN1.shared.environment")).isEqualTo("true");
+        assertThat(mockDss.get("run.SHARED-RUN1.obr")).isEqualTo(obr);
+        assertThat(mockDss.get("run.SHARED-RUN1.group")).isEqualTo(groupName);
+        assertThat(mockDss.get("run.SHARED-RUN1.requestor")).isEqualTo(requestor);
+        assertThat(mockDss.get("run.SHARED-RUN1.testbundle")).isEqualTo(bundleName);
+        assertThat(mockDss.get("run.SHARED-RUN1.repository")).isEqualTo(mavenRepo);
+        assertThat(mockDss.get("run.SHARED-RUN1.stream")).isEqualTo(stream);
+        assertThat(mockDss.get("run.SHARED-RUN1.local")).isEqualTo(Boolean.toString(local));
+        assertThat(mockDss.get("run.SHARED-RUN1.testclass")).isEqualTo(testName);
+        assertThat(mockDss.get("run.SHARED-RUN1.trace")).isEqualTo(Boolean.toString(trace));
+        assertThat(mockDss.get("run.SHARED-RUN1.request.type")).isEqualTo(runType.toUpperCase());
+        assertThat(mockDss.get("run.SHARED-RUN1.status")).isEqualTo("queued");
+    }
+
+    @Test
+    public void testSubmitRunWithSharedEnvironmentBuildPhaseAndNoRunNameThrowsError() throws Exception {
+        // Given...
+        MockDSSStore mockDss = new MockDSSStore(new HashMap<>());
+        MockCPSStore mockCps = new MockCPSStore(new HashMap<>());
+        MockFramework mockFramework = new MockFramework(mockCps, mockDss);
+
+        FrameworkRuns frameworkRuns = new FrameworkRuns(mockFramework);
+
+        SharedEnvironmentPhase sharedEnvironmentPhase = SharedEnvironmentPhase.BUILD;
+        String sharedEnvironmentRunName = null;
+
+        String language = "java";
+        String runType = "local";
+        String bundleName = "mybundle";
+        String testName = "mysharedenvtest";
+        String requestor = "me";
+        String groupName = "my.group";
+        String mavenRepo = "https://my.maven.repo";
+        String obr = "mvn:my.group/my.group.obr/0.38.0/obr";
+        String stream = "a-test-stream";
+        boolean local = true;
+        boolean trace = true;
+
+        Properties overrides = new Properties();
+
+        // When...
+        FrameworkException thrown = catchThrowableOfType(() -> {
+            frameworkRuns.submitRun(
+                runType,
+                requestor,
+                bundleName,
+                testName,
+                groupName,
+                mavenRepo,
+                obr,
+                stream,
+                local,
+                trace,
+                overrides,
+                sharedEnvironmentPhase,
+                sharedEnvironmentRunName,
+                language
+            );
+        }, FrameworkException.class);
+
+        // Then...
+        assertThat(thrown).isNotNull();
+        assertThat(thrown.getMessage()).isEqualTo("Missing run name for shared environment");
+    }
+
+    @Test
+    public void testSubmitRunWithSharedEnvironmentDiscardPhaseReturnsRunCorrectly() throws Exception {
+        // Given...
+        MockDSSStore mockDss = new MockDSSStore(new HashMap<>());
+        String sharedEnvironmentRunName = "SHARED-RUN1";
+
+        mockDss.put("run." + sharedEnvironmentRunName + ".shared.environment", "true");
+        mockDss.put("run." + sharedEnvironmentRunName + ".status", "up");
+
+        MockCPSStore mockCps = new MockCPSStore(new HashMap<>());
+        MockFramework mockFramework = new MockFramework(mockCps, mockDss);
+
+        FrameworkRuns frameworkRuns = new FrameworkRuns(mockFramework);
+
+        SharedEnvironmentPhase sharedEnvironmentPhase = SharedEnvironmentPhase.DISCARD;
+
+        String language = "java";
+        String runType = "local";
+        String bundleName = "mybundle";
+        String testName = "mysharedenvtest";
+        String requestor = "me";
+        String groupName = "my.group";
+        String mavenRepo = "https://my.maven.repo";
+        String obr = "mvn:my.group/my.group.obr/0.38.0/obr";
+        String stream = "a-test-stream";
+        boolean local = true;
+        boolean trace = true;
+
+        Properties overrides = new Properties();
+
+        // When...
+        IRun run = frameworkRuns.submitRun(
+            runType,
+            requestor,
+            bundleName,
+            testName,
+            groupName,
+            mavenRepo,
+            obr,
+            stream,
+            local,
+            trace,
+            overrides,
+            sharedEnvironmentPhase,
+            sharedEnvironmentRunName,
+            language
+        );
+
+        // Then...
+        assertThat(run).isNotNull();
+        assertThat(run.getName()).isEqualTo(sharedEnvironmentRunName);
+
+        // Check that the DSS has been populated with the correct run-related properties
+        assertThat(mockDss.get("run.SHARED-RUN1.overrides")).isEqualTo("framework.run.shared.environment.phase=DISCARD");
+        assertThat(mockDss.get("run.SHARED-RUN1.shared.environment")).isEqualTo("true");
+        assertThat(mockDss.get("run.SHARED-RUN1.group")).isEqualTo(groupName);
+        assertThat(mockDss.get("run.SHARED-RUN1.status")).isEqualTo("queued");
+    }
+
+    @Test
+    public void testSubmitRunWithDuplicateSharedEnvironmentBuildPhaseRunThrowsError() throws Exception {
+        // Given...
+        MockDSSStore mockDss = new MockDSSStore(new HashMap<>());
+        mockDss.setSwapSetToFail(true);
+
+        MockCPSStore mockCps = new MockCPSStore(new HashMap<>());
+        String sharedEnvironmentRunName = "SHARED-RUN1";
+
+        mockDss.put("run." + sharedEnvironmentRunName + ".test", "existing/test");
+        MockFramework mockFramework = new MockFramework(mockCps, mockDss);
+
+        FrameworkRuns frameworkRuns = new FrameworkRuns(mockFramework);
+
+        SharedEnvironmentPhase sharedEnvironmentPhase = SharedEnvironmentPhase.BUILD;
+
+        String language = "java";
+        String runType = "local";
+        String bundleName = "mybundle";
+        String testName = "mysharedenvtest";
+        String requestor = "me";
+        String groupName = "my.group";
+        String mavenRepo = "https://my.maven.repo";
+        String obr = "mvn:my.group/my.group.obr/0.38.0/obr";
+        String stream = "a-test-stream";
+        boolean local = true;
+        boolean trace = true;
+
+        Properties overrides = new Properties();
+
+        // When...
+        FrameworkException thrown = catchThrowableOfType(() -> {
+            frameworkRuns.submitRun(
+                runType,
+                requestor,
+                bundleName,
+                testName,
+                groupName,
+                mavenRepo,
+                obr,
+                stream,
+                local,
+                trace,
+                overrides,
+                sharedEnvironmentPhase,
+                sharedEnvironmentRunName,
+                language
+            );
+        }, FrameworkException.class);
+
+        // Then...
+        assertThat(thrown).isNotNull();
+        assertThat(thrown.getMessage()).contains("Unable to submit shared environment run", sharedEnvironmentRunName, "is there a duplicate runname?");
+    }
+}

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockCPSStore.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockCPSStore.java
@@ -37,7 +37,7 @@ public class MockCPSStore implements IConfigurationPropertyStore, IConfiguration
 
     @Override
     public void setProperty(@NotNull String key, @NotNull String value) throws ConfigurationPropertyStoreException {
-        throw new UnsupportedOperationException("Unimplemented method 'setProperty'");
+        this.properties.put(key, value);
     }
 
     @Override

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockDSSStore.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockDSSStore.java
@@ -7,6 +7,7 @@ package dev.galasa.framework.mocks;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.UUID;
 
@@ -19,20 +20,25 @@ import org.apache.commons.logging.LogFactory;
 import dev.galasa.framework.spi.DynamicStatusStoreException;
 import dev.galasa.framework.spi.DynamicStatusStoreMatchException;
 import dev.galasa.framework.spi.IDssAction;
+import dev.galasa.framework.spi.IDynamicResource;
+import dev.galasa.framework.spi.IDynamicRun;
 import dev.galasa.framework.spi.IDynamicStatusStore;
+import dev.galasa.framework.spi.IDynamicStatusStoreService;
 import dev.galasa.framework.spi.IDynamicStatusStoreWatcher;
 
-public class MockDSSStore implements IDynamicStatusStore {
+public class MockDSSStore implements IDynamicStatusStore, IDynamicStatusStoreService {
 
     private Map<String,String> valueMap ;
     private Log logger = LogFactory.getLog(MockDSSStore.class.getName());
+    private boolean isSwapSetToFail = false;
+
     public MockDSSStore(Map<String,String> valueMap) {
         this.valueMap = valueMap;
     }
 
     @Override
     public void put(@NotNull String key, @NotNull String value) throws DynamicStatusStoreException {
-        throw new UnsupportedOperationException("Unimplemented method 'put'");
+        valueMap.put(key, value);
     }
 
     @Override
@@ -52,8 +58,14 @@ public class MockDSSStore implements IDynamicStatusStore {
     public boolean putSwap(@NotNull String key, String oldValue, @NotNull String newValue,
             @NotNull Map<String, String> others) throws DynamicStatusStoreException {
         logger.debug("DSS putswap of property "+key+" oldValue:"+oldValue+" newValue:"+newValue);
-        valueMap.put(key,newValue);
-        return true;
+        boolean isSuccessful = !isSwapSetToFail;
+        if (isSuccessful) {
+            valueMap.put(key,newValue);
+            for (Entry<String, String> entry : others.entrySet()) {
+                valueMap.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return isSuccessful;
     }
 
     @Override
@@ -73,6 +85,10 @@ public class MockDSSStore implements IDynamicStatusStore {
         }
         logger.debug("DSS getPrefix of property "+keyPrefix+" returning "+results.toString());
         return results;
+    }
+
+    public void setSwapSetToFail(boolean isSwapSetToFail) {
+        this.isSwapSetToFail = isSwapSetToFail;
     }
 
     @Override
@@ -114,6 +130,16 @@ public class MockDSSStore implements IDynamicStatusStore {
     @Override
     public void shutdown() throws DynamicStatusStoreException {
         throw new UnsupportedOperationException("Unimplemented method 'shutdown'");
+    }
+
+    @Override
+    public IDynamicResource getDynamicResource(String resourceKey) {
+        throw new UnsupportedOperationException("Unimplemented method 'getDynamicResource'");
+    }
+
+    @Override
+    public IDynamicRun getDynamicRun() throws DynamicStatusStoreException {
+        throw new UnsupportedOperationException("Unimplemented method 'getDynamicRun'");
     }
     
 }

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockFramework.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockFramework.java
@@ -9,7 +9,9 @@ import dev.galasa.framework.Framework;
 import dev.galasa.framework.internal.cps.FpfConfigurationPropertyStore;
 import dev.galasa.framework.internal.cps.FrameworkConfigurationPropertyService;
 import dev.galasa.framework.spi.ConfigurationPropertyStoreException;
+import dev.galasa.framework.spi.DynamicStatusStoreException;
 import dev.galasa.framework.spi.IConfigurationPropertyStoreService;
+import dev.galasa.framework.spi.IDynamicStatusStoreService;
 
 import java.io.File;
 import java.util.Properties;
@@ -19,23 +21,33 @@ public class MockFramework extends Framework {
 
     private Properties overrides = new Properties();
     private Properties records = new Properties();
-    private File cps;
+    private File cpsFile;
+
+    private MockDSSStore mockDss;
+    private MockCPSStore mockCps;
 
     public MockFramework() {
         super();
     }
 
+    public MockFramework(MockCPSStore mockCps, MockDSSStore mockDss) {
+        this.mockCps = mockCps;
+        this.mockDss = mockDss;
+    }
+
     public MockFramework(File cpsFile) {
-        this.cps = cpsFile;
+        this.cpsFile = cpsFile;
     }
 
     @Override
     public @NotNull IConfigurationPropertyStoreService getConfigurationPropertyService(@NotNull String namespace) throws ConfigurationPropertyStoreException {
         IConfigurationPropertyStoreService cpsService = null;
-        if (this.cps != null) {
+        if (this.mockCps != null) {
+            cpsService = mockCps;
+        } else if (this.cpsFile != null) {
             try {
                 cpsService = new FrameworkConfigurationPropertyService(this,
-                        new FpfConfigurationPropertyStore(cps.toURI()), overrides, records, namespace);
+                        new FpfConfigurationPropertyStore(cpsFile.toURI()), overrides, records, namespace);
             } catch (Exception e) {
                 throw new ConfigurationPropertyStoreException("error initialising", e);
             }
@@ -43,5 +55,22 @@ public class MockFramework extends Framework {
             cpsService = super.getConfigurationPropertyService(namespace);
         }
         return cpsService;
+    }
+
+    @Override
+    public @NotNull IDynamicStatusStoreService getDynamicStatusStoreService(@NotNull String namespace) throws DynamicStatusStoreException {
+        IDynamicStatusStoreService dss = mockDss;
+        if (dss == null) {
+            dss = super.getDynamicStatusStoreService(namespace);
+        }
+        return dss;
+    }
+
+    public void setMockCps(MockCPSStore mockCps) {
+        this.mockCps = mockCps;
+    }
+
+    public void setMockDss(MockDSSStore mockDss) {
+        this.mockDss = mockDss;
     }
 }


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2000

## Changes
- Instead of setting multiple `dss.framework.run.X.override.<override-property>` properties into the DSS, the framework will now only set a single `dss.framework.run.X.overrides` property containing multiple overrides in a JSON array, for example:
```properties
dss.framework.run.C123.overrides=[{"key": "my.first.override", "value": "abc"}, {"key": "my.second.override", "value": "123"}]
```
  - Updated the consuming code in the test runner and framework initialisation to pull overrides out of this new property
- Refactored the `submitRuns` method in the `FrameworkRuns` class and added unit tests