### PR TITLE
build locally script - detect secrets should not have timestamp in on linux builds

### DIFF
--- a/build-locally.sh
+++ b/build-locally.sh
@@ -305,8 +305,19 @@ function check_secrets {
         error "Not all secrets found have been audited"
         exit 1  
     fi
-    sed -i '' '/[ ]*"generated_at": ".*",/d' .secrets.baseline
     success "secrets audit complete"
+
+    h2 "Removing the timestamp from the secrets baseline file so it doesn't always cause a git change."
+    mkdir -p temp
+    rc=$? 
+    check_exit_code $rc "Failed to create a temporary folder"
+    cat .secrets.baseline | grep -v "generated_at" > temp/.secrets.baseline.temp
+    rc=$? 
+    check_exit_code $rc "Failed to create a temporary file with no timestamp inside"
+    mv temp/.secrets.baseline.temp .secrets.baseline
+    rc=$? 
+    check_exit_code $rc "Failed to overwrite the secrets baseline with one containing no timestamp inside."
+    success "secrets baseline timestamp content has been removed ok"
 }
 
 function update_release_yaml {


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>
