### PR TITLE
Disable pretty printing DSS overrides to reduce etcd request size

### DIFF
--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkRuns.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FrameworkRuns.java
@@ -37,6 +37,7 @@ import dev.galasa.framework.spi.IFramework;
 import dev.galasa.framework.spi.IFrameworkRuns;
 import dev.galasa.framework.spi.IRun;
 import dev.galasa.framework.spi.utils.GalasaGson;
+import dev.galasa.framework.spi.utils.GalasaGsonBuilder;
 
 public class FrameworkRuns implements IFrameworkRuns {
 
@@ -55,12 +56,13 @@ public class FrameworkRuns implements IFrameworkRuns {
 
     private final String                             RUN_PREFIX   = "run.";
 
-    private static final GalasaGson gson = new GalasaGson();
+    private final GalasaGson gson = new GalasaGson();
 
     public FrameworkRuns(IFramework framework) throws FrameworkException {
         this.framework = framework;
         this.dss = framework.getDynamicStatusStoreService("framework");
         this.cps = framework.getConfigurationPropertyService("framework");
+        gson.setGsonBuilder(new GalasaGsonBuilder(false));
     }
 
     @Override

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/FrameworkRunsTest.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/FrameworkRunsTest.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.Properties;
 import java.util.Map.Entry;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.gson.JsonArray;
@@ -23,10 +24,16 @@ import dev.galasa.framework.spi.FrameworkException;
 import dev.galasa.framework.spi.IRun;
 import dev.galasa.framework.spi.IFrameworkRuns.SharedEnvironmentPhase;
 import dev.galasa.framework.spi.utils.GalasaGson;
+import dev.galasa.framework.spi.utils.GalasaGsonBuilder;
 
 public class FrameworkRunsTest {
 
     private static final GalasaGson gson = new GalasaGson();
+
+    @BeforeClass
+    public static void setUp() {
+        gson.setGsonBuilder(new GalasaGsonBuilder(false));
+    }
 
     private String getExpectedOverridesJson(Properties properties) {
         JsonArray overridesArray = new JsonArray();


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2000

etcd limits requests to 1.5MB, so to reduce the size of the request payload, this PR disables pretty-printing the JSON array value for the `dss.framework.run.X.overrides` DSS property.