### PR TITLE
Add credentials encryption and decryption, mount encryption keys in test pods

### DIFF
--- a/galasa-parent/dev.galasa.framework.k8s.controller/build.gradle
+++ b/galasa-parent/dev.galasa.framework.k8s.controller/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 description = 'Galasa Kubernetes Controller'
 
-version '0.36.0'
+version '0.38.0'
 
 dependencies {
 
@@ -36,6 +36,7 @@ dependencies {
         }
     }
 
+    testImplementation project(':dev.galasa.framework').sourceSets.test.output
 }
 
 // Note: These values are consumed by the parent build process

--- a/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/K8sController.java
+++ b/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/K8sController.java
@@ -88,6 +88,7 @@ public class K8sController {
         // *** Fetch the settings
 
         settings = new Settings(this, api);
+        settings.init();
 
         // *** Setup defaults and properties
 
@@ -233,7 +234,7 @@ public class K8sController {
         return value;
     }
 
-    public void pollUpated() {
+    public void pollUpdated() {
         if (pollFuture == null) {
             return;
         }

--- a/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/K8sController.java
+++ b/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/K8sController.java
@@ -43,7 +43,7 @@ public class K8sController {
 
     private Health                   healthServer;
 
-    private RunPoll runPoll;
+    private TestPodScheduler podScheduler;
     private ScheduledFuture<?> pollFuture;
 
     private RunDeleted runDeleted;
@@ -139,7 +139,7 @@ public class K8sController {
         // *** Start the run polling
         runDeleted = new RunDeleted(settings, api, pc, framework.getFrameworkRuns());
         scheduleDelete();
-        runPoll = new RunPoll(dss, settings, api, framework.getFrameworkRuns());
+        podScheduler = new TestPodScheduler(dss, settings, api, framework.getFrameworkRuns());
         schedulePoll();
 
         
@@ -184,7 +184,7 @@ public class K8sController {
             this.pollFuture.cancel(false);
         }
         
-        pollFuture = scheduledExecutorService.scheduleWithFixedDelay(runPoll, 1, settings.getPoll(), TimeUnit.SECONDS);
+        pollFuture = scheduledExecutorService.scheduleWithFixedDelay(podScheduler, 1, settings.getPoll(), TimeUnit.SECONDS);
     }
 
     private void scheduleDelete() {

--- a/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/RunDeleted.java
+++ b/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/RunDeleted.java
@@ -39,8 +39,8 @@ public class RunDeleted implements Runnable {
         logger.info("Starting Deleted runs scan");
 
         try {
-            List<V1Pod> pods = RunPoll.getPods(api, settings);
-            RunPoll.filterTerminated(pods);
+            List<V1Pod> pods = TestPodScheduler.getPods(api, settings);
+            TestPodScheduler.filterTerminated(pods);
 
             for (V1Pod pod : pods) {
                 Map<String, String> labels = pod.getMetadata().getLabels();

--- a/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/RunPoll.java
+++ b/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/RunPoll.java
@@ -5,6 +5,8 @@
  */
 package dev.galasa.framework.k8s.controller;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -324,9 +326,11 @@ public class RunPoll implements Runnable {
 
         String encryptionKeysMountPath = env.getenv(ENCRYPTION_KEYS_PATH_ENV);
         if (encryptionKeysMountPath != null && !encryptionKeysMountPath.isBlank()) {
+            Path encryptionKeysDirectory = Paths.get(encryptionKeysMountPath).getParent().toAbsolutePath();
+
             V1VolumeMount encryptionKeysVolumeMount = new V1VolumeMount();
             encryptionKeysVolumeMount.setName(ENCRYPTION_KEYS_VOLUME_NAME);
-            encryptionKeysVolumeMount.setMountPath(encryptionKeysMountPath);
+            encryptionKeysVolumeMount.setMountPath(encryptionKeysDirectory.toString());
             encryptionKeysVolumeMount.setReadOnly(true);
 
             volumeMounts.add(encryptionKeysVolumeMount);

--- a/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/RunPoll.java
+++ b/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/RunPoll.java
@@ -25,6 +25,7 @@ import dev.galasa.framework.spi.IDynamicStatusStoreService;
 import dev.galasa.framework.spi.IFrameworkRuns;
 import dev.galasa.framework.spi.IRun;
 import dev.galasa.framework.spi.SystemEnvironment;
+import dev.galasa.framework.spi.creds.FrameworkEncryptionService;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1Affinity;
@@ -44,12 +45,18 @@ import io.kubernetes.client.openapi.models.V1PodStatus;
 import io.kubernetes.client.openapi.models.V1PreferredSchedulingTerm;
 import io.kubernetes.client.openapi.models.V1ResourceRequirements;
 import io.kubernetes.client.openapi.models.V1SecretKeySelector;
+import io.kubernetes.client.openapi.models.V1SecretVolumeSource;
+import io.kubernetes.client.openapi.models.V1Volume;
+import io.kubernetes.client.openapi.models.V1VolumeMount;
 import io.prometheus.client.Counter;
 
 public class RunPoll implements Runnable {
 
     private static final String RAS_TOKEN_ENV = "GALASA_RAS_TOKEN";
     private static final String EVENT_TOKEN_ENV = "GALASA_EVENT_STREAMS_TOKEN";
+
+    private static final String ENCRYPTION_KEYS_PATH_ENV = FrameworkEncryptionService.ENCRYPTION_KEYS_PATH_ENV;
+    public static final String ENCRYPTION_KEYS_VOLUME_NAME = "encryption-keys";
 
     private final Log                        logger           = LogFactory.getLog(getClass());
 
@@ -64,6 +71,11 @@ public class RunPoll implements Runnable {
 
 
     public RunPoll(IDynamicStatusStoreService dss, Settings settings, CoreV1Api api, IFrameworkRuns runs) {
+        this(new SystemEnvironment(), dss, settings, api, runs);
+    }
+
+    public RunPoll(Environment env, IDynamicStatusStoreService dss, Settings settings, CoreV1Api api, IFrameworkRuns runs) {
+        this.env = env;
         this.settings = settings;
         this.api = api;
         this.runs = runs;
@@ -160,118 +172,7 @@ public class RunPoll implements Runnable {
                 return;
             }
 
-            V1Pod newPod = new V1Pod();
-            newPod.setApiVersion("v1");
-            newPod.setKind("Pod");
-
-            V1ObjectMeta metadata = new V1ObjectMeta();
-            newPod.setMetadata(metadata);
-            metadata.setName(engineName);
-            metadata.putLabelsItem("galasa-engine-controller", this.settings.getEngineLabel());
-            metadata.putLabelsItem("galasa-run", runName);
-
-            V1PodSpec podSpec = new V1PodSpec();
-            newPod.setSpec(podSpec);
-            podSpec.setRestartPolicy("Never");
-
-            String nodeArch = this.settings.getNodeArch();
-            if (!nodeArch.isEmpty()) {
-                HashMap<String, String> nodeSelector = new HashMap<>();
-                nodeSelector.put("beta.kubernetes.io/arch", nodeArch);
-                podSpec.setNodeSelector(nodeSelector);
-            }
-
-            String nodePreferredAffinity = this.settings.getNodePreferredAffinity();
-            if (!nodePreferredAffinity.isEmpty()) {
-                String[] selection = nodePreferredAffinity.split("=");
-                if (selection.length == 2) {
-                    V1Affinity affinity = new V1Affinity();
-                    podSpec.setAffinity(affinity);
-
-                    V1NodeAffinity nodeAffinity = new V1NodeAffinity();
-                    affinity.setNodeAffinity(nodeAffinity);
-
-                    V1PreferredSchedulingTerm preferred = new V1PreferredSchedulingTerm();
-                    nodeAffinity.addPreferredDuringSchedulingIgnoredDuringExecutionItem(preferred);
-                    preferred.setWeight(1);
-
-                    V1NodeSelectorTerm selectorTerm = new V1NodeSelectorTerm();
-                    preferred.setPreference(selectorTerm);
-
-                    V1NodeSelectorRequirement requirement = new V1NodeSelectorRequirement();
-                    selectorTerm.addMatchExpressionsItem(requirement);
-                    requirement.setKey(selection[0]);
-                    requirement.setOperator("In");
-                    requirement.addValuesItem(selection[1]);
-                }
-            }
-
-            V1Container container = new V1Container();
-            podSpec.addContainersItem(container);
-            container.setName("engine");
-            container.setImage(this.settings.getEngineImage());
-            container.setImagePullPolicy("Always"); // TODO parameterise
-
-            ArrayList<String> commands = new ArrayList<>();
-            container.setCommand(commands);
-            commands.add("java");
-
-            ArrayList<String> args = new ArrayList<>();
-            container.setArgs(args);
-            args.add("-jar");
-            args.add("boot.jar");
-            args.add("--obr");
-            args.add("file:galasa.obr");
-            args.add("--bootstrap");
-            args.add(settings.getBootstrap());
-            args.add("--run");
-            args.add(runName);
-            if (run.isTrace()) {
-                args.add("--trace");
-            }
-
-            V1ResourceRequirements resources = new V1ResourceRequirements();
-            container.setResources(resources);
-
-            // TODO reinstate
-            // System.out.println("requests=" +
-            // Integer.toString(this.settings.getEngineMemoryRequest()) + "Mi");
-            // System.out.println("limit=" +
-            // Integer.toString(this.settings.getEngineMemoryLimit()) + "Mi");
-            // resources.putRequestsItem("memory", new
-            // Quantity(Integer.toString(this.settings.getEngineMemoryRequest()) + "Mi"));
-            // resources.putLimitsItem("memory", new
-            // Quantity(Integer.toString(this.settings.getEngineMemoryLimit()) + "Mi"));
-
-            ArrayList<V1EnvVar> envs = new ArrayList<>();
-            container.setEnv(envs);
-            // envs.add(createConfigMapEnv("GALASA_URL", configMapName, "galasa_url"));
-            // envs.add(createConfigMapEnv("GALASA_INFRA_OBR", configMapName,
-            // "galasa_maven_infra_obr"));
-            // envs.add(createConfigMapEnv("GALASA_INFRA_REPO", configMapName,
-            // "galasa_maven_infra_repo"));
-            // envs.add(createConfigMapEnv("GALASA_TEST_REPO", configMapName,
-            // "galasa_maven_test_repo"));
-            // envs.add(createConfigMapEnv("GALASA_HELPER_REPO", configMapName,
-            // "galasa_maven_helper_repo"));
-            //
-            // envs.add(createValueEnv("GALASA_ENGINE_TYPE", engineLabel));
-            envs.add(createValueEnv("MAX_HEAP", Integer.toString(this.settings.getEngineMemory()) + "m"));
-            envs.add(createValueEnv(RAS_TOKEN_ENV, env.getenv(RAS_TOKEN_ENV)));
-            envs.add(createValueEnv(EVENT_TOKEN_ENV, env.getenv(EVENT_TOKEN_ENV)));
-            //
-            // envs.add(createSecretEnv("GALASA_SERVER_USER", "galasa-secret",
-            // "galasa-server-username"));
-            // envs.add(createSecretEnv("GALASA_SERVER_PASSWORD", "galasa-secret",
-            // "galasa-server-password"));
-            // envs.add(createSecretEnv("GALASA_MAVEN_USER", "galasa-secret",
-            // "galasa-maven-username"));
-            // envs.add(createSecretEnv("GALASA_MAVEN_PASSWORD", "galasa-secret",
-            // "galasa-maven-password"));
-            //
-            // envs.add(createValueEnv("GALASA_RUN_ID", runUUID.toString()));
-            // envs.add(createFieldEnv("GALASA_ENGINE_ID", "metadata.name"));
-            // envs.add(createFieldEnv("GALASA_K8S_NODE", "spec.nodeName"));
+            V1Pod newPod = createTestPod(runName, engineName, run.isTrace());
 
             boolean successful = false;
             int retry = 0;
@@ -308,7 +209,162 @@ public class RunPoll implements Runnable {
         } catch (Exception e) {
             logger.error("Failed to start new engine", e);
         }
-        return;
+    }
+
+    V1Pod createTestPod(String runName, String engineName, boolean isTraceEnabled) {
+        V1Pod newPod = new V1Pod();
+        newPod.setApiVersion("v1");
+        newPod.setKind("Pod");
+
+        V1ObjectMeta metadata = new V1ObjectMeta();
+        newPod.setMetadata(metadata);
+        metadata.setName(engineName);
+        metadata.putLabelsItem("galasa-engine-controller", this.settings.getEngineLabel());
+        metadata.putLabelsItem("galasa-run", runName);
+
+        V1PodSpec podSpec = new V1PodSpec();
+        newPod.setSpec(podSpec);
+        podSpec.setRestartPolicy("Never");
+
+        String nodeArch = this.settings.getNodeArch();
+        if (!nodeArch.isEmpty()) {
+            HashMap<String, String> nodeSelector = new HashMap<>();
+            nodeSelector.put("beta.kubernetes.io/arch", nodeArch);
+            podSpec.setNodeSelector(nodeSelector);
+        }
+
+        String nodePreferredAffinity = this.settings.getNodePreferredAffinity();
+        if (!nodePreferredAffinity.isEmpty()) {
+            String[] selection = nodePreferredAffinity.split("=");
+            if (selection.length == 2) {
+                V1Affinity affinity = new V1Affinity();
+                podSpec.setAffinity(affinity);
+
+                V1NodeAffinity nodeAffinity = new V1NodeAffinity();
+                affinity.setNodeAffinity(nodeAffinity);
+
+                V1PreferredSchedulingTerm preferred = new V1PreferredSchedulingTerm();
+                nodeAffinity.addPreferredDuringSchedulingIgnoredDuringExecutionItem(preferred);
+                preferred.setWeight(1);
+
+                V1NodeSelectorTerm selectorTerm = new V1NodeSelectorTerm();
+                preferred.setPreference(selectorTerm);
+
+                V1NodeSelectorRequirement requirement = new V1NodeSelectorRequirement();
+                selectorTerm.addMatchExpressionsItem(requirement);
+                requirement.setKey(selection[0]);
+                requirement.setOperator("In");
+                requirement.addValuesItem(selection[1]);
+            }
+        }
+
+        podSpec.setVolumes(createTestPodVolumes());
+        podSpec.addContainersItem(createTestContainer(runName, engineName, isTraceEnabled));
+        return newPod;
+    }
+
+    private V1Container createTestContainer(String runName, String engineName, boolean isTraceEnabled) {
+        V1Container container = new V1Container();
+        container.setName("engine");
+        container.setImage(this.settings.getEngineImage());
+        container.setImagePullPolicy("Always"); // TODO parameterise
+
+        ArrayList<String> commands = new ArrayList<>();
+        container.setCommand(commands);
+        commands.add("java");
+
+        ArrayList<String> args = new ArrayList<>();
+        container.setArgs(args);
+        args.add("-jar");
+        args.add("boot.jar");
+        args.add("--obr");
+        args.add("file:galasa.obr");
+        args.add("--bootstrap");
+        args.add(settings.getBootstrap());
+        args.add("--run");
+        args.add(runName);
+        if (isTraceEnabled) {
+            args.add("--trace");
+        }
+
+        V1ResourceRequirements resources = new V1ResourceRequirements();
+        container.setResources(resources);
+
+        // TODO reinstate
+        // System.out.println("requests=" +
+        // Integer.toString(this.settings.getEngineMemoryRequest()) + "Mi");
+        // System.out.println("limit=" +
+        // Integer.toString(this.settings.getEngineMemoryLimit()) + "Mi");
+        // resources.putRequestsItem("memory", new
+        // Quantity(Integer.toString(this.settings.getEngineMemoryRequest()) + "Mi"));
+        // resources.putLimitsItem("memory", new
+        // Quantity(Integer.toString(this.settings.getEngineMemoryLimit()) + "Mi"));
+
+        container.setVolumeMounts(createTestContainerVolumeMounts());
+        container.setEnv(createTestContainerEnvVariables());
+        return container;
+    }
+
+    private List<V1Volume> createTestPodVolumes() {
+        List<V1Volume> volumes = new ArrayList<>();
+
+        V1Volume encryptionKeysVolume = new V1Volume();
+        encryptionKeysVolume.setName(ENCRYPTION_KEYS_VOLUME_NAME);
+
+        V1SecretVolumeSource encryptionKeysSecretSource = new V1SecretVolumeSource();
+        encryptionKeysSecretSource.setSecretName(this.settings.getEncryptionKeysSecretName());
+
+        encryptionKeysVolume.setSecret(encryptionKeysSecretSource);
+        volumes.add(encryptionKeysVolume);
+        return volumes;
+    }
+
+    private List<V1VolumeMount> createTestContainerVolumeMounts() {
+        List<V1VolumeMount> volumeMounts = new ArrayList<>();
+
+        String encryptionKeysMountPath = env.getenv(ENCRYPTION_KEYS_PATH_ENV);
+        if (encryptionKeysMountPath != null && !encryptionKeysMountPath.isBlank()) {
+            V1VolumeMount encryptionKeysVolumeMount = new V1VolumeMount();
+            encryptionKeysVolumeMount.setName(ENCRYPTION_KEYS_VOLUME_NAME);
+            encryptionKeysVolumeMount.setMountPath(encryptionKeysMountPath);
+            encryptionKeysVolumeMount.setReadOnly(true);
+
+            volumeMounts.add(encryptionKeysVolumeMount);
+        }
+        return volumeMounts;
+    }
+
+    private List<V1EnvVar> createTestContainerEnvVariables() {
+        ArrayList<V1EnvVar> envs = new ArrayList<>();
+        // envs.add(createConfigMapEnv("GALASA_URL", configMapName, "galasa_url"));
+        // envs.add(createConfigMapEnv("GALASA_INFRA_OBR", configMapName,
+        // "galasa_maven_infra_obr"));
+        // envs.add(createConfigMapEnv("GALASA_INFRA_REPO", configMapName,
+        // "galasa_maven_infra_repo"));
+        // envs.add(createConfigMapEnv("GALASA_TEST_REPO", configMapName,
+        // "galasa_maven_test_repo"));
+        // envs.add(createConfigMapEnv("GALASA_HELPER_REPO", configMapName,
+        // "galasa_maven_helper_repo"));
+        //
+        // envs.add(createValueEnv("GALASA_ENGINE_TYPE", engineLabel));
+        envs.add(createValueEnv("MAX_HEAP", Integer.toString(this.settings.getEngineMemory()) + "m"));
+        envs.add(createValueEnv(RAS_TOKEN_ENV, env.getenv(RAS_TOKEN_ENV)));
+        envs.add(createValueEnv(EVENT_TOKEN_ENV, env.getenv(EVENT_TOKEN_ENV)));
+        envs.add(createValueEnv(ENCRYPTION_KEYS_PATH_ENV, env.getenv(ENCRYPTION_KEYS_PATH_ENV)));
+        //
+        // envs.add(createSecretEnv("GALASA_SERVER_USER", "galasa-secret",
+        // "galasa-server-username"));
+        // envs.add(createSecretEnv("GALASA_SERVER_PASSWORD", "galasa-secret",
+        // "galasa-server-password"));
+        // envs.add(createSecretEnv("GALASA_MAVEN_USER", "galasa-secret",
+        // "galasa-maven-username"));
+        // envs.add(createSecretEnv("GALASA_MAVEN_PASSWORD", "galasa-secret",
+        // "galasa-maven-password"));
+        //
+        // envs.add(createValueEnv("GALASA_RUN_ID", runUUID.toString()));
+        // envs.add(createFieldEnv("GALASA_ENGINE_ID", "metadata.name"));
+        // envs.add(createFieldEnv("GALASA_K8S_NODE", "spec.nodeName"));
+        return envs;
     }
 
     private HashMap<String, Pool> getPools(@NotNull List<IRun> runs) {

--- a/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
+++ b/galasa-parent/dev.galasa.framework.k8s.controller/src/main/java/dev/galasa/framework/k8s/controller/TestPodScheduler.java
@@ -52,7 +52,7 @@ import io.kubernetes.client.openapi.models.V1Volume;
 import io.kubernetes.client.openapi.models.V1VolumeMount;
 import io.prometheus.client.Counter;
 
-public class RunPoll implements Runnable {
+public class TestPodScheduler implements Runnable {
 
     private static final String RAS_TOKEN_ENV = "GALASA_RAS_TOKEN";
     private static final String EVENT_TOKEN_ENV = "GALASA_EVENT_STREAMS_TOKEN";
@@ -72,11 +72,11 @@ public class RunPoll implements Runnable {
     private Environment                      env              = new SystemEnvironment();
 
 
-    public RunPoll(IDynamicStatusStoreService dss, Settings settings, CoreV1Api api, IFrameworkRuns runs) {
+    public TestPodScheduler(IDynamicStatusStoreService dss, Settings settings, CoreV1Api api, IFrameworkRuns runs) {
         this(new SystemEnvironment(), dss, settings, api, runs);
     }
 
-    public RunPoll(Environment env, IDynamicStatusStoreService dss, Settings settings, CoreV1Api api, IFrameworkRuns runs) {
+    public TestPodScheduler(Environment env, IDynamicStatusStoreService dss, Settings settings, CoreV1Api api, IFrameworkRuns runs) {
         this.env = env;
         this.settings = settings;
         this.api = api;

--- a/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/RunPollTest.java
+++ b/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/RunPollTest.java
@@ -136,7 +136,7 @@ public class RunPollTest {
         // Given...
         MockEnvironment mockEnvironment = new MockEnvironment();
 
-        String encryptionKeysMountPath = "/encryption-keys.yaml";
+        String encryptionKeysMountPath = "/encryption/encryption-keys.yaml";
         mockEnvironment.setenv(FrameworkEncryptionService.ENCRYPTION_KEYS_PATH_ENV, encryptionKeysMountPath);
 
         MockK8sController controller = new MockK8sController();
@@ -157,6 +157,7 @@ public class RunPollTest {
         V1Pod pod = runPoll.createTestPod(runName, podName, isTraceEnabled);
 
         // Then...
-        assertPodDetailsAreCorrect(pod, runName, podName, encryptionKeysMountPath, settings);
+        String expectedEncryptionKeysMountPath = "/encryption";
+        assertPodDetailsAreCorrect(pod, runName, podName, expectedEncryptionKeysMountPath, settings);
     }
 }

--- a/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/RunPollTest.java
+++ b/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/RunPollTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.k8s.controller;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import dev.galasa.framework.mocks.MockEnvironment;
+import dev.galasa.framework.mocks.MockIDynamicStatusStoreService;
+import dev.galasa.framework.mocks.MockIFrameworkRuns;
+import dev.galasa.framework.spi.creds.FrameworkEncryptionService;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.V1ConfigMap;
+import io.kubernetes.client.openapi.models.V1Container;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1PodSpec;
+import io.kubernetes.client.openapi.models.V1Volume;
+import io.kubernetes.client.openapi.models.V1VolumeMount;
+
+public class RunPollTest {
+
+    class MockSettings extends Settings {
+
+        private V1ConfigMap mockConfigMap;
+
+        public MockSettings(V1ConfigMap configMap, K8sController controller, CoreV1Api api) throws K8sControllerException {
+            super(controller, api);
+            this.mockConfigMap = configMap;
+        }
+
+        @Override
+        V1ConfigMap retrieveConfigMap() {
+            return mockConfigMap;
+        }
+    }
+
+    class MockK8sController extends K8sController {
+        @Override
+        public void pollUpdated() {
+            // Do nothing...
+        }
+    }
+    
+    private V1ConfigMap createMockConfigMap() {
+        V1ConfigMap configMap = new V1ConfigMap();
+
+        V1ObjectMeta metadata = new V1ObjectMeta().resourceVersion("mockVersion");
+        configMap.setMetadata(metadata);
+
+        Map<String, String> data = new HashMap<>();
+        data.put("bootstrap", "http://my.server/bootstrap");
+        data.put("max_engines", "10");
+        data.put("engine_label", "my-test-engine");
+        data.put("node_arch", "arch");
+        data.put("run_poll", "5");
+        data.put("encryption_keys_secret_name", "service-encryption-keys-secret");
+        
+        configMap.setData(data);
+
+        return configMap;
+    }
+
+    private void assertPodDetailsAreCorrect(
+        V1Pod pod,
+        String expectedRunName,
+        String expectedPodName,
+        String expectedEncryptionKeysMountPath,
+        Settings settings
+    ) {
+        checkPodMetadata(pod, expectedRunName, expectedPodName, settings);
+        checkPodContainer(pod, expectedEncryptionKeysMountPath, settings);
+        checkPodVolumes(pod, settings);
+    }
+
+    @SuppressWarnings("null")
+    private void checkPodMetadata(V1Pod pod, String expectedRunName, String expectedPodName, Settings settings) {
+        V1ObjectMeta expectedMetadata = new V1ObjectMeta()
+            .labels(Map.of("galasa-run", expectedRunName, "galasa-engine-controller", settings.getEngineLabel()))
+            .name(expectedPodName);
+        
+        // Check the pod's metadata is as expected
+        assertThat(pod).isNotNull();
+        assertThat(pod.getApiVersion()).isEqualTo("v1");
+        assertThat(pod.getKind()).isEqualTo("Pod");
+
+        V1ObjectMeta actualMetadata = pod.getMetadata();
+        assertThat(actualMetadata.getLabels()).containsExactlyInAnyOrderEntriesOf(expectedMetadata.getLabels());
+        assertThat(actualMetadata.getName()).isEqualTo(expectedPodName);
+    }
+
+    @SuppressWarnings("null")
+    private void checkPodContainer(V1Pod pod, String expectedEncryptionKeysMountPath, Settings settings) {
+        // Check that test container has been added
+        V1PodSpec actualPodSpec = pod.getSpec();
+        List<V1Container> actualContainers = actualPodSpec.getContainers();
+        assertThat(actualContainers).hasSize(1);
+
+        V1Container testContainer = actualContainers.get(0);
+        assertThat(testContainer.getCommand()).containsExactly("java");
+        assertThat(testContainer.getArgs()).contains("-jar", "boot.jar", "--run", settings.getBootstrap());
+
+        // Check that the encryption keys have been mounted to the correct location
+        List<V1VolumeMount> testContainerVolumeMounts = testContainer.getVolumeMounts();
+        assertThat(testContainerVolumeMounts).hasSize(1);
+
+        V1VolumeMount encryptionKeysVolumeMount = testContainerVolumeMounts.get(0);
+        assertThat(encryptionKeysVolumeMount.getName()).isEqualTo(RunPoll.ENCRYPTION_KEYS_VOLUME_NAME);
+        assertThat(encryptionKeysVolumeMount.getMountPath()).isEqualTo(expectedEncryptionKeysMountPath);
+        assertThat(encryptionKeysVolumeMount.getReadOnly()).isTrue();
+    }
+
+    @SuppressWarnings("null")
+    private void checkPodVolumes(V1Pod pod, Settings settings) {
+        // Check that the encryption keys volume has been added
+        V1PodSpec actualPodSpec = pod.getSpec();
+        List<V1Volume> actualVolumes = actualPodSpec.getVolumes();
+        assertThat(actualVolumes).hasSize(1);
+
+        V1Volume encryptionKeysVolume = actualVolumes.get(0);
+        assertThat(encryptionKeysVolume.getName()).isEqualTo(RunPoll.ENCRYPTION_KEYS_VOLUME_NAME);
+        assertThat(encryptionKeysVolume.getSecret().getSecretName()).isEqualTo(settings.getEncryptionKeysSecretName());
+    }
+
+    @Test
+    public void testCanCreateTestPodOk() throws Exception {
+        // Given...
+        MockEnvironment mockEnvironment = new MockEnvironment();
+
+        String encryptionKeysMountPath = "/encryption-keys.yaml";
+        mockEnvironment.setenv(FrameworkEncryptionService.ENCRYPTION_KEYS_PATH_ENV, encryptionKeysMountPath);
+
+        MockK8sController controller = new MockK8sController();
+        MockIDynamicStatusStoreService mockDss = new MockIDynamicStatusStoreService();
+        MockIFrameworkRuns mockFrameworkRuns = new MockIFrameworkRuns(new ArrayList<>());
+
+        V1ConfigMap mockConfigMap = createMockConfigMap();
+        MockSettings settings = new MockSettings(mockConfigMap, controller, null);
+        settings.init();
+        
+        RunPoll runPoll = new RunPoll(mockEnvironment, mockDss, settings, null, mockFrameworkRuns);
+
+        String runName = "run1";
+        String podName = settings.getEngineLabel() + "-" + runName;
+        boolean isTraceEnabled = false;
+
+        // When...
+        V1Pod pod = runPoll.createTestPod(runName, podName, isTraceEnabled);
+
+        // Then...
+        assertPodDetailsAreCorrect(pod, runName, podName, encryptionKeysMountPath, settings);
+    }
+}

--- a/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/TestPodSchedulerTest.java
+++ b/galasa-parent/dev.galasa.framework.k8s.controller/src/test/java/dev/galasa/framework/k8s/controller/TestPodSchedulerTest.java
@@ -27,7 +27,7 @@ import io.kubernetes.client.openapi.models.V1PodSpec;
 import io.kubernetes.client.openapi.models.V1Volume;
 import io.kubernetes.client.openapi.models.V1VolumeMount;
 
-public class RunPollTest {
+public class TestPodSchedulerTest {
 
     class MockSettings extends Settings {
 
@@ -114,7 +114,7 @@ public class RunPollTest {
         assertThat(testContainerVolumeMounts).hasSize(1);
 
         V1VolumeMount encryptionKeysVolumeMount = testContainerVolumeMounts.get(0);
-        assertThat(encryptionKeysVolumeMount.getName()).isEqualTo(RunPoll.ENCRYPTION_KEYS_VOLUME_NAME);
+        assertThat(encryptionKeysVolumeMount.getName()).isEqualTo(TestPodScheduler.ENCRYPTION_KEYS_VOLUME_NAME);
         assertThat(encryptionKeysVolumeMount.getMountPath()).isEqualTo(expectedEncryptionKeysMountPath);
         assertThat(encryptionKeysVolumeMount.getReadOnly()).isTrue();
     }
@@ -127,7 +127,7 @@ public class RunPollTest {
         assertThat(actualVolumes).hasSize(1);
 
         V1Volume encryptionKeysVolume = actualVolumes.get(0);
-        assertThat(encryptionKeysVolume.getName()).isEqualTo(RunPoll.ENCRYPTION_KEYS_VOLUME_NAME);
+        assertThat(encryptionKeysVolume.getName()).isEqualTo(TestPodScheduler.ENCRYPTION_KEYS_VOLUME_NAME);
         assertThat(encryptionKeysVolume.getSecret().getSecretName()).isEqualTo(settings.getEncryptionKeysSecretName());
     }
 
@@ -147,7 +147,7 @@ public class RunPollTest {
         MockSettings settings = new MockSettings(mockConfigMap, controller, null);
         settings.init();
         
-        RunPoll runPoll = new RunPoll(mockEnvironment, mockDss, settings, null, mockFrameworkRuns);
+        TestPodScheduler runPoll = new TestPodScheduler(mockEnvironment, mockDss, settings, null, mockFrameworkRuns);
 
         String runName = "run1";
         String podName = settings.getEngineLabel() + "-" + runName;

--- a/galasa-parent/dev.galasa.framework/build.gradle
+++ b/galasa-parent/dev.galasa.framework/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation 'org.apache.bcel:bcel:6.7.0'
     implementation 'commons-io:commons-io:2.16.1'
     implementation 'com.google.code.gson:gson:2.10.1'
+    implementation 'org.yaml:snakeyaml:2.0'
 
     testImplementation project (':dev.galasa')
 

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FileSystem.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/FileSystem.java
@@ -95,4 +95,9 @@ public class FileSystem implements IFileSystem {
         }
         return lines ;
     }
+
+    @Override
+    public String readString(Path path) throws IOException {
+        return Files.readString(path);
+    }
 }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/IFileSystem.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/IFileSystem.java
@@ -35,7 +35,9 @@ public interface IFileSystem {
 
     Path createFile(Path path, FileAttribute<?>... attrs) throws IOException;
 
-    void write(Path rasProperties, byte[] bytes) throws IOException ;
+    void write(Path rasProperties, byte[] bytes) throws IOException;
 
-    List<String> readLines(URI uri) throws IOException ;
+    List<String> readLines(URI uri) throws IOException;
+
+    String readString(Path path) throws IOException;
 }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/creds/Credentials.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/creds/Credentials.java
@@ -11,12 +11,27 @@ import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
+import dev.galasa.framework.FileSystem;
+import dev.galasa.framework.IFileSystem;
+import dev.galasa.framework.spi.Environment;
+import dev.galasa.framework.spi.SystemEnvironment;
+
 public abstract class Credentials {
 
+    private IEncryptionService encryptionService;
     private final SecretKeySpec key;
 
-    public Credentials(SecretKeySpec key) {
+    public Credentials(SecretKeySpec key) throws CredentialsException {
+        this(key, new FileSystem(), new SystemEnvironment());
+    }
+
+    public Credentials(SecretKeySpec key, IFileSystem fileSystem, Environment environment) throws CredentialsException {
         this.key = key;
+        this.encryptionService = new FrameworkEncryptionService(key, fileSystem, environment);
+    }
+
+    protected String decryptToString(String encryptedText) throws CredentialsException {
+        return encryptionService.decrypt(encryptedText);
     }
 
     protected byte[] decode(String text) throws CredentialsException {

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/creds/CredentialsToken.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/creds/CredentialsToken.java
@@ -15,7 +15,12 @@ public class CredentialsToken extends Credentials implements ICredentialsToken {
     public CredentialsToken(SecretKeySpec key, String stoken) throws CredentialsException {
         super(key);
 
-        this.token = decode(stoken);
+        String decryptedToken = decryptToString(stoken);
+        if (decryptedToken == null) {
+            this.token = decode(stoken);
+        } else {
+            this.token = decryptedToken.getBytes();
+        }
     }
 
     public byte[] getToken() {

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/creds/CredentialsUsername.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/creds/CredentialsUsername.java
@@ -5,7 +5,7 @@
  */
 package dev.galasa.framework.spi.creds;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import javax.crypto.spec.SecretKeySpec;
 
@@ -16,12 +16,11 @@ public class CredentialsUsername extends Credentials implements ICredentialsUser
 
     public CredentialsUsername(SecretKeySpec key, String username) throws CredentialsException {
         super(key);
-        try {
-            this.username = new String(decode(username), "utf-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new CredentialsException("utf-8 is not available for credentials", e);
-        } catch (CredentialsException e) {
-            throw e;
+
+        this.username = decryptToString(username);
+
+        if (this.username == null) {
+            this.username = new String(decode(username), StandardCharsets.UTF_8);
         }
     }
 

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/creds/CredentialsUsernamePassword.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/creds/CredentialsUsernamePassword.java
@@ -5,7 +5,7 @@
  */
 package dev.galasa.framework.spi.creds;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import javax.crypto.spec.SecretKeySpec;
 
@@ -19,15 +19,16 @@ public class CredentialsUsernamePassword extends Credentials implements ICredent
             throws CredentialsException {
         super(key);
 
-        try {
-            this.username = new String(decode(username), "utf-8");
-            this.password = new String(decode(password), "utf-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new CredentialsException("utf-8 is not available for credentials", e);
-        } catch (CredentialsException e) {
-            throw e;
+        this.username = decryptToString(username);
+        this.password = decryptToString(password);
+
+        if (this.username == null) {
+            this.username = new String(decode(username), StandardCharsets.UTF_8);
         }
 
+        if (this.password == null) {
+            this.password = new String(decode(password), StandardCharsets.UTF_8);
+        }
     }
 
     public String getUsername() {

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/creds/CredentialsUsernameToken.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/creds/CredentialsUsernameToken.java
@@ -5,7 +5,7 @@
  */
 package dev.galasa.framework.spi.creds;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import javax.crypto.spec.SecretKeySpec;
 
@@ -17,15 +17,18 @@ public class CredentialsUsernameToken extends Credentials implements ICredential
 
     public CredentialsUsernameToken(SecretKeySpec key, String username, String token) throws CredentialsException {
         super(key);
-        try {
-            this.username = new String(decode(username), "utf-8");
-            this.token = decode(token);
-        } catch (UnsupportedEncodingException e) {
-            throw new CredentialsException("utf-8 is not available for credentials", e);
-        } catch (CredentialsException e) {
-            throw e;
+
+        this.username = decryptToString(username);
+        if (this.username == null) {
+            this.username = new String(decode(username), StandardCharsets.UTF_8);
         }
 
+        String decryptedToken = decryptToString(token);
+        if (decryptedToken == null) {
+            this.token = decode(token);
+        } else {
+            this.token = decryptedToken.getBytes();
+        }
     }
 
     public String getUsername() {

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/creds/EncryptionKeys.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/creds/EncryptionKeys.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.spi.creds;
+
+import java.util.List;
+
+public class EncryptionKeys {
+    private String encryptionKey;
+    private List<String> oldDecryptionKeys;
+
+    public String getEncryptionKey() {
+        return encryptionKey;
+    }
+
+    public void setEncryptionKey(String encryptionKey) {
+        this.encryptionKey = encryptionKey;
+    }
+
+    public List<String> getOldDecryptionKeys() {
+        return oldDecryptionKeys;
+    }
+
+    public void setOldDecryptionKeys(List<String> oldDecryptionKeys) {
+        this.oldDecryptionKeys = oldDecryptionKeys;
+    }
+}

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/creds/EncryptionKeys.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/creds/EncryptionKeys.java
@@ -5,11 +5,29 @@
  */
 package dev.galasa.framework.spi.creds;
 
+import java.nio.file.Paths;
 import java.util.List;
+
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+
+import dev.galasa.framework.IFileSystem;
+import dev.galasa.framework.spi.Environment;
 
 public class EncryptionKeys {
     private String encryptionKey;
     private List<String> fallbackDecryptionKeys;
+
+    public EncryptionKeys() {
+        // No-op constructor
+    }
+
+    public EncryptionKeys(IFileSystem fileSystem, Environment environment) throws CredentialsException {
+        EncryptionKeys parsedEncryptionKeys = parseEncryptionKeysFile(fileSystem, environment);
+        this.encryptionKey = parsedEncryptionKeys.getEncryptionKey();
+        this.fallbackDecryptionKeys = parsedEncryptionKeys.getFallbackDecryptionKeys();
+    }
 
     public String getEncryptionKey() {
         return encryptionKey;
@@ -25,5 +43,38 @@ public class EncryptionKeys {
 
     public void setFallbackDecryptionKeys(List<String> fallbackDecryptionKeys) {
         this.fallbackDecryptionKeys = fallbackDecryptionKeys;
+    }
+
+    /**
+     * Parses a YAML file containing a primary encryption key and a list of fallback decryption keys, and returns
+     * the keys parsed into an EncryptionKeys bean.
+     *
+     * All keys in the YAML file must be base64-encoded in order for the keys to be properly decoded.
+     * The YAML format for the encryption keys is as follows:
+     *
+     * encryptionKey: <current-base64-encoded-key>
+     * fallbackDecryptionKeys:
+     * - <encoded-fallback-key-1>
+     * - <encoded-fallback-key-2>
+     *
+     * @return a bean object representing the parsed encryption keys
+     * @throws CredentialsException if there was an error parsing the encryption keys YAML file
+     */
+    private EncryptionKeys parseEncryptionKeysFile(IFileSystem fileSystem, Environment environment) throws CredentialsException {
+        EncryptionKeys encryptionKeys = this;
+        String encryptionKeysLocation = environment.getenv(FrameworkEncryptionService.ENCRYPTION_KEYS_PATH_ENV);
+        if (encryptionKeysLocation != null) {
+            try {
+                String encryptionKeysYamlStr = fileSystem.readString(Paths.get(encryptionKeysLocation));
+                if (encryptionKeysYamlStr != null && !encryptionKeysYamlStr.isBlank()) {
+                    Yaml yamlParser = new Yaml(new Constructor(EncryptionKeys.class, new LoaderOptions()));
+                    encryptionKeys = yamlParser.load(encryptionKeysYamlStr);
+                }
+            } catch (Exception e) {
+                throw new CredentialsException("Failed to read encryption keys file", e);
+            }
+        }
+
+        return encryptionKeys;
     }
 }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/creds/EncryptionKeys.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/creds/EncryptionKeys.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public class EncryptionKeys {
     private String encryptionKey;
-    private List<String> oldDecryptionKeys;
+    private List<String> fallbackDecryptionKeys;
 
     public String getEncryptionKey() {
         return encryptionKey;
@@ -19,11 +19,11 @@ public class EncryptionKeys {
         this.encryptionKey = encryptionKey;
     }
 
-    public List<String> getOldDecryptionKeys() {
-        return oldDecryptionKeys;
+    public List<String> getFallbackDecryptionKeys() {
+        return fallbackDecryptionKeys;
     }
 
-    public void setOldDecryptionKeys(List<String> oldDecryptionKeys) {
-        this.oldDecryptionKeys = oldDecryptionKeys;
+    public void setFallbackDecryptionKeys(List<String> fallbackDecryptionKeys) {
+        this.fallbackDecryptionKeys = fallbackDecryptionKeys;
     }
 }

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/creds/FrameworkEncryptionService.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/creds/FrameworkEncryptionService.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.spi.creds;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+
+import dev.galasa.framework.FileSystem;
+import dev.galasa.framework.IFileSystem;
+import dev.galasa.framework.spi.Environment;
+import dev.galasa.framework.spi.SystemEnvironment;
+
+public class FrameworkEncryptionService implements IEncryptionService {
+    public static final String ENCRYPTION_KEYS_PATH_ENV = "GALASA_ENCRYPTION_KEYS_PATH";
+
+    private static final String KEY_ALGORITHM = "AES";
+    private static final String ENCRYPTION_ALGORITHM = "AES/GCM/NoPadding";
+
+    private static final int GCM_AUTH_TAG_LENGTH_BITS = 128;
+    private static final int GCM_IV_BYTES_LENGTH = 12;
+
+    private SecretKey encryptionKey;
+    private List<SecretKey> decryptionKeys = new ArrayList<>();
+
+    private Environment environment = new SystemEnvironment();
+    private IFileSystem fileSystem = new FileSystem();
+
+    public FrameworkEncryptionService(SecretKey encryptionKey, IFileSystem fileSystem, Environment environment) throws CredentialsException {
+        this.fileSystem = fileSystem;
+        this.environment = environment;
+        this.encryptionKey = encryptionKey;
+
+        if (encryptionKey == null) {
+            EncryptionKeys encryptionKeysYaml = parseEncryptionKeysFile();
+            if (encryptionKeysYaml != null) {
+                this.decryptionKeys = loadDecryptionKeys(encryptionKeysYaml);
+                this.encryptionKey = loadPrimaryEncryptionKey(encryptionKeysYaml);
+            }
+        } else {
+            this.decryptionKeys = new ArrayList<>();
+            this.decryptionKeys.add(encryptionKey);
+        }
+    }
+
+    public FrameworkEncryptionService(IFileSystem fileSystem, Environment environment) throws CredentialsException {
+        this(null, fileSystem, environment);
+    }
+
+    private EncryptionKeys parseEncryptionKeysFile() throws CredentialsException {
+        EncryptionKeys encryptionKeys = null;
+        String encryptionKeysLocation = environment.getenv(ENCRYPTION_KEYS_PATH_ENV);
+        if (encryptionKeysLocation != null) {
+            try {
+                String encryptionKeysYamlStr = fileSystem.readString(Paths.get(encryptionKeysLocation));
+                if (encryptionKeysYamlStr != null && !encryptionKeysYamlStr.isBlank()) {
+                    Yaml yamlParser = new Yaml(new Constructor(EncryptionKeys.class, new LoaderOptions()));
+                    encryptionKeys = yamlParser.load(encryptionKeysYamlStr);
+                }
+            } catch (IOException e) {
+                throw new CredentialsException("Failed to read encryption keys file", e);
+            }
+        }
+
+        return encryptionKeys;
+    }
+
+    private SecretKeySpec loadPrimaryEncryptionKey(EncryptionKeys encryptionKeysYaml) throws CredentialsException {
+        SecretKeySpec encryptionKey = null;
+        String encodedKeyStr = encryptionKeysYaml.getEncryptionKey();
+        if (encodedKeyStr != null) {
+            byte[] decodedPrimaryKeyBytes = Base64.getDecoder().decode(encodedKeyStr);
+            encryptionKey = new SecretKeySpec(decodedPrimaryKeyBytes, KEY_ALGORITHM);
+        }
+        return encryptionKey;
+    }
+
+    private List<SecretKey> loadDecryptionKeys(EncryptionKeys encryptionKeysYaml) throws CredentialsException {
+        List<SecretKey> decryptionKeys = new ArrayList<>();
+
+        // The encryption keys secret is mounted as a file of the form:
+        //   encryptionKey: <current-base64-encoded-key>
+        //   oldDecryptionKeys:
+        //   - <encoded-old-key-1>
+        //   - <encoded-old-key-2>
+        SecretKey primaryEncryptionKey = loadPrimaryEncryptionKey(encryptionKeysYaml);
+        if (primaryEncryptionKey != null) {
+            decryptionKeys.add(primaryEncryptionKey);
+        }
+
+        for (String oldKey : encryptionKeysYaml.getOldDecryptionKeys()) {
+            byte[] oldKeyDecodedBytes = Base64.getDecoder().decode(oldKey);
+            SecretKey key = new SecretKeySpec(oldKeyDecodedBytes, KEY_ALGORITHM);
+            decryptionKeys.add(key);
+        }
+        return decryptionKeys;
+    }
+
+    @Override
+    public String encrypt(String plainText) throws CredentialsException {
+        // Generate a random initialization vector (IV)
+        byte[] initVector = new byte[GCM_IV_BYTES_LENGTH];
+        SecureRandom secureRandom = new SecureRandom();
+        secureRandom.nextBytes(initVector);
+
+        byte[] encryptedIvAndText;
+        try {
+            // Initialise the GCM cipher in encrypt mode
+            Cipher cipher = Cipher.getInstance(ENCRYPTION_ALGORITHM);
+            GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(GCM_AUTH_TAG_LENGTH_BITS, initVector);
+            cipher.init(Cipher.ENCRYPT_MODE, this.encryptionKey, gcmParameterSpec);
+
+            // Encrypt the plaintext
+            byte[] encryptedBytes = cipher.doFinal(plainText.getBytes(StandardCharsets.UTF_8));
+
+            // Concatenate the IV and the encrypted text
+            encryptedIvAndText = new byte[initVector.length + encryptedBytes.length];
+            System.arraycopy(initVector, 0, encryptedIvAndText, 0, initVector.length);
+            System.arraycopy(encryptedBytes, 0, encryptedIvAndText, initVector.length, encryptedBytes.length);
+
+        } catch (Exception e) {
+            throw new CredentialsException("Failed to encrypt the provided data", e);
+        }
+
+        return Base64.getEncoder().encodeToString(encryptedIvAndText);
+    }
+
+    @Override
+    public String decrypt(String encryptedText) throws CredentialsException {
+        String decryptedText = null;
+        for (SecretKey key : decryptionKeys) {
+            try {
+                decryptedText = decrypt(encryptedText, key);
+            } catch (CredentialsException e) {
+                // Decryption failed, so let's try the next key...
+            }
+        }
+        return decryptedText;
+    }
+
+    private String decrypt(String encryptedText, SecretKey decryptionKey) throws CredentialsException {
+        String decryptedText = null;
+        try {
+            byte[] decodedBytes = Base64.getDecoder().decode(encryptedText);
+
+            // Get the IV from the encrypted text
+            byte[] initVector = new byte[GCM_IV_BYTES_LENGTH];
+            System.arraycopy(decodedBytes, 0, initVector, 0, initVector.length);
+
+            Cipher cipher = Cipher.getInstance(ENCRYPTION_ALGORITHM);
+            GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(GCM_AUTH_TAG_LENGTH_BITS, initVector);
+            cipher.init(Cipher.DECRYPT_MODE, decryptionKey, gcmParameterSpec);
+
+            // Strip off the IV and decrypt the text
+            byte[] decryptedBytes = cipher.doFinal(decodedBytes, initVector.length, decodedBytes.length - initVector.length);
+            decryptedText = new String(decryptedBytes, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new CredentialsException("Failed to decrypt the provided data", e);
+        }
+        return decryptedText;
+    }
+}

--- a/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/creds/IEncryptionService.java
+++ b/galasa-parent/dev.galasa.framework/src/main/java/dev/galasa/framework/spi/creds/IEncryptionService.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.spi.creds;
+
+public interface IEncryptionService {
+    String encrypt(String plainText) throws CredentialsException;
+    String decrypt(String encryptedText) throws CredentialsException;
+}

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockFileSystem.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/mocks/MockFileSystem.java
@@ -237,6 +237,15 @@ public class MockFileSystem extends FileSystem implements IFileSystem {
         return lines ;
     }
 
+
+    @Override
+    public String readString(Path path) throws IOException {
+        if (!exists(path)) {
+            throw new FileNotFoundException("File "+path+" was not found");
+        }
+        return getContentsAsString(path);
+    }
+
     // -------------- Un-implemented methods follow ------------------
 
     @Override

--- a/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/spi/creds/FrameworkEncryptionServiceTest.java
+++ b/galasa-parent/dev.galasa.framework/src/test/java/dev/galasa/framework/spi/creds/FrameworkEncryptionServiceTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package dev.galasa.framework.spi.creds;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.Test;
+
+import dev.galasa.framework.mocks.MockEnvironment;
+import dev.galasa.framework.mocks.MockFileSystem;
+
+public class FrameworkEncryptionServiceTest {
+
+    private SecretKey generateEncryptionKey() throws NoSuchAlgorithmException {
+        byte[] keyBytes = RandomStringUtils.randomAlphanumeric(32).getBytes();
+        return new SecretKeySpec(keyBytes, "AES");
+    }
+
+    private String generateEncodedEncryptionKeyString() throws NoSuchAlgorithmException {
+        byte[] keyBytes = generateEncryptionKey().getEncoded();
+        return Base64.getEncoder().encodeToString(keyBytes);
+    }
+
+    private String createEncryptionKeysYaml(String primaryEncryptionKey, List<String> oldEncryptionKeys) {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("encryptionKey: " + primaryEncryptionKey);
+        stringBuilder.append("\n");
+        stringBuilder.append("oldDecryptionKeys: ");
+
+        if (oldEncryptionKeys.isEmpty()) {
+            stringBuilder.append("[]");
+        } else {
+            stringBuilder.append("\n");
+            for (String key : oldEncryptionKeys) {
+                stringBuilder.append("- " + key);
+                stringBuilder.append("\n");
+            }
+        }
+        return stringBuilder.toString();
+    }
+
+    @Test
+    public void testCanEncryptAndDecryptTextOk() throws Exception {
+        // Given...
+        SecretKey key = generateEncryptionKey();
+        MockFileSystem mockFileSystem = new MockFileSystem();
+        MockEnvironment mockEnvironment = new MockEnvironment();
+        FrameworkEncryptionService encryptionService = new FrameworkEncryptionService(key, mockFileSystem, mockEnvironment);
+        String plainText = "encrypt me!";
+
+        // When...
+        String encryptedText = encryptionService.encrypt(plainText);
+        assertThat(encryptedText).isNotNull();
+
+        String decryptedText = encryptionService.decrypt(encryptedText);
+        
+        // Then...
+        assertThat(decryptedText).isEqualTo(plainText);
+    }
+   
+    @Test
+    public void testCanLoadAndUseEncryptionKeysFromFileSystemOk() throws Exception {
+        // Given...
+        MockFileSystem mockFileSystem = new MockFileSystem();
+        MockEnvironment mockEnvironment = new MockEnvironment();
+
+        String mockEncryptionKeysFilePath = "/encryption-keys.yaml";
+        mockEnvironment.setenv(FrameworkEncryptionService.ENCRYPTION_KEYS_PATH_ENV, mockEncryptionKeysFilePath);
+        
+        List<String> oldDecryptionKeys = new ArrayList<>();
+        String encodedEncryptionkey = generateEncodedEncryptionKeyString();
+        String yaml = createEncryptionKeysYaml(encodedEncryptionkey, oldDecryptionKeys);
+        mockFileSystem.write(Paths.get(mockEncryptionKeysFilePath), yaml.getBytes(StandardCharsets.UTF_8));
+        
+        FrameworkEncryptionService encryptionService = new FrameworkEncryptionService(mockFileSystem, mockEnvironment);
+
+        String plainText = "encrypt me!";
+        
+        // When...
+        String encryptedText = encryptionService.encrypt(plainText);
+        String decryptedText = encryptionService.decrypt(encryptedText);
+
+        // Then...
+        assertThat(decryptedText).isEqualTo(plainText);       
+    }
+   
+    @Test
+    public void testDecryptTextWithWrongKeyReturnsNullText() throws Exception {
+        // Given...
+        MockFileSystem mockFileSystem = new MockFileSystem();
+        MockEnvironment mockEnvironment = new MockEnvironment();
+
+        String mockEncryptionKeysFilePath = "/encryption-keys.yaml";
+        mockEnvironment.setenv(FrameworkEncryptionService.ENCRYPTION_KEYS_PATH_ENV, mockEncryptionKeysFilePath);
+        
+        List<String> oldDecryptionKeys = List.of(
+            generateEncodedEncryptionKeyString(),
+            generateEncodedEncryptionKeyString()
+        );
+        String encodedEncryptionkey = generateEncodedEncryptionKeyString();
+        String yaml = createEncryptionKeysYaml(encodedEncryptionkey, oldDecryptionKeys);
+        mockFileSystem.write(Paths.get(mockEncryptionKeysFilePath), yaml.getBytes(StandardCharsets.UTF_8));
+
+        FrameworkEncryptionService encryptionService = new FrameworkEncryptionService(mockFileSystem, mockEnvironment);
+        String mockEncryptedText = "letspretendthatthisisencrypted";
+
+        // When...
+        // The decryption should fail since the provided text was not encrypted with any known encryption keys
+        String decryptedText = encryptionService.decrypt(mockEncryptedText);
+        
+        // Then...
+        assertThat(decryptedText).isNull();
+    }
+}

--- a/release.yaml
+++ b/release.yaml
@@ -51,7 +51,7 @@ framework:
     codecoverage: true
 
   - artifact: dev.galasa.framework.k8s.controller
-    version: 0.36.0
+    version: 0.38.0
     obr:          true
     mvp:          false
     bom:          false


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/1467

## Changes
- Added new encryption and decryption using AES256 (GCM Cipher mode) to credentials as per IBM Security Guidelines
  - When reading credentials, the framework will attempt to decrypt the text and if the decryption was unsuccessful, it will fall back to read credentials as they were being read in the past
- Added a Kubernetes volume and volumeMount to test pods to mount the Kubernetes Secret containing the encryption keys for the Galasa service to use
  - The name of the Kubernetes Secret to be mount has been added to the engine controller's settings, which is parsed from a ConfigMap created when installing the helm chart
